### PR TITLE
FP-387: UI Fix: Column Widths

### DIFF
--- a/client/src/components/Jobs/Jobs.scss
+++ b/client/src/components/Jobs/Jobs.scss
@@ -4,14 +4,19 @@
 @import '../../styles/trumps/_truncate.scss';
 
 .jobs-view {
+  /* icon */
   th:nth-child(1),
   td:nth-child(1) { width: 05%; }
+  /* name */
   th:nth-child(2),
-  td:nth-child(2) { width: 25%; }
+  td:nth-child(2) { width: 20%; }
+  /* path */
   th:nth-child(3),
   td:nth-child(3) { width: 40%; }
+  /* date */
   th:nth-child(4),
-  td:nth-child(4) { width: 15%; }
+  td:nth-child(4) { width: 20%; }
+  /* status */
   th:nth-child(5),
   td:nth-child(5) { width: 15%; }
 }
@@ -20,3 +25,5 @@
 .job__path {
   @extend ._truncate-approx-char-count--inline;
 }
+.job__name { --width: 15ch; }
+.job__path { --width: 30ch; }

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
@@ -14,10 +14,6 @@
     color: #707070;
     border-bottom: 1px solid #707070;
 
-    th {
-      padding-right: 1em;
-    }
-
     .-sort-asc, .sort-desc {
       color: #484848;
     }
@@ -91,16 +87,20 @@ Markup:
 Styleguide Objects.FixedHeaderTable
 */
 .o-fixed-header-table {
+  /* RFE: Find a way to make this automatically calculated */
+  /* WARNING: Every consumer must define this value to match their layout */
   --body-height: 100px;
 
   table-layout: fixed;
   border-collapse: collapse;
 }
 
+/* Make table rows act like table rows, even though `tbody` has become a block */
 .o-fixed-header-table tr {
   display: flex;
   flex-direction: row;
 }
+/* Allow table body to scroll (which also pins the table head in place) */
 .o-fixed-header-table tbody {
   display: block;
   overflow: auto;

--- a/client/src/styles/trumps/_truncate.scss
+++ b/client/src/styles/trumps/_truncate.scss
@@ -9,10 +9,12 @@
 ._truncate-approx-char-count,
 ._truncate-approx-char-count--inline,
 ._truncate-approx-char-count--block {
+  --width: 25ch; /* `25ch` is approx. 30 characters */
+
   /* TODO: After FP-103: Use `composes:` not `@extend` */
   @extend .u-ellipsis;
 
-  width: 25ch;
+  width: var(--width);
 }
 ._truncate-approx-char-count--inline { display: inline-block; }
 ._truncate-approx-char-count--block { display: block; }


### PR DESCRIPTION
## Overview: ##

Fix columns widths so everything fits nicely.

See [request on PR for FP-387](https://github.com/TACC/Frontera-Portal/pull/29#pullrequestreview-420205889).

### Important

For `o-fixed-header-table` (thus `InfiniteScrollTable`), native browser table layout has been supplanted almost entirely with CSS Flexbox.

## PR Status: ##

* [x] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [FP-387](https://jira.tacc.utexas.edu/browse/FP-387)

## Summary of Changes: ##

1. Simplify overly-specific and inaccurate selector (remove `.InfiniteScrollTable` from selector).
    - Called "overly-specific", because the selector matches without the extra class 
    - Called "inaccurate", because the column widths are for the jobs-view, regardless what kind of table it uses.
1. Update column width styles to match new columns.
1. Tweak truncation per use of it.
1. Remove padding that seemed to be unnecessary.
1. Explain (with comments) some relevant CSS I previously added.
1. Make all rows of `o-fixed-header-table` (thus `InfiniteScrollTable`) use CSS Flexbox.
1. Make truncation truncate closer to an actual 30 characters.
1. Support tweaking truncation per use of it.

## Testing Steps: ##
1. Load Dashboard.
2. Ensure column headers and cell content all fit in the Jobs table.

## Notes: ##
