### PR TITLE
FP-559: adding temp link to job history page from app form

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -14,8 +14,10 @@ import parse from 'html-react-parser';
 import './AppForm.scss';
 import SystemsPushKeysModal from '_common/SystemsPushKeysModal';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import FormSchema from './AppFormSchema';
 import { getMaxQueueRunTime, createMaxRunTimeRegex } from './AppFormUtils';
+import * as ROUTES from '../../../constants/routes';
 
 const appShape = PropTypes.shape({
   id: PropTypes.string,
@@ -183,7 +185,10 @@ const AppSchemaForm = ({ app }) => {
             </Alert>
           ) : (
             <Alert color="info" isOpen={visible} toggle={onDismiss}>
-              Your job has submitted successfully!
+              Your job has submitted successfully! See details in&nbsp;
+              <Link to={`${ROUTES.WORKBENCH}${ROUTES.HISTORY}/jobs`}>
+                <Button color="link">History &gt; Jobs.</Button>
+              </Link>
             </Alert>
           )}
         </div>


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-559](https://jira.tacc.utexas.edu/browse/FP-559)

## Summary of Changes: ##
Adding in a temporary link to the Job History page from the Application form that is shown in the Job Submitted message.

## Testing Steps: ##
1. Open the Applications page
2. Select an App (I used RStudio, since I could set the runtime to 5 minutes to get a more immediate "failure" due to limited ability to end interactive jobs on this branch.)
3. Submit a job, and scroll up to see the Job Submitted message with the link to the Jobs History page.

## UI Photos:
<img width="739" alt="Screen Shot 2020-08-05 at 3 10 34 PM" src="https://user-images.githubusercontent.com/7683802/89459892-0d9c4000-d72f-11ea-8cbb-823b42162140.png">

## Notes: ##
This isn't 100% what the Design team had in mind for this low-tech solution.  The original design had text at the bottom of the form to the right side of the Submit/Reset Form button/links.  I felt that this was just as simple a solution and it was easier for me to code up in the short time I had to look at it.
It also doesn't change between Interactive and Non-Interactive jobs, so I used the more generic Non-Interactive wording.