### PR TITLE
Task/FP-253: Fetch ticket list after replying to ticket

### DIFF
--- a/client/src/redux/sagas/tickets.sagas.js
+++ b/client/src/redux/sagas/tickets.sagas.js
@@ -136,6 +136,9 @@ export function* postTicketReply(action) {
         payload: json.ticket_history_reply
       });
       action.payload.resetSubmittedForm();
+
+      /* ticket reply causes ticket status change so list of ticket needs to be updated */
+      yield put({ type: 'TICKET_LIST_FETCH' });
     }
   } catch {
     yield put({


### PR DESCRIPTION
## Overview: ##
Update dashboard with ticket list after user replies to ticket
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##
* [FP-253](https://jira.tacc.utexas.edu/browse/FP-253)

## Summary of Changes: ##
Fetch ticket list after replying to ticket

## Testing Steps: ##
1. Choose a resolved ticket
2. Reply to resolved ticket (you might notice that ticket list on dashboard is being updated)
3. Close ticket dialog and look to see if your ticket status has been updated
