### PR TITLE
FP-318: Header Data Truncation: Tweak

### DIFF
--- a/client/src/components/History/HistoryViews/JobHistoryModal.js
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.js
@@ -166,7 +166,6 @@ function JobHistoryModal({ jobId }) {
           data={headerData}
           direction="horizontal"
           styleName="header-details"
-          density="compact"
         />
       </ModalHeader>
 

--- a/client/src/components/_common/DescriptionList/DescriptionList.module.scss
+++ b/client/src/components/_common/DescriptionList/DescriptionList.module.scss
@@ -34,6 +34,7 @@
   content: '|';
   display: inline-block;
 }
+
 .is-horz.is-narrow > .key ~ .key::before {
   padding-left: 0.5em;
   padding-right: 0.5em;
@@ -48,7 +49,10 @@
 .is-vert.is-narrow > .value { padding-left: 0; }
 .is-vert.is-wide > .value   { padding-left: 2.5rem; } /* 40px Firefox default margin */
 
-/* Truncate specific edge case */
+/* Truncate specific edge cases */
+.is-horz.is-wide > .value {
+  @include truncate-with-ellipsis;
+}
 .is-vert.is-narrow > .value {
   @include truncate-with-ellipsis;
 }


### PR DESCRIPTION
## Overview: ##

- Quick resolution of https://github.com/TACC/Frontera-Portal/pull/99#issuecomment-671424177.
- Update `<DescriptionList>` to truncate long values for wide horizontal instances.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-318](https://jira.tacc.utexas.edu/browse/FP-318) PR #99

## Summary of Changes: ##

## Testing Steps: ##

### Job History View Details Modal

1. Open a Job History modal.
2. If values in header data list are not very long, edit live markup to make the values ridiculously long.
3. Ensure value **is** truncated _(if so, then like this: letters stop early, ellipses appended)_.
4. Key **may be** truncated _(if so, then like this: letters stop early off, but no ellipses)_. \*

\* The desirability of this is under scrutiny. It should be reviewed, during testing, by Craig J. It will be detrimental to fix now, because it can potentially break all other variations of the `<DescriptionList>`, which would need fixing _under pressure_.

### UI Patterns Section.

1. Open UI Patterns section.
2. Scroll to "Horizontal" `<DescritpionList>`'s.
3. Ensure UI has not changed.

## UI Photos:

### After

- After - First Value Super Long\
    <img width="822" alt="After - First Value Super Long" src="https://user-images.githubusercontent.com/62723358/89803391-6174a380-daf8-11ea-9c7b-9509ea61a823.png">
- After - All Values Super Long\
    <img width="817" alt="After - All Values Super Long" src="https://user-images.githubusercontent.com/62723358/89803387-60dc0d00-daf8-11ea-9e6f-a1c22dc4fc0c.png">
- After - No Values Super Long\
    <img width="818" alt="After - No Values Super Long" src="https://user-images.githubusercontent.com/62723358/89803394-6174a380-daf8-11ea-9827-34693d3b0dbc.png">
- After - UI Pattern Horizontal Lists\
    <img width="851" alt="After - UI Pattern Horizontal Lists" src="https://user-images.githubusercontent.com/62723358/89803397-620d3a00-daf8-11ea-9806-f36c8205d952.png">

### Before

- Before - First Value Super Long\
    <img width="822" alt="Before - First Value Super Long" src="https://user-images.githubusercontent.com/62723358/89803380-5faae000-daf8-11ea-8ef1-4ceeeda08fc3.png">
- Before - All Values Super Long\
    <img width="823" alt="Before - All Values Super Long" src="https://user-images.githubusercontent.com/62723358/89803383-60437680-daf8-11ea-98c3-e2d1f52e8e41.png">
- Before - No Values Super Long\
    <img width="824" alt="Before - No Values Super Long" src="https://user-images.githubusercontent.com/62723358/89803395-620d3a00-daf8-11ea-89cc-3b7fa41fd811.png">
- Before - UI Pattern Horizontal Lists\
    <img width="851" alt="Before - UI Pattern Horizontal Lists" src="https://user-images.githubusercontent.com/62723358/89803398-62a5d080-daf8-11ea-9e08-e829e31882ac.png">


## Notes: ##
