### PR TITLE
bug/FP-632: fixing ticket double reply issue

### DIFF
--- a/client/src/redux/sagas/index.js
+++ b/client/src/redux/sagas/index.js
@@ -54,7 +54,6 @@ export default function* rootSaga() {
     watchApps(),
     watchSystems(),
     watchSystemMonitor(),
-    watchPostTicketReply(),
     ...watchProfile,
     watchTicketListFetch(),
     watchTicketDetailedView(),


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-632](https://jira.tacc.utexas.edu/browse/FP-632)

## Summary of Changes: ##
Removed a duplicate call to the ticket reply function that was causing two replies to be posted to consult rt

## Testing Steps: ##
1. Run the portal.
2. View a ticket in your My Tickets list, and submit a reply.  There should only be one reply added, and you should only get one email.
   Caveat: if you are both the requester and the owner, you will get two.  If you're just the requestor, you should only get one.

## UI Photos:

## Notes: ##
