### PR TITLE
task/FP-880 - Fix Manage Team for Shared Workspaces with deleted members

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.js
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.js
@@ -162,6 +162,8 @@ const DataFilesProjectMembers = ({
     isTransferring ? 'transfer-list' : 'addremove-list'
   }`;
 
+  const existingMembers = members.filter(member => member.user);
+
   return (
     <div styleName="root">
       <Label className="form-field__label" size="sm">
@@ -210,7 +212,7 @@ const DataFilesProjectMembers = ({
       </div>
       <InfiniteScrollTable
         tableColumns={isTransferring ? transferColumns : columns}
-        tableData={members}
+        tableData={existingMembers}
         styleName={listStyle}
         columnMemoProps={[loading, mode, transferUser]}
       />


### PR DESCRIPTION
## Overview: ##

Managing Team for Shared Workspaces now fixed when a user has been deleted from a portal

## Related Jira tickets: ##

* [FP-880](https://jira.tacc.utexas.edu/browse/FP-880)

## Summary of Changes: ##

Skip displaying any member of a Shared Workspace that does not have a user object

## Testing Steps: ##
1. Create a Shared Workspace
2. Add a test account as an editor of the project
3. Delete the test account from your portal from within the django shell using:
```
from django.contrib.auth import get_user_model
get_user_model().objects.get(username="testuser").delete()
```
4. Try managing the team. It should skip displaying the non-existent user

## UI Photos:

## Notes: ##

We probably need a more robust solution, such as pulling in user profiles from the tenant.