### PR TITLE
FP-254: Proposal: Avoid "{` `}"

### DIFF
--- a/client/src/components/Allocations/AllocationsTables.js
+++ b/client/src/components/Allocations/AllocationsTables.js
@@ -133,6 +133,7 @@ export const AllocationsTable = ({ page }) => {
               );
             })
           ) : (
+            /* eslint-disable prettier/prettier */
             <tr>
               <td colSpan={headerGroups[0].headers.length}>
                 <center style={{ padding: '1rem' }}>
@@ -140,14 +141,13 @@ export const AllocationsTable = ({ page }) => {
                     <ErrorMessage />
                   ) : (
                     <span>
-                      You have no{' '}
-                      {`${page[0].toLocaleUpperCase()}${page.slice(1)}`}
-                      allocations.
+                      You have no {`${page[0].toLocaleUpperCase()}${page.slice(1)}`} allocations.
                     </span>
                   )}
                 </center>
               </td>
             </tr>
+            /* eslint-enable prettier/prettier */
           )}
         </tbody>
       </table>


### PR DESCRIPTION
## Overview: ##

Resolve `max-len` limit from ESLint (via Prettier) without using a typography/minification hack of `{' '}`.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-254](https://jira.tacc.utexas.edu/browse/FP-254)

## Summary of Changes: ##

- Write line of text as a line of text.
- Disable prettier for relevant block of text.

## Testing Steps: ##
1. Text has space before and after variable.

## Notes: ##
Other, grander-scale, solutions exist:
- Use language files and a `sprintf`-like feature.
- Limit or prevent template literals in JSX (forces definition of objects for rendering data during loops in templates).