### PR TITLE
task/FP-908 - Hide empty application tabs

### DIFF
--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -507,11 +507,19 @@ class AppsTrayView(BaseApiView):
         """
         tabs, definitions = self.getPublicApps(request.user)
         my_apps = self.getPrivateApps(request.user)
-        tabs.append(
+        tabs.insert(
+            0,
             {
                 "title": "My Apps",
                 "apps": my_apps
             }
+        )
+        # Only return tabs that are non-empty
+        tabs = list(
+            filter(
+                lambda tab: len(tab["apps"]) > 0,
+                tabs
+            )
         )
 
         return JsonResponse({"tabs": tabs, "definitions": definitions})

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -507,8 +507,7 @@ class AppsTrayView(BaseApiView):
         """
         tabs, definitions = self.getPublicApps(request.user)
         my_apps = self.getPrivateApps(request.user)
-        tabs.insert(
-            0,
+        tabs.append(
             {
                 "title": "My Apps",
                 "apps": my_apps


### PR DESCRIPTION
## Overview: ##

List My Apps as last app category

## Related Jira tickets: ##

* [FP-908](https://jira.tacc.utexas.edu/browse/FP-908)
* [FP-892](https://jira.tacc.utexas.edu/browse/FP-892)


## Summary of Changes: ##

Hide empty application tabs, including My Apps if a user has none

## Testing Steps: ##
1. Import app categories with `python manage.py import-apps`
2. Delete an app that was the only app in its category in cep.dev/core/admin
3. Make sure that category does not appear

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/107377926-1a6c6880-6ab1-11eb-847a-811b18b24907.png)


## Notes: ##
