### PR TITLE
Task/fp 254  proposal wes 1

### DIFF
--- a/client/src/components/Allocations/AllocationsModals.js
+++ b/client/src/components/Allocations/AllocationsModals.js
@@ -163,7 +163,11 @@ export const TeamView = ({ isOpen, toggle, pid }) => {
                 )}
               </Col>
               <Col className="modal-right">
-                <ContactCard listing={card} />
+                {isLoading ? (
+                  <span>Loading user list. This may take a moment.</span>
+                ) : (
+                  <ContactCard listing={card} />
+                )}
               </Col>
             </Row>
           )}


### PR DESCRIPTION
## Overview: ##

~~Move and simplify the error UI for rendering a Team in Allocations (proposal for change to FP-254 in PR #9).~~

Add loading text, per Design's initial thoughts, when asked ([source](https://github.com/TACC/Frontera-Portal/pull/35/commits/f5e6fede3a8560470fc8520f546692f7cc303cc0#r430628445)).

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-254](https://jira.tacc.utexas.edu/browse/FP-254)

## Summary of Changes: ##

- ~~Remove inline style.~~
- ~~Move error markup.~~
- Add loading text.

## Testing Steps: ##
1. Load app, and navigation to Allocations section.
1. Via Developer Tools, throttle network connection to be very slow (e.g. GPRS).
1. In Allocations section, open "View Team" modal.
1. Verify that loading text appears in right-side panel.

## Notes: ##

I assume that if no team members are available for listing, that the left panel of modal does not explode. This PR is just to ~~fix the display of error markup~~ _add loading text_. I'll mention this other case in the target PR #9.