### PR TITLE
Task/FP-498 project membership step unit tests

### DIFF
--- a/server/portal/apps/onboarding/steps/project_membership_unit_test.py
+++ b/server/portal/apps/onboarding/steps/project_membership_unit_test.py
@@ -1,74 +1,66 @@
-from django.test import TestCase, override_settings
 from django.contrib.auth import get_user_model
-from mock import patch
-from pytas.http import TASClient
 from portal.apps.onboarding.steps.project_membership import ProjectMembershipStep
 import pytest
 
 
-@pytest.mark.django_db(transaction=True)
-class ProjectMembershipStepTest(TestCase):
-    fixtures = ['users', 'auth']
+@pytest.fixture
+def tas_client_projects_for_user_mock(mocker):
+    task_client_mock = mocker.patch('portal.apps.onboarding.steps.project_membership.TASClient', autospec=True)
+    task_client_mock.return_value.projects_for_user.return_value = [
+        {"chargeCode": "TACC-Team"}, {"chargeCode": "MyProject"}]
+    yield task_client_mock
 
-    def setUp(self):
-        # Mock the step's complete function so we can spy on it
-        self.mock_complete_patcher = patch(
-            'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep.complete'
-        )
-        self.mock_complete = self.mock_complete_patcher.start()
 
-        # Mock the step's fail function so we can spy on it
-        self.mock_fail_patcher = patch(
-            'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep.fail'
-        )
-        self.mock_fail = self.mock_fail_patcher.start()
+@pytest.fixture
+def project_membership_step(authenticated_user):
+    step = ProjectMembershipStep(get_user_model().objects.get(username=authenticated_user.username))
+    yield step
 
-        self.mock_tas_patcher = patch(
-            'portal.apps.onboarding.steps.project_membership.TASClient',
-            spec=TASClient
-        )
-        self.mock_tas = self.mock_tas_patcher.start()
 
-        self.mock_tas.return_value.projects_for_user.return_value = [
-            {
-                "chargeCode": "TACC-Team"
-            },
-            {
-                "chargeCode": "MyProject"
-            }
-        ]
+@pytest.fixture
+def project_membership_fail_mock(mocker):
+    yield mocker.patch.object(ProjectMembershipStep, 'fail')
 
-        self.step = ProjectMembershipStep(get_user_model().objects.get(username="username"))
 
-    def tearDown(self):
-        self.mock_complete_patcher.stop()
-        self.mock_fail_patcher.stop()
-        self.mock_tas_patcher.stop()
+@pytest.fixture
+def project_membership_complete_mock(mocker):
+    yield mocker.patch.object(ProjectMembershipStep, 'complete')
 
-    @override_settings(REQUIRED_PROJECTS=[])
-    def test_no_required_project(self):
-        self.step.process()
-        self.mock_complete.assert_called_with("No project is required for access to this portal")
 
-    @override_settings(REQUIRED_PROJECTS=['SOME_OTHER_PROJECT'])
-    def test_unable_to_get_users_projects(self):
-        # Make the projects_for_user function generate an exception
-        self.mock_tas.return_value.projects_for_user.side_effect = Exception()
-        self.step.process()
-        self.mock_fail.assert_called_with("Unable to get projects for user")
+def test_no_required_project(settings, project_membership_step,
+                             tas_client_projects_for_user_mock, project_membership_complete_mock):
+    settings.REQUIRED_PROJECTS = []
+    project_membership_step.process()
+    project_membership_complete_mock.assert_called_with("No project is required for access to this portal")
 
-    @override_settings(REQUIRED_PROJECTS=['SOME_OTHER_PROJECT', 'ONE_OTHER_PROJECCT'])
-    def test_not_member_of_project(self):
-        self.step.process()
-        self.mock_fail.assert_called_with("You must be added to one of the required project(s) (e.g. SOME_OTHER_PROJECT,"
-                                          " ONE_OTHER_PROJECCT) in order to access this portal")
 
-    @override_settings(REQUIRED_PROJECTS=['MyProject'])
-    def test_member_of_single_project_list(self):
-        self.step.process()
-        self.mock_complete.assert_called_with("You are on a required project needed to access this portal")
+def test_unable_to_get_users_projects(settings, project_membership_step,
+                                      tas_client_projects_for_user_mock, project_membership_fail_mock):
+    settings.REQUIRED_PROJECTS = ['SOME_OTHER_PROJECT']
+    tas_client_projects_for_user_mock.return_value.projects_for_user.side_effect = Exception()
+    project_membership_step.process()
+    project_membership_fail_mock.assert_called_with("Unable to get projects for user")
 
-    @override_settings(REQUIRED_PROJECTS=['SOME_THER_PROJECT', 'MyProject'])
-    def test_member_of_project_list(self):
-        self.step.process()
-        self.mock_complete.assert_called_with("You are on a required project needed to access this portal")
+
+def test_not_member_of_project(settings, project_membership_step,
+                               tas_client_projects_for_user_mock, project_membership_fail_mock):
+    settings.REQUIRED_PROJECTS = ['SOME_OTHER_PROJECT', 'ONE_OTHER_PROJECCT']
+    project_membership_step.process()
+    project_membership_fail_mock.assert_called_with("You must be added to one of the required project(s) "
+                                                    "(e.g. SOME_OTHER_PROJECT, ONE_OTHER_PROJECCT) in order "
+                                                    "to access this portal")
+
+
+def test_member_of_single_project_list(settings, project_membership_step,
+                                       tas_client_projects_for_user_mock, project_membership_complete_mock):
+    settings.REQUIRED_PROJECTS = ['MyProject']
+
+    project_membership_step.process()
+    project_membership_complete_mock.assert_called_with("You are on a required project needed to access this portal")
+
+
+def test_member_of_project_list(settings, project_membership_step,
+                                tas_client_projects_for_user_mock, project_membership_complete_mock):
+    settings.REQUIRED_PROJECTS = ['SOME_OTHER_PROJECT', 'MyProject']
+    project_membership_step.process()
+    project_membership_complete_mock.assert_called_with("You are on a required project needed to access this portal")


### PR DESCRIPTION
## Overview: ##

Use pytest in project membership unit tests

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-498](https://jira.tacc.utexas.edu/browse/FP-498)
