### PR TITLE
Bugfix/fp 579 scope data files sidebar styles

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -25,86 +25,87 @@ $frontera-portal-color-primary: #9d85ef;
 
 /* HACK: Quick solution (via FP-579) to prevent styles from cascading into header dropdown */
 .data-files-sidebar {
+/* FAQ: No indent, so that diff is less frightening */
+/* TODO: Fix indentation (as necessary) when converting to CSS Module */
+.data-files-btn {
+  background-color: #9d85ef;
+  border-color: #9d85ef;
+  border-radius: 0;
+}
 
-  .data-files-btn {
-    background-color: #9d85ef;
-    border-color: #9d85ef;
-    border-radius: 0;
-  }
+.data-files-btn-cancel {
+  border-radius: 0;
+}
 
-  .data-files-btn-cancel {
-    border-radius: 0;
-  }
+#data-files-add {
+  width: 140px;
+}
 
-  #data-files-add {
-    width: 140px;
-  }
+.data-files-nav {
+  padding-top: 20px;
+  /* Pull back sidebar to the left, so it can use (as UI design dictactes)
+      the negative space created from `data-files-wrapper`'s `padding` */
+  margin-left: -$data-files-wrapper-horizontal-padding;
+}
 
-  .data-files-nav {
-    padding-top: 20px;
-    /* Pull back sidebar to the left, so it can use (as UI design dictactes)
-        the negative space created from `data-files-wrapper`'s `padding` */
-    margin-left: -$data-files-wrapper-horizontal-padding;
-  }
+.dropdown-menu {
+  border-color: $frontera-portal-color-primary;
+  border-radius: 0;
+  margin-top: 11px;
+  padding: 0;
+  width: 200px;
+  vertical-align: top;
+}
+.dropdown-menu::before {
+  position: absolute;
+  top: -10px;
+  left: 65px;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid $frontera-portal-color-primary;
+  border-left: 10px solid transparent;
+  content: '';
+}
+.dropdown-menu::after {
+  position: absolute;
+  top: -9px;
+  left: 66px;
+  border-right: 9px solid transparent;
+  border-bottom: 9px solid #ffffff;
+  border-left: 9px solid transparent;
+  content: '';
+}
 
-  .dropdown-menu {
-    border-color: $frontera-portal-color-primary;
-    border-radius: 0;
-    margin-top: 11px;
-    padding: 0;
-    width: 200px;
-    vertical-align: top;
-  }
-  .dropdown-menu::before {
-    position: absolute;
-    top: -10px;
-    left: 65px;
-    border-right: 10px solid transparent;
-    border-bottom: 10px solid $frontera-portal-color-primary;
-    border-left: 10px solid transparent;
-    content: '';
-  }
-  .dropdown-menu::after {
-    position: absolute;
-    top: -9px;
-    left: 66px;
-    border-right: 9px solid transparent;
-    border-bottom: 9px solid #ffffff;
-    border-left: 9px solid transparent;
-    content: '';
-  }
+.complex-dropdown-item {
+  border-top: 1px solid #707070;
+  display: flex;
+}
 
-  .complex-dropdown-item {
-    border-top: 1px solid #707070;
-    display: flex;
+.multiline-menu-item-wrapper {
+  display: inline-block;
+  padding-left: 5px;
+  line-height: 1.1em;
+  small {
+    display: block;
+    color: #484848;
   }
+}
 
-  .multiline-menu-item-wrapper {
-    display: inline-block;
-    padding-left: 5px;
-    line-height: 1.1em;
-    small {
-      display: block;
-      color: #484848;
-    }
+.dropdown-item {
+  padding: 10px 6px;
+  color: #707070;
+  font-size: 14px;
+  i {
+      padding-right: 19px;
+      font-size: 20px;
+      vertical-align: middle;
   }
-
-  .dropdown-item {
-    padding: 10px 6px;
+  &:hover {
     color: #707070;
-    font-size: 14px;
-    i {
-        padding-right: 19px;
-        font-size: 20px;
-        vertical-align: middle;
-    }
-    &:hover {
-      color: #707070;
-    }
   }
+}
 
-  .dropdown-item:focus,
-  .dropdown-item:hover {
-    background-color: #E6E0FB;
-  }
+.dropdown-item:focus,
+.dropdown-item:hover {
+  background-color: #E6E0FB;
+}
 }


### PR DESCRIPTION
## Overview: ##

Fix header dropdown using styles meant only for Data Files sidebar "+Add" button dropdown.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-579](https://jira.tacc.utexas.edu/browse/FP-579)

## Summary of Changes: ##

- __New__: Nest culprit styles under relevant class.

## Testing Steps: ##
1. Open "Data Files".
1. Open header portal dropdown nav.
1. Compare header portal dropdown nav styles to production.
1. Those dropdown navigation styles match between dev and production.
1. Open Data Files "+Add" dropdown.
1. Those dropdown styles match between `master` and `bugfix/FP-579-scope-data-files-sidebar-styles`.

## UI Photos:

- Before\
    <img width="234" alt="FP-579 Before" src="https://user-images.githubusercontent.com/62723358/89820750-1caa3600-db13-11ea-9719-dbbd9f93f8e9.png">
- After\
    <img width="234" alt="FP-579 After" src="https://user-images.githubusercontent.com/62723358/89820752-1d42cc80-db13-11ea-809f-7a2d09d5dbf2.png">
- Data Files (Before & After)\
    <img width="218" alt="Data Files +Add Dropdown Unchanged" src="https://user-images.githubusercontent.com/62723358/89820754-1d42cc80-db13-11ea-8cb3-2285b28e2a9f.png">


## Notes: ##
