### PR TITLE
FP-456: Load Production Images of CMS & Docs

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -112,7 +112,7 @@ services:
     container_name: frontera_prtl_workers
 
   docs:
-    image: taccwma/frontera-docs:latest
+    image: taccwma/frontera-docs:latest-master
     volumes:
       - ../../docs:/docs/site
     command: ["mkdocs", "build"]


### PR DESCRIPTION
## Overview: ##

Fix CMS compatibility with Portal by loading production build of CMS.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-456](https://jira.tacc.utexas.edu/browse/FP-456)

## Summary of Changes: ##

- Update the build pointers for `cms` and `docs` services to newest compatible builds.

## Testing Steps: ##

### 1. Setup

Choose either method.

#### A. Fresh Local Install of Portal

1. Checkout the branch of this PR.
1. Set up a fresh install of Portal _(by following the instructions in the repo `README.md`)_.
1. Ensure all dockers are running.

#### B. Existing Local Install of Portal

1. Checkout the branch of this PR.
1. In a terminal, run `docker-compose -f ./server/conf/docker/docker-compose-dev.all.debug.yml up --build --force-recreate --attach-dependencies cms`
1. In another Terminal, run:
    1. `python3 manage.py migrate`
        - _(added after approval, but testing was done with Setup method A)_
    1. `docker exec -it frontera_prtl_cms /bin/bash`
    1. `python3 manage.py collectstatic`
1. Ensure all dockers are running.

### 2. Test

1. Load Portal dashboard, and ensure:
    - header renders like production
    - the loaded `site.header.css` is from `/static/site_cms/css/site.header.css`
1. Load CMS website, and ensure:
    - header renders like production
    - the loaded `site.header.css` is from `/static/site_cms/css/site.header.css`
1. Load User Guide minisite, and ensure:
    - header renders like production
    - the loaded `site.header.css` is from `/static/site_cms/css/site.header.css`

## UI Photos:

![FP-456 User Guide](https://user-images.githubusercontent.com/62723358/84532111-4974d500-acab-11ea-8cda-a1cd375850a0.png)
![FP-456 Portal Client](https://user-images.githubusercontent.com/62723358/84532112-4a0d6b80-acab-11ea-88af-be4df07f91ae.png)
![FP-456 CMS Website](https://user-images.githubusercontent.com/62723358/84532113-4aa60200-acab-11ea-9cf2-f29a285d1ebc.png)

## Notes: ##

This is similar to PR #63, but relies on out-dated (but production) CMS code.