### PR TITLE
Quick: Replace Ellipsis Trump with Mixin

### DIFF
--- a/client/src/components/_common/DescriptionList/DescriptionList.js
+++ b/client/src/components/_common/DescriptionList/DescriptionList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import './DescriptionList.module.css';
+import './DescriptionList.module.scss';
 
 export const DIRECTION_CLASS_MAP = {
   vertical: 'is-vert',

--- a/client/src/components/_common/DescriptionList/DescriptionList.module.scss
+++ b/client/src/components/_common/DescriptionList/DescriptionList.module.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/tools/mixins.scss';
+
 .container {
   /* … */
 }
@@ -5,7 +7,7 @@
 /* Children */
 
 .key {
-  composes: u-ellipsis from '../../../styles/trumps/_u-ellipsis.scss';
+  @include truncate-with-ellipsis;
 
   font-weight: 500;
   text-overflow: ':';
@@ -42,12 +44,7 @@
 }
 
 .is-vert.is-narrow .value {
-  /* TODO: Support mixins, but prevent SCSS pollution in `src/styles/` */
-  /* HACK: CSS Modules will NOT compose with nested classes */
-  /* composes: u-ellipsis from '../../../styles/trumps/_u-ellipsis.scss'; */
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  @include truncate-with-ellipsis;
 }
 
 /* Overwrite Bootstrap `_reboot.scss` */

--- a/client/src/styles/tools/mixins.scss
+++ b/client/src/styles/tools/mixins.scss
@@ -1,0 +1,5 @@
+@mixin truncate-with-ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/client/src/styles/trumps/_u-ellipsis.scss
+++ b/client/src/styles/trumps/_u-ellipsis.scss
@@ -1,7 +1,0 @@
-.u-ellipsis {
-  /* display: block; *//* Set relevant value in consumer styelsheet */
-
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}


### PR DESCRIPTION
## Overview: ##

Instead of providing a `.u-ellipses`, provide a `u-ellipsis` SASS mixin.

### Reasons: ###
1. **Most** attempts to CSS Modules to `composes: u-ellipses …` **fail** _(because the composer has a nested selector, and nested selectors can **not** compose)_.
2. **All** attempts to CSS Modules `composes: u-ellipses …` **succeed** _instead_ with `@includes u-ellipses;` _(because pre-processing happens before CSS Modules)_.
3. There is no good reason to `composes: u-ellipses …` (CSS Modules) over `@includes u-ellipses;` (SASS mixin) besides avoiding SASS\*.

\* And I can avoid SASS but still have mixins, later, by installing `@apply` or `@extend`.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* None

## Summary of Changes: ##

## Testing Steps: ##
1. Load "UI Patterns".
2. Ensure that "Favorite Numeric Value" never wraps.
3. Ensure that "Favorite Numeric Value" truncates with an ellipsis when container is narrow.

## UI Photos:

<img width="1363" alt="Screen Shot 2020-08-03 at 17 56 04" src="https://user-images.githubusercontent.com/62723358/89234886-a063a000-d5b2-11ea-8a95-d4f4527b5768.png">

## Notes: ##

This change has been wanted in several PRs. It may be merged in to one of them (like PR #128). If such a PR is merged, then this PR will have no diff with master, in which case it may be closed.