### PR TITLE
Task/FP-398 Ensure CI fails if unable to upload coverage info

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,8 @@ jobs:
         cd client
         npm run test
 
-    - run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_TOKEN }} -cF javascript
+    - name: Upload coverage to Codecov
+      run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_TOKEN }} -cF javascript
 
   Client_Side_Linting:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Overview: ##
Ensure CI fails if unable to upload coverage info
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-398](https://jira.tacc.utexas.edu/browse/FP-398)

## Summary of Changes: ##


## Notes: ##

Here is info on how to make sure it fails for the two ways we use it:
- https://github.com/codecov/codecov-action#usage
- https://docs.codecov.io/docs/about-the-codecov-bash-uploader#uploading-process 