### PR TITLE
Do not encode results of license_as_str for license model

### DIFF
--- a/server/portal/apps/licenses/models.py
+++ b/server/portal/apps/licenses/models.py
@@ -30,7 +30,7 @@ class BaseLicense(models.Model):
 
     def license_as_str(self):
         self.license_file_content = self.license_file_content.replace('\r\n', '\n')
-        return self.license_file_content.encode('utf-8')
+        return self.license_file_content
 
 
 class MATLABLicense(BaseLicense):


### PR DESCRIPTION
## Overview: ##

Fix JSON Decode error during job submission fo Matlab with license

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-596](https://jira.tacc.utexas.edu/browse/FP-596)

## Summary of Changes: ##

Remove .encode('utf-8') when returning license as a string

## Testing Steps: ##
1. Add a matlab license at cep.dev/core/admin
2. Run a matlab job
