### PR TITLE
Add initial fixtures

### DIFF
--- a/client/src/redux/sagas/fixtures/appDefinitions.fixtures.js
+++ b/client/src/redux/sagas/fixtures/appDefinitions.fixtures.js
@@ -1,0 +1,37 @@
+// Applications definitions
+const appDefinitions = {
+  'matlab-frontera-9.5u1': {
+    definition: {},
+    requirements: {
+      host: 'frontera.tacc.utexas.edu',
+      defaultQueue: 'normal',
+      requiresLicense: 'matlab-f'
+    }
+  },
+  'matlab-s2-9.5u1': {
+    definition: {},
+    requirements: {
+      host: 'stampede2.tacc.utexas.edu',
+      defaultQueue: 'skx-normal',
+      requiresLicense: 'matlab-s2'
+    }
+  },
+  'matlab-ls5-9.5u1': {
+    definition: {},
+    requirements: {
+      host: 'ls5.tacc.utexas.edu',
+      defaultQueue: 'normal',
+      requiresLicense: 'matlab-ls5'
+    }
+  },
+  'my-private-app-0.1': {
+    definition: {},
+    requirements: {
+      host: 'stampede2.tacc.utexas.edu'
+    },
+    pems: {
+      otheruser: 'READ_EXECUTE'
+    }
+  }
+};
+export default appDefinitions;

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -1,0 +1,74 @@
+// Applications browser data
+const applicationsFixture = {
+  'Data Analysis': {
+    jupyter: {
+      specifications: [
+        {
+          type: 'html',
+          displayName: 'TACC.cloud JupyterHub',
+          html: '<h3>Jupyter HTML definition</h3>',
+          available: true
+        },
+        {
+          type: 'agave',
+          displayName: 'HPC Jupyter on Frontera',
+          name: 'hpc-jupyter-frontera',
+          version: 'latest',
+          revision: 'latest',
+          available: true,
+          lastRetrieved: '2020-10-02',
+          id: 'hpc-jupyter-frontera-0.1u1'
+        }
+      ],
+      description: 'Jupyter',
+      icon: 'jupyter'
+    }
+  },
+  Simulation: {
+    matlab: {
+      // Admin can specify apps
+      specifications: [
+        {
+          type: 'agave',
+          name: 'matlab-frontera',
+          version: '9.5',
+          revision: 'latest',
+          // Dropdown display name
+          displayName: 'Matlab on Frontera',
+          available: true,
+          // Retrieved (or cached) id
+          id: 'matlab-frontera-9.5u7',
+          // Should be cached in model, but if it's stale then we can
+          // re-retrieve from Agave automatically or on admin demand
+          lastRetrieved: '2020-10-02'
+        },
+        {
+          type: 'agave',
+          name: 'matlab-s2',
+          version: 'latest',
+          revision: 'latest',
+          available: true,
+          displayName: 'Matlab on Stampede2',
+          id: 'matlab-s2-9.5u1'
+        },
+        {
+          type: 'agave',
+          name: 'matlab-ls5',
+          version: '9.5',
+          revision: '1',
+          available: false,
+          displayName: 'Matlab on LS5'
+        }
+      ],
+      description: 'Matlab',
+      icon: 'matlab'
+    }
+  },
+  'My Private Applications': {
+    'my-private-app': {
+      type: 'agave',
+      versions: ['my-private-app-0.1']
+    }
+  }
+};
+export default applicationsFixture;

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -1,6 +1,6 @@
 // Applications browser data
 const applicationsFixture = {
-  'Data Analysis': {
+  'Data Processing': {
     jupyter: {
       specifications: [
         {

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -92,4 +92,5 @@ const applicationsFixture = {
     }
   }
 };
+
 export default applicationsFixture;

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -83,8 +83,12 @@ const applicationsFixture = {
   },
   'My Apps': {
     'my-private-app': {
-      type: 'agave',
-      versions: ['my-private-app-0.1']
+      specifications: [
+        {
+          type: 'agave',
+          id: 'my-private-app-0.1'
+        }
+      ]
     }
   }
 };

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -8,7 +8,8 @@ const applicationsFixture = {
           displayName: 'TACC.cloud JupyterHub',
           html:
             '<div class="jumbotron text-center"> <h2>Jupyter Notebook</h2> <p> The Jupyter Notebook is a web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text. Uses include: data cleaning and transformation, numerical simulation, statistical modeling, machine learning and <a target="_blank" href="http://jupyter.org/">much more</a>. </p><p><a class="btn btn-lg btn-primary" href="https://jupyter.tacc.cloud" target="_blank">Launch</a></p><p><b>NOTE:</b> This Jupyter instance will terminate after being idle for 3 days.</p></div>',
-          available: true
+          available: true,
+          id: 'uid-abcd1234'
         },
         {
           type: 'agave',
@@ -72,7 +73,8 @@ const applicationsFixture = {
           html:
             '<div class="jumbotron text-center"> <h2>TACC Visualization Portal</h2> <p> The TACC Visualization Portal allows simple access to TACC\'s vis resources, including remote, interactive web-based access to Stampede2, Frontera, and Wrangler. Launch iPython, Jupyter, and R Studio sessions and more.</p><p><a class="btn btn-lg btn-primary" href="https://vis.tacc.utexas.edu/" target="_blank">Launch</a></p></div>',
           displayName: 'TACC Visualization Portal',
-          available: true
+          available: true,
+          id: 'uid-1234abcd'
         }
       ],
       description: 'TACC Visualization Portal',

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -76,7 +76,7 @@ const applicationsFixture = {
         }
       ],
       description: 'TACC Visualization Portal',
-      icon: 'vis-portal',
+      icon: 'vis-portal'
     }
   },
   'My Apps': {

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -27,7 +27,6 @@ const applicationsFixture = {
   },
   Simulation: {
     matlab: {
-      // Admin can specify apps
       specifications: [
         {
           type: 'agave',
@@ -65,7 +64,22 @@ const applicationsFixture = {
       icon: 'matlab'
     }
   },
-  'My Private Applications': {
+  Visualization: {
+    'TACC Visualization Portal': {
+      specifications: [
+        {
+          type: 'html',
+          html:
+            '<div class="jumbotron text-center"> <h2>TACC Visualization Portal</h2> <p> The TACC Visualization Portal allows simple access to TACC\'s vis resources, including remote, interactive web-based access to Stampede2, Frontera, and Wrangler. Launch iPython, Jupyter, and R Studio sessions and more.</p><p><a class="btn btn-lg btn-primary" href="https://vis.tacc.utexas.edu/" target="_blank">Launch</a></p></div>',
+          displayName: 'TACC Visualization Portal',
+          available: true
+        }
+      ],
+      description: 'TACC Visualization Portal',
+      icon: 'vis-portal',
+    }
+  },
+  'My Apps': {
     'my-private-app': {
       type: 'agave',
       versions: ['my-private-app-0.1']

--- a/client/src/redux/sagas/fixtures/applications.fixtures.js
+++ b/client/src/redux/sagas/fixtures/applications.fixtures.js
@@ -6,7 +6,8 @@ const applicationsFixture = {
         {
           type: 'html',
           displayName: 'TACC.cloud JupyterHub',
-          html: '<h3>Jupyter HTML definition</h3>',
+          html:
+            '<div class="jumbotron text-center"> <h2>Jupyter Notebook</h2> <p> The Jupyter Notebook is a web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text. Uses include: data cleaning and transformation, numerical simulation, statistical modeling, machine learning and <a target="_blank" href="http://jupyter.org/">much more</a>. </p><p><a class="btn btn-lg btn-primary" href="https://jupyter.tacc.cloud" target="_blank">Launch</a></p><p><b>NOTE:</b> This Jupyter instance will terminate after being idle for 3 days.</p></div>',
           available: true
         },
         {


### PR DESCRIPTION
## Overview: ##
Add fixtures for new application responses

## PR Status: ##

* [ ] Ready.
* [X] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-762](https://jira.tacc.utexas.edu/browse/FP-762)


## Notes: ##

## Todo: ##
- [ ] add example tapis app definitions
- [ ] question:  we have a description field for the apps in our response.  it also exists in the tapis app definition (short description/long description) and can vary between multiple versions (i.e. stacked) apps. what about web apps (should they ignore description or just not have one in the response?). [note that updated design no longer has description]
- [ ] webapps will need id which matches name (?)