### PR TITLE
rename master to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 
-# Controls when the action will run. Triggers the workflow on pushes to master or on pull request events
+# Controls when the action will run. Triggers the workflow on pushes to main or on pull request events
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches: [ '**' ]
 
@@ -81,9 +81,9 @@ jobs:
     - name: Server-Side Linting
       run: |
         cd server
-        git fetch origin "+refs/heads/master:refs/remotes/origin/master"
-        git diff -U0 origin/master..HEAD | poetry run flake8 --diff
-#         poetry run pylint --rcfile=server/.pylintrc $(git diff origin/master..HEAD --name-only "*.py")
+        git fetch origin "+refs/heads/main:refs/remotes/origin/main"
+        git diff -U0 origin/main..HEAD | poetry run flake8 --diff
+#         poetry run pylint --rcfile=server/.pylintrc $(git diff origin/main..HEAD --name-only "*.py")
 
   Client_Side_Unit_Tests:
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Working Design: https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/
 
-[![codecov](https://codecov.io/gh/TACC/Core-Portal/branch/master/graph/badge.svg?token=TM9CH1AHJ1)](https://codecov.io/gh/TACC/Core-Portal)
+[![codecov](https://codecov.io/gh/TACC/Core-Portal/branch/main/graph/badge.svg?token=TM9CH1AHJ1)](https://codecov.io/gh/TACC/Core-Portal)
 
 ## Prequisites for running the portal application
 
@@ -173,7 +173,7 @@ You may auto-fix your linting errors to conform with configured standards, for s
 - `npm run lint:js -- --fix`
 - `npm run lint:js -- --fix`
 
-Server-side Python code is linted via Flake8, and is also enforced on commits to the repo. To see server side linting errors, run `git diff -U0 master | flake8 --diff` from the command line.
+Server-side Python code is linted via Flake8, and is also enforced on commits to the repo. To see server side linting errors, run `git diff -U0 main | flake8 --diff` from the command line.
 This requires that you have a local python virtual environemnt setup with this project's dependencies installed:
 
 ```
@@ -192,7 +192,7 @@ Client-side javascript testing is run through Jest. Run `npm run test`* from the
 
 #### Test Coverage
 
-Coverage is sent to codecov on commits to the repo (see Github Actions for branch to see branch coverage). Ideally we only merge positive code coverage changes to master.
+Coverage is sent to codecov on commits to the repo (see Github Actions for branch to see branch coverage). Ideally we only merge positive code coverage changes to `main`.
 
 
 #### Production Deployment
@@ -214,7 +214,7 @@ Deployments are initiated via [Jenkins](https://jenkins01.tacc.utexas.edu/view/W
 ### Contributing
 
 #### Development Workflow
-We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) as our development workflow. Our [development site](https://dev.cep.tacc.utexas.edu) (accessible behind the TACC Network) is always up-to-date with `master`, while the [production site](https://prod.cep.tacc.utexas.edu) is built to a hashed commit tag.
+We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) as our development workflow. Our [development site](https://dev.cep.tacc.utexas.edu) (accessible behind the TACC Network) is always up-to-date with `main`, while the [production site](https://prod.cep.tacc.utexas.edu) is built to a hashed commit tag.
 - Feature branches contain major updates, bug fixes, and hot fixes with respective branch prefixes:
     - `task/` for features and updates
     - `bug/` for bugfixes

--- a/client/src/styles/components/c-button.css
+++ b/client/src/styles/components/c-button.css
@@ -1,6 +1,6 @@
 /* WARNING: This file is copied from Portal repo */
 /* TODO: Share source code between CMS, Portal, & User Guide */
-/* SEE: https://github.com/TACC/Core-Portal/blob/master/client/src/styles/components/c-button.css */
+/* SEE: https://github.com/TACC/Core-Portal/blob/main/client/src/styles/components/c-button.css */
 
 /* FP-545: Move these styles to `_common/Button` */
 /*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ## Welcome to GitHub Pages
 
-You can use the [editor on GitHub](https://github.com/TACC/Core-Portal/edit/master/docs/index.md) to maintain and preview the content for your website in Markdown files.
+You can use the [editor on GitHub](https://github.com/TACC/Core-Portal/edit/main/docs/index.md) to maintain and preview the content for your website in Markdown files.
 
 Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
 


### PR DESCRIPTION
## Overview: ##

Rename references of branch name `master` to `main`

