### PR TITLE
Task/fp 387 handle lots of jobs  table scroll css

### DIFF
--- a/client/src/components/_common/PaginationTable/PaginationTable.js
+++ b/client/src/components/_common/PaginationTable/PaginationTable.js
@@ -23,9 +23,8 @@ const PaginationTable = ({ tableColumns, tableData }) => {
     { columns, data }
   )
 
-  /* TODO: After, FP-103, use `composes:` to apply `o-fixed-header-table` */
   return (
-    <table {...getTableProps()} className="PaginationTable o-fixed-header-table">
+    <table {...getTableProps()} className="PaginationTable">
       <thead>
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>

--- a/client/src/components/_common/PaginationTable/PaginationTable.scss
+++ b/client/src/components/_common/PaginationTable/PaginationTable.scss
@@ -1,5 +1,7 @@
 .PaginationTable {
   --fixed-header-table--body-height: 30vh; /* calculated by guess & check */
+  /* TODO: After, FP-103, use `composes:` not `@extend` */
+  @extend .o-fixed-header-table;
 
   position: relative;
   align-items: stretch;
@@ -40,7 +42,6 @@
 
 
 
-/* TODO: After, FP-103, use `composes:` to apply `o-fixed-header-table` */
 /*
 Fixed Header Table
 


### PR DESCRIPTION
## Overview: ##

Provide CSS for fixing table header and scrolling table body on new `PaginationTable` component from FP-387.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-387](https://jira.tacc.utexas.edu/browse/FP-387)
* [FP-421](https://jira.tacc.utexas.edu/browse/FP-421)

## Summary of Changes: ##
- Added custom property (native CSS variable) definition for cascading property value to `fixed-table-header` CSS object.
- Added `fixed-table-header` CSS object.
- Added sample styles (for required column widths) for user/client component.

# Testing Steps: ##
1. Does table body height match desired height?
2. Does table body height scroll?
3. Does table header stay fixed relative to table?

## Notes: ##
