### PR TITLE
Quick: Fix icon name mixup (non-fatal)

### DIFF
--- a/client/src/components/Allocations/AllocationsLayout.js
+++ b/client/src/components/Allocations/AllocationsLayout.js
@@ -39,7 +39,7 @@ export const Sidebar = () => (
         to={`${ROUTES.WORKBENCH}${ROUTES.ALLOCATIONS}/approved`}
         activeClassName="active"
       >
-        <Icon name="approved" className="link-icon" />
+        <Icon name="approved-reverse" className="link-icon" />
         <span className="link-text">Approved</span>
       </NavLink>
     </NavItem>
@@ -49,7 +49,7 @@ export const Sidebar = () => (
         to={`${ROUTES.WORKBENCH}${ROUTES.ALLOCATIONS}/expired`}
         activeClassName="active"
       >
-        <Icon name="denied" className="link-icon" />
+        <Icon name="denied-reverse" className="link-icon" />
         <span className="link-text">Expired</span>
       </NavLink>
     </NavItem>


### PR DESCRIPTION
## Overview: ##

Fix typo in icon names (need filled icons, not outlined icons).

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-110](https://jira.tacc.utexas.edu/browse/FP-110)

## Summary of Changes: ##

- Fix icon name, two icons, in Allocations sidebar.

## Testing Steps: ##
1. Icons in Allocations sidebar are filled in, not outlined.

## UI Photos:
<img width="275" alt="Screen Shot 2020-08-11 at 15 10 00" src="https://user-images.githubusercontent.com/62723358/89943992-bd1c5b00-dbe4-11ea-9c54-49c6b0e7dd9e.png">

## Notes: ##
