### PR TITLE
use "npm ci" in docker client build event

### DIFF
--- a/client/build_client.sh
+++ b/client/build_client.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 if [ "$1" == true ] ; then
     cd /srv/www/portal/client
-    rm -rf node_modules/ && rm -rf build/ && npm install && npm run build
+    npm ci && npm run build
 else
     echo  'Not building client'
 fi


### PR DESCRIPTION
## Overview: ##
Add usage of `npm ci` to `build_client.sh`

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.
