### PR TITLE
Task/FP-123 - Add incremented file number to files copied into the same directory.

### DIFF
--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -228,7 +228,6 @@ def move(client, src_system, src_path, dest_system, dest_path, file_name=None):
         # list the directory and check if file_name exists
         file_listing = client.files.list(systemId=dest_system, filePath=dest_path)
         file_name = increment_file_name(listing=file_listing, file_name=file_name)
-
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -288,7 +287,6 @@ def copy(client, src_system, src_path, dest_system, dest_path, file_name=None,
         # list the directory and check if file_name exists
         file_listing = client.files.list(systemId=dest_system, filePath=dest_path)
         file_name = increment_file_name(listing=file_listing, file_name=file_name)
-
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -419,18 +417,16 @@ def upload(client, system, path, uploaded_file):
     -------
     dict
     """
-    dest_path = os.path.join(path, uploaded_file.name)
     try:
-        file_listing = client.files.list(systemId=system, filePath=dest_path)
+        file_listing = client.files.list(systemId=system, filePath=path)
         uploaded_file.name = increment_file_name(listing=file_listing, file_name=uploaded_file.name)
-
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
-
+    
+    # the fileName param does not seem to accept a different file name
     resp = client.files.importData(systemId=system,
                                    filePath=urllib.parse.quote(path),
-                                   fileName=str(uploaded_file.name),
                                    fileToUpload=uploaded_file)
 
     agave_indexer.apply_async(kwargs={'systemId': system,

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -9,7 +9,7 @@ from elasticsearch_dsl import Q
 from portal.libs.elasticsearch.indexes import IndexedFile
 from portal.apps.search.tasks import agave_indexer, agave_listing_indexer
 from portal.exceptions.api import ApiException
-from portal.libs.agave.utils import text_preview, get_file_size
+from portal.libs.agave.utils import text_preview, get_file_size, increment_file_name
 logger = logging.getLogger(__name__)
 
 
@@ -227,18 +227,8 @@ def move(client, src_system, src_path, dest_system, dest_path, file_name=None):
     try:
         # list the directory and check if file_name exists
         file_listing = client.files.list(systemId=dest_system, filePath=dest_path)
+        file_name = increment_file_name(listing=file_listing, file_name=file_name)
 
-        if len([x['name'] for x in file_listing if x['name'] == file_name]) > 0:
-            inc = 1
-            _ext = os.path.splitext(file_name)[1].lower()
-            _name = os.path.splitext(file_name)[0]
-            _inc = "({})".format(inc)
-            file_name = '{}{}{}'.format(_name, _inc, _ext)
-
-            while len([x['name'] for x in file_listing if x['name'] == file_name]) > 0:
-                inc += 1
-                _inc = "({})".format(inc)
-                file_name = '{}{}{}'.format(_name, _inc, _ext)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -297,18 +287,8 @@ def copy(client, src_system, src_path, dest_system, dest_path, file_name=None,
     try:
         # list the directory and check if file_name exists
         file_listing = client.files.list(systemId=dest_system, filePath=dest_path)
+        file_name = increment_file_name(listing=file_listing, file_name=file_name)
 
-        if len([x['name'] for x in file_listing if x['name'] == file_name]) > 0:
-            inc = 1
-            _ext = os.path.splitext(file_name)[1].lower()
-            _name = os.path.splitext(file_name)[0]
-            _inc = "({})".format(inc)
-            file_name = '{}{}{}'.format(_name, _inc, _ext)
-
-            while len([x['name'] for x in file_listing if x['name'] == file_name]) > 0:
-                inc += 1
-                _inc = "({})".format(inc)
-                file_name = '{}{}{}'.format(_name, _inc, _ext)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -421,18 +401,8 @@ def trash(client, system, path):
         # list the defaul trash directory and check if file_name exists
         file_listing = client.files.list(systemId=system,
                                          filePath=os.path.join(settings.AGAVE_DEFAULT_TRASH_NAME, file_name))
+        file_name = increment_file_name(listing=file_listing, file_name=file_name)
 
-        if len([x['name'] for x in file_listing if x['name'] == file_name]) > 0:
-            inc = 1
-            _ext = os.path.splitext(file_name)[1].lower()
-            _name = os.path.splitext(file_name)[0]
-            _inc = "({})".format(inc)
-            file_name = '{}{}{}'.format(_name, _inc, _ext)
-
-            while len([x['name'] for x in file_listing if x['name'] == file_name]) > 0:
-                inc += 1
-                _inc = "({})".format(inc)
-                file_name = '{}{}{}'.format(_name, _inc, _ext)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -385,9 +385,8 @@ def trash(client, system, path):
     """
 
     file_name = path.strip('/').split('/')[-1]
-    trash_name = file_name
 
-    # Create a trash path if none exists
+    # Create a .Trash path if none exists
     try:
         client.files.list(systemId=system,
                           filePath=settings.AGAVE_DEFAULT_TRASH_NAME)
@@ -397,18 +396,8 @@ def trash(client, system, path):
             raise
         mkdir(client, system, '/', settings.AGAVE_DEFAULT_TRASH_NAME)
 
-    try:
-        # list the defaul trash directory and check if file_name exists
-        file_listing = client.files.list(systemId=system,
-                                         filePath=os.path.join(settings.AGAVE_DEFAULT_TRASH_NAME, file_name))
-        file_name = increment_file_name(listing=file_listing, file_name=file_name)
-
-    except HTTPError as err:
-        if err.response.status_code != 404:
-            raise
-
     resp = move(client, system, path, system,
-                settings.AGAVE_DEFAULT_TRASH_NAME, trash_name)
+                settings.AGAVE_DEFAULT_TRASH_NAME, file_name)
 
     return resp
 

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -289,14 +289,20 @@ def copy(client, src_system, src_path, dest_system, dest_path, file_name=None,
         file_name = src_path.strip('/').split('/')[-1]
 
     try:
-        client.files.list(systemId=dest_system,
-                          filePath="{}/{}".format(dest_path, file_name))
+        # list the directory and check if file_name exists
+        file_listing = client.files.list(systemId=dest_system, filePath=dest_path)
 
-        # Destination path exists, must make it unique.
-        _ext = os.path.splitext(file_name)[1].lower()
-        _name = os.path.splitext(file_name)[0]
-        now = datetime.datetime.utcnow().strftime('%Y-%m-%d %H-%M-%S')
-        file_name = '{}_{}{}'.format(_name, now, _ext)
+        if len([x['name'] for x in file_listing if x['name']==file_name]) > 0:
+            inc = 1
+            _ext = os.path.splitext(file_name)[1].lower()
+            _name = os.path.splitext(file_name)[0]
+            _inc = "({})".format(inc)
+            file_name = '{}{}{}'.format(_name, _inc, _ext)
+
+            while len([x['name'] for x in file_listing if x['name']==file_name]) > 0:
+                inc+=1
+                _inc = "({})".format(inc)
+                file_name = '{}{}{}'.format(_name, _inc, _ext)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -419,18 +419,18 @@ def upload(client, system, path, uploaded_file):
     -------
     dict
     """
-
+    dest_path = os.path.join(path, uploaded_file.name)
     try:
-        listing(client, system=system, path=path)
+        file_listing = client.files.list(systemId=system, filePath=dest_path)
+        uploaded_file.name = increment_file_name(listing=file_listing, file_name=uploaded_file.name)
+
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
 
-    upload_name = os.path.basename(uploaded_file.name)
-
     resp = client.files.importData(systemId=system,
                                    filePath=urllib.parse.quote(path),
-                                   fileName=str(upload_name),
+                                   fileName=str(uploaded_file.name),
                                    fileToUpload=uploaded_file)
 
     agave_indexer.apply_async(kwargs={'systemId': system,

--- a/server/portal/libs/agave/unit_test.py
+++ b/server/portal/libs/agave/unit_test.py
@@ -226,6 +226,15 @@ class TestAgaveUtils(TestCase):
         ) as _file:
             self.agave_listing = json.load(_file)
 
+        with open(
+            os.path.join(
+                agave_path,
+                'files',
+                'file-listing.json'
+                )
+        ) as _file:
+            self.agave_file_listing = json.load(_file)
+
     def test_to_camel_case(self):
         """Test `to_camel_case` util."""
         attr = 'some_attribute'
@@ -329,3 +338,15 @@ class TestAgaveUtils(TestCase):
                 files,
                 [f['path'] for f in level[2]]
             )
+
+    def test_increment_file_name(self):
+        """Test `increment_file_name` util."""
+        self.magave.reset_mock()
+        file_name = 'some_file_name.txt'
+        res = AgaveUtils.increment_file_name(self.agave_file_listing, file_name)
+        self.assertEqual(res, 'some_file_name.txt')
+
+        file_name = 'file.txt'
+        res = AgaveUtils.increment_file_name(self.agave_file_listing, file_name)
+        self.assertEqual(res, 'file(1).txt')
+

--- a/server/portal/libs/agave/utils.py
+++ b/server/portal/libs/agave/utils.py
@@ -225,6 +225,21 @@ def text_preview(url):
         raise ValueError("File does not contain text")
 
 
+def increment_file_name(listing, file_name):
+    if any(x['name'] for x in listing if x['name'] == file_name):
+        inc = 1
+        _ext = os.path.splitext(file_name)[1]
+        _name = os.path.splitext(file_name)[0]
+        _inc = "({})".format(inc)
+        file_name = '{}{}{}'.format(_name, _inc, _ext)
+
+        while any(x['name'] for x in listing if x['name'] == file_name):
+            inc += 1
+            _inc = "({})".format(inc)
+            file_name = '{}{}{}'.format(_name, _inc, _ext)
+    return file_name
+
+
 def get_file_size(client, system, path):
     """ Get file size
     :param client: an Agave client


### PR DESCRIPTION
## Overview: ##
Increment files names for Move, Copy, Trash options in the portal.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)

## Summary of Changes: ##

## Testing Steps: ##
1. Navigate to My Data and copy a file into its current path
2. The a copy of the file should be created like `foo.txt` => `foo(1).txt`
3. If you repeat the copy process on `foo.txt` again you should get `foo(2).txt`
4. If you copy a duplicated file `foo(1).txt` the expected behavior is that the incrementation will start over like so:
`foo(1).txt` => `foo(1)(1).txt`

## UI Photos:
<img width="1315" alt="Screen Shot 2020-07-01 at 11 14 02 AM" src="https://user-images.githubusercontent.com/29575979/86267241-090ec580-bb8c-11ea-9118-cab5ea3ba122.png">
