### PR TITLE
Quick: Fix: Account Profile Link Color Nav Bleed

### DIFF
--- a/client/src/components/ManageAccount/ManageAccount.js
+++ b/client/src/components/ManageAccount/ManageAccount.js
@@ -32,7 +32,7 @@ const ManageAccountView = () => {
   return (
     <Container fluid className="manage-account-wrapper">
       <Sidebar />
-      <Container fluid>
+      <Container fluid className="manage-account-content">
         <Row className="manage-account-header">
           <h5>Manage Account</h5>
           <Link to="/workbench/dashboard" style={{ fontWeight: '500' }}>

--- a/client/src/components/ManageAccount/ManageAccount.scss
+++ b/client/src/components/ManageAccount/ManageAccount.scss
@@ -4,21 +4,17 @@
 .manage-account-wrapper {
   display: flex;
   padding: 0;
-  a {
-    color: #9d85ef;
-  }
   .container-fluid {
-    padding: 20px 40px 0 25px !important;
+    padding: 20px 40px 0 25px !important; /* overwrite Bootstrap *//* NOTE: The `!important` may not be necessary */
     display: flex;
     flex-direction: column;
     margin: 0;
   }
 }
 .manage-account-content {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  max-height: 100%;
+  a {
+    color: #9d85ef;
+  }
 }
 .user-profile {
   flex-grow: 1;


### PR DESCRIPTION
## Overview: ##

Prevent the color for hyperlink in Manage Account UI from bleeding into sidebar nav.

(This happens because the CSS is not specific enough.)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* none

## Summary of Changes: ##

- Move the culprit styles to nested styles with mroe specific parent selector.
- Add missing class in markup.
- Remove unused CSS for that now active class.

## Testing Steps: ##
1. Open Manage Account.
2. Confirm sidebar nave does **not** have purple text.

## UI Photos:

- After\
    <img width="1851" alt="Account Profile After" src="https://user-images.githubusercontent.com/62723358/89832397-e07fd100-db24-11ea-9ea8-adcc47e3059d.png">
- Before\
    <img width="1851" alt="Account Profile Before" src="https://user-images.githubusercontent.com/62723358/89832403-e2499480-db24-11ea-951f-7277def8a674.png">

## Notes: ##
