### PR TITLE
bugfix/FP-654 - Allow Open Session modal to use default x icon

### DIFF
--- a/client/src/components/Jobs/JobsSessionModal/JobsSessionModal.js
+++ b/client/src/components/Jobs/JobsSessionModal/JobsSessionModal.js
@@ -7,10 +7,7 @@ import './JobsSessionModal.module.scss';
 const JobsSessionModal = ({ isOpen, toggle, interactiveSessionLink }) => {
   return (
     <Modal isOpen={isOpen} toggle={toggle} contentClassName="session-modal">
-      <ModalHeader
-        styleName="session-modal-header"
-        toggle={toggle}
-      >
+      <ModalHeader styleName="session-modal-header" toggle={toggle}>
         Open Session
       </ModalHeader>
       <ModalBody styleName="session-modal-body">


### PR DESCRIPTION
## Overview: ##

Restore default close button for Open Session Modal

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-654](https://jira.tacc.utexas.edu/browse/FP-654)

## Summary of Changes: ##

- Remove "charCode" for close button

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/90930718-c796db80-e3c0-11ea-8794-06c483a0cb8e.png)


## Notes: ##

@tacc-wbomar The header text is h5 which looks slightly out of alignment with the close control. I think this artifact makes it inconsistent from other modals. Should we demote the header of this modal?

![image](https://user-images.githubusercontent.com/17181582/90930994-5c013e00-e3c1-11ea-92fc-dd9fc0f48feb.png)

![image](https://user-images.githubusercontent.com/17181582/90931035-70453b00-e3c1-11ea-95fe-71a4f0e3d8ab.png)
