### PR TITLE
FP-560: Update tech-docs docker tag

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -125,7 +125,7 @@ services:
     container_name: frontera_prtl_workers
 
   docs:
-    image: taccwma/frontera-docs:latest-master
+    image: taccwma/frontera-docs:43c7e45
     volumes:
       - ../../docs:/docs/site
     command: ["mkdocs", "build"]


### PR DESCRIPTION
## Overview: ##

Update tag for `frontera-tech-docs` docker.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-560](https://jira.tacc.utexas.edu/browse/FP-560)

## Summary of Changes: ##

- Update tag in `docker-compose.….yml`.

## Testing Steps: ##
1. Change is isolated to Tech Docs, whose PRs (see FP-560) have been approved.

## UI Photos:

See [`frontera-tech-docs` PR #11](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/11).

## Notes: ##

- Build: https://jenkins01.tacc.utexas.edu/job/Frontera_Docs/100/console