### PR TITLE
Quick: Make disabled links be gray

### DIFF
--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -37,9 +37,19 @@
     align-items: center;
 }
 
+/* FP-546: Before FP-546 standardizes `_common/Button`, these color
+           styles override and duplicate those in `bootstrap.btn.scss` */
+/* FAQ: The extra `.workbench-content` specificty is too great,
+        but neither `bootstrap.btn.scss` nor `_common/Button` are ready
+        to usurp the responsibility of styling buttons globally */
 .workbench-content .btn-link,
 .workbench-content .wb-link {
-  color: #9d85ef;
+  color: var(--global-color-accent--normal);
+}
+.workbench-content .btn-link:disabled,
+.workbench-content .wb-link:disabled {
+  /* Relies on Bootstrap opacity drop to lighten the color */
+  color: var(--global-color-primary--light);
 }
 
 .workbench-content .btn-secondary {

--- a/client/src/styles/components/bootstrap.btn.css
+++ b/client/src/styles/components/bootstrap.btn.css
@@ -54,3 +54,7 @@ Styleguide Components.Bootstrap.Btn
 .btn-link {
   color: var(--global-color-accent--normal);
 }
+.btn-link:disabled {
+  /* Relies on Bootstrap opacity drop to lighten the color */
+  color: var(--global-color-primary--dark);
+}


### PR DESCRIPTION
## Overview: ##

Make disabled links be gray.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* N/A

## Summary of Changes: ##

- __Major__: Globally, make disabled `.btn-link`'s gray.
- __Minor__: Duplicate stlyes in the two existing places that have `.btn-link` styles (comments exist to explain why).

## Testing Steps: ##
1. Visit Applications.
2. Submit job.
3. Confirm that "Reset Fields to Defaults" button/link is light gray (dark gray but low opacity).

## UI Photos:

- Enabled:\
    <img width="544" alt="Enabled" src="https://user-images.githubusercontent.com/62723358/90798480-99899c80-e2d7-11ea-945b-f99c6af0665a.png">

- Disabled (Before):\
    <img width="544" alt="Disabled - Purple, Opactiy Drop" src="https://user-images.githubusercontent.com/62723358/90798477-98f10600-e2d7-11ea-9213-b5c52394cbd4.png">

- Disabled (After):\
    <img width="544" alt="Disabled - Gray,  Opacity Drop" src="https://user-images.githubusercontent.com/62723358/90798484-9abac980-e2d7-11ea-931f-af674707843e.png">


## Notes: ##
