### PR TITLE
bug/FP-896: Fix add definition to list

### DIFF
--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -69,7 +69,7 @@ export function systems(state = initialSystemState, action) {
         ...state,
         definitions: {
           ...state.definitions,
-          list: addSystemDefinition(action.payload, state.definitions),
+          list: addSystemDefinition(action.payload, state.definitions.list),
           error: false,
           errorMessage: null,
           loading: false
@@ -79,7 +79,7 @@ export function systems(state = initialSystemState, action) {
       return {
         ...state,
         definitions: {
-          ...state.datafiles,
+          ...state.definitions,
           error: true,
           errorMessage: action.payload,
           loading: false

--- a/client/src/redux/reducers/tests/datafiles.reducers.test.js
+++ b/client/src/redux/reducers/tests/datafiles.reducers.test.js
@@ -1,0 +1,26 @@
+import {systems as datafilesReducer,  initialSystemState } from "../datafiles.reducers";
+import systemDefinitionFixture from '../../sagas/fixtures/systemDefinition.fixture';
+
+describe("Datafiles Reducer", () => {
+  test("Load initial state", () => {
+    expect(datafilesReducer(initialSystemState, { type: undefined })).toEqual(
+      initialSystemState
+    );
+  });
+  test("Add system definition to state", () => {
+    const addSystemDefinitionAction = {
+      type: "FETCH_SYSTEM_DEFINITION_SUCCESS",
+      payload: systemDefinitionFixture
+    };
+    expect(datafilesReducer(initialSystemState, addSystemDefinitionAction)).toEqual({
+      ...initialSystemState,
+        definitions: {
+          ...initialSystemState.definitions,
+          list: [systemDefinitionFixture],
+          error: false,
+          errorMessage: null,
+          loading: false
+        }
+    });
+  });
+});

--- a/client/src/redux/sagas/fixtures/systemDefinition.fixture.js
+++ b/client/src/redux/sagas/fixtures/systemDefinition.fixture.js
@@ -1,0 +1,43 @@
+const systemDefinitionFixture = {
+  owner: 'wma_prtl',
+  _links: {
+    owner: { href: 'https://portals-api.tacc.utexas.edu/profiles/v2/wma_prtl' },
+    metadata: {
+      href:
+        'https://portals-api.tacc.utexas.edu/meta/v2/data/?q=%7B%22associationIds%22%3A%221843722814843916777-242ac119-0001-006%22%7D'
+    },
+    roles: {
+      href:
+        'https://portals-api.tacc.utexas.edu/systems/v2/frontera.home.user/roles'
+    },
+    self: {
+      href: 'https://portals-api.tacc.utexas.edu/systems/v2/frontera.home.user'
+    }
+  },
+  available: true,
+  description: 'Home system for user: user',
+  storage: {
+    proxy: null,
+    protocol: 'SFTP',
+    mirror: false,
+    port: 22,
+    auth: { type: 'SSHKEYS' },
+    publicAppsDir: null,
+    host: 'frontera.tacc.utexas.edu',
+    rootDir: '/home1/12345/user',
+    homeDir: '/'
+  },
+  type: 'STORAGE',
+  uuid: '1843722814843916777-242ac119-0001-006',
+  revision: 2,
+  site: 'portal.dev',
+  default: false,
+  public: false,
+  globalDefault: false,
+  name: 'frontera.home.user',
+  id: 'frontera.home.user',
+  lastModified: '2020-08-11T14:37:39-05:00',
+  status: 'UP'
+};
+
+export default systemDefinitionFixture;


### PR DESCRIPTION
## Overview: ##
Fixes adding definitions to the `state.definitions.list` via the `addSystemDefinition` function in `datafiles.reducers.js`.

## Related Jira tickets: ##

* [FP-896](https://jira.tacc.utexas.edu/browse/FP-896)
* [FP-866](https://jira.tacc.utexas.edu/browse/FP-866)
* [FP-872](https://jira.tacc.utexas.edu/browse/FP-872)

## Summary of Changes: ##

## Testing Steps: ##
1. Click "View Path" on a file and ensure it works correctly. (Before this PR the app would crash after clicking the button)
