### PR TITLE
FP-396: Polish CSS classes and selectors

### DIFF
--- a/client/src/components/SystemMonitor/SystemMonitor.js
+++ b/client/src/components/SystemMonitor/SystemMonitor.js
@@ -17,14 +17,13 @@ const SystemsList = () => {
       {
         accessor: 'display_name',
         Header: 'Name',
-        Cell: Display,
-        styleName: 'left-aligned'
+        Cell: Display
       },
       {
         accessor: 'is_operational',
         Header: 'Status',
         Cell: Operational,
-        styleName: 'operational-cell left-aligned'
+        styleName: 'status'
       },
       {
         accessor: 'load_percentage',
@@ -69,10 +68,7 @@ const SystemsList = () => {
     <table {...getTableProps()} styleName="root" className="multi-system">
       <thead>
         {headerGroups.map(headerGroup => (
-          <tr
-            {...headerGroup.getHeaderGroupProps()}
-            styleName="system-monitor-header"
-          >
+          <tr {...headerGroup.getHeaderGroupProps()} styleName="header">
             {headerGroup.headers.map(column => (
               <th key={column.Header}>{column.render('Header')}</th>
             ))}
@@ -83,9 +79,8 @@ const SystemsList = () => {
         {rows.length ? (
           rows.map((row, idx) => {
             prepareRow(row);
-            const styleName = idx % 2 === 0 ? 'odd-row' : null;
             return (
-              <tr {...row.getRowProps()} styleName={styleName}>
+              <tr {...row.getRowProps()}>
                 {row.cells.map(cell => (
                   <td
                     {...cell.getCellProps({ test: cell.column.testProp })}

--- a/client/src/components/SystemMonitor/SystemMonitor.module.scss
+++ b/client/src/components/SystemMonitor/SystemMonitor.module.scss
@@ -4,26 +4,27 @@
     border-bottom: var(--table-border);
     margin: 0;
     width: 100%;
+
+    tr:nth-child(odd) {
+        background-color: rgba(#c6c6c6, 0.1);
+    }
     tr:hover {
         background-color: rgba(0, 0, 0, 0.05);
     }
     td {
         padding: 5px 8px;
     }
-    .system-monitor-header {
-        border-bottom: var(--table-border);
-    }
-    .left-aligned {
-        padding-left: 0;
-    }
-    .operational-cell {
-        width: 100px;
-    }
-    .odd-row {
-        background-color: rgba(#c6c6c6, 0.1);
-    }
+}
+.header {
+    border-bottom: var(--table-border);
 }
 
+/* Columns */
+.status {
+    width: 100px;
+}
+
+/* Messaging */
 .error {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Overview: ##

Polish the CSS of PR #50.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-396](https://jira.tacc.utexas.edu/browse/FP-396)

## Summary of Changes: ##

- Remove unused `left-aligned` class.
- Rename `operational-cell` to `status`.
- Rename `system-monitor-header` to `header`.
- Replace `odd-row` with `tr:nth-child(odd)`.
- Do not nest those styles which were unnecessarily nested.

## Testing Steps: ##
1. Compare results of this branch to `task/FP-396-system-monitor-fix`.
1. Ensure UI matches exactly.

## UI Photos:

<img width="506" alt="FP-396 CSS Polish" src="https://user-images.githubusercontent.com/62723358/86832912-6e682800-c05e-11ea-94c3-d8e39af2cf89.png">

The `.error` was not changed, so a screenshot of it was not deemed necessary. I accept this decision being overridden.

## Notes: ##

None.