### PR TITLE
FP-354/FP-537: Add Message UI Patterns

### DIFF
--- a/client/src/components/UIPatterns/UIPatternsMessages/UIPatternsMessages.js
+++ b/client/src/components/UIPatterns/UIPatternsMessages/UIPatternsMessages.js
@@ -1,13 +1,23 @@
 import React from 'react';
+import { Message } from '_common';
+import './UIPatternsMessages.module.css';
 
 function UIPatternsMessages() {
   return (
-    <span>
-      <span role="img" aria-label="Warning">
-        ⚠️
-      </span>{' '}
-      <span>This is unstyled placeholder message markup</span>
-    </span>
+    <div styleName="container">
+      <Message type="info" styleName="item">
+        All your information, are belong to us.
+      </Message>
+      <Message type="success" styleName="item">
+        All your success, are belong to us.
+      </Message>
+      <Message type="warn" styleName="item">
+        All your warning, are come from us.
+      </Message>
+      <Message type="error" styleName="item">
+        All your error, are belong to you.
+      </Message>
+    </div>
   );
 }
 

--- a/client/src/components/UIPatterns/UIPatternsMessages/UIPatternsMessages.module.css
+++ b/client/src/components/UIPatterns/UIPatternsMessages/UIPatternsMessages.module.css
@@ -1,0 +1,8 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+}
+.item + .item {
+  margin-top: 1em;
+}


### PR DESCRIPTION
## Overview: ##

Add Messages to UI Patterns section (in placeholder file from FP-537).

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-354](https://jira.tacc.utexas.edu/browse/FP-354)
* [FP-537](https://jira.tacc.utexas.edu/browse/FP-537)

## Summary of Changes: ##

- __New__: Add `Messages`'s to `UIPatternsMessages`.
- __New__: Style `UIPatternsMessages`.

## Testing Steps: ##
1. Open app.
2. Navigate to "UI Patterns".
3. See UI Patterns.

## UI Photos:

<img width="581" alt="UIPatternsMessage" src="https://user-images.githubusercontent.com/62723358/87602407-92f67c80-c6bc-11ea-9e36-79779ccbf9ba.png">

## Notes: ##
