### PR TITLE
Quick: Change "Expires" to "Expired"

### DIFF
--- a/client/src/components/Allocations/AllocationsTables.js
+++ b/client/src/components/Allocations/AllocationsTables.js
@@ -58,7 +58,7 @@ export const useAllocations = page => {
         className: 'system-cell'
       },
       {
-        Header: 'Expires',
+        Header: 'Expired',
         accessor: ({ systems }) => systemAccessor(systems, 'Expires'),
         id: 'expires',
         Cell: Expires,

--- a/client/src/components/Allocations/tests/AllocationsTables.test.js
+++ b/client/src/components/Allocations/tests/AllocationsTables.test.js
@@ -46,7 +46,7 @@ describe('Allocations Table', () => {
     expect(getByText(/Systems/)).toBeDefined();
     expect(getByText(/Awarded/)).toBeDefined();
     expect(getByText(/Remaining/)).toBeDefined();
-    expect(getByText(/Expires/)).toBeDefined();
+    expect(getByText(/Expired/)).toBeDefined();
   });
 
   it('should display an error', async () => {


### PR DESCRIPTION
## Overview: ##

Change text from "Expires" to "Expired". Mentioned by developers and by a stakeholder(?), Jason. Wes agrees; the "Expires" seems to have been a copy/paste from a data property name.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* N/A (see [a discussion in Slack](https://tacc-team.slack.com/archives/GQW4Q8HLG/p1597762884245900))

## Summary of Changes: ##

- Rename text. _(Single-character change.)_
- Update test. _(Single-character change.)_

## Testing Steps: ##
1. Load app.
2. Visit Allocations table.
3. Ensure text has changed.

## UI Photos:

(skipped)

> I'm having difficulty testing CMS/Portal together, so I currently can't login (502) to my Portal. — @tacc-wbomar 

## Notes: ##

Quickie PR.