### PR TITLE
bugfix/FP-372--Disable DataFilesSystemSelector input during copying operations

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
@@ -12,7 +12,6 @@ import DataFilesSystemSelector from '../DataFilesSystemSelector/DataFilesSystemS
 const DataFilesCopyModal = React.memo(() => {
   const history = useHistory();
   const location = useLocation();
-  const [copying, setCopying] = useState(false);
 
   const dispatch = useDispatch();
   const params = useSelector(
@@ -25,7 +24,6 @@ const DataFilesCopyModal = React.memo(() => {
   );
   const reloadPage = () => {
     history.push(location.pathname);
-    setCopying(false);
     dispatch({
       type: 'FETCH_FILES_MODAL',
       payload: { ...modalParams, section: 'modal' }
@@ -37,7 +35,6 @@ const DataFilesCopyModal = React.memo(() => {
     state => state.files.operationStatus.copy,
     shallowEqual
   );
-  const loading = useSelector(state => state.files.loading.modal);
   const [disabled, setDisabled] = useState(false);
 
   const selectedFiles = useSelector(
@@ -76,7 +73,6 @@ const DataFilesCopyModal = React.memo(() => {
     (system, path) => {
       setDisabled(true);
       const filteredSelected = selected.filter(f => status[f.id] !== 'SUCCESS');
-      setCopying(true);
       dispatch({
         type: 'DATA_FILES_COPY',
         payload: {
@@ -86,7 +82,7 @@ const DataFilesCopyModal = React.memo(() => {
         }
       });
     },
-    [selected, reloadPage, status, setCopying]
+    [selected, reloadPage, status]
   );
 
   const actionString = `Copying ${selected.length} File${
@@ -125,7 +121,7 @@ const DataFilesCopyModal = React.memo(() => {
               <DataFilesSystemSelector
                 systemId={modalParams.system}
                 section="modal"
-                disabled={loading || copying}
+                disabled={disabled}
               />
             </div>
             <DataFilesBreadcrumbs

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
@@ -9,7 +9,6 @@ import DataFilesSystemSelector from '../DataFilesSystemSelector/DataFilesSystemS
 const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
   const systems = useSelector(state => state.systems.systemList, shallowEqual);
   const files = useSelector(state => state.files.listing.modal, shallowEqual);
-  const loading = useSelector(state => state.files.loading.modal);
   const dispatch = useDispatch();
   const modalParams = useSelector(
     state => state.files.params.modal,
@@ -52,7 +51,6 @@ const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
               <DataFilesSystemSelector
                 systemId={modalParams.system}
                 section="modal"
-                disabled={loading}
               />
             </div>
             <DataFilesBreadcrumbs


### PR DESCRIPTION
## Overview: ##

- Adds a {disabled} property to DataFilesSystemSelector
- Disable selector during loading and copying operations

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-372](https://jira.tacc.utexas.edu/browse/FP-372)
