### PR TITLE
task/FP-898 - onboarding system health checks

### DIFF
--- a/server/portal/apps/accounts/managers/accounts.py
+++ b/server/portal/apps/accounts/managers/accounts.py
@@ -82,6 +82,16 @@ def setup(username, system):
     user = check_user(username)
     mgr = UserSystemsManager(user, system)
     home_dir = mgr.get_private_directory(user)
+    systemId = mgr.get_system_id()
+    system = StorageSystem(user.agave_oauth.client, id=systemId)
+    success, result = system.test()
+    if success:
+        logger.info(
+            "{username} has valid configuration for {systemId}, skipping creation".format(
+                username=username, systemId=systemId
+            )
+        )
+        return home_dir, success
     home_sys = mgr.setup_private_system(user)
 
     return home_dir, home_sys

--- a/server/portal/apps/accounts/managers/accounts.py
+++ b/server/portal/apps/accounts/managers/accounts.py
@@ -91,10 +91,10 @@ def setup(username, system):
                 username=username, systemId=systemId
             )
         )
-        return home_dir, success
+        return home_dir
     home_sys = mgr.setup_private_system(user)
 
-    return home_dir, home_sys
+    return home_dir
 
 
 def reset_system_keys(username, system_id):

--- a/server/portal/apps/auth/tasks.py
+++ b/server/portal/apps/auth/tasks.py
@@ -15,7 +15,7 @@ def setup_user(self, username, system):
         :param dict systems: dict of systems from settings
     """
     from portal.apps.accounts.managers.accounts import setup
-    logger.info("Async setup task for {username} launched on {system}".format(username=username, system=system))
+    logger.info("Setup task for {username} launched on {system}".format(username=username, system=system))
     setup(username, system)
 
 

--- a/server/portal/apps/onboarding/steps/key_service_creation.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation.py
@@ -57,13 +57,18 @@ class KeyServiceCreationStep(AbstractStep):
         for systemId in systems.keys():
             success, result = StorageSystem(self.user.agave_oauth.client, id=systemId).test()
             if success:
-                self.loggger.info(
+                self.logger.info(
                     "{username} has valid configuration for {systemId}, skipping creation".format(
                         username=self.user.username, systemId=systemId
                     )
                 )
             else:
                 systemList.append(systemId)
+
+        # If all required systems already exist, mark this step complete
+        if len(systemList) == 0:
+            self.complete("Found existing storage systems")
+            return
 
         # Store requested systemIds
         data = {

--- a/server/portal/apps/onboarding/steps/key_service_creation.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation.py
@@ -9,6 +9,7 @@ from portal.apps.system_creation.utils import (
 from portal.apps.onboarding.execute import (
     execute_setup_steps,
 )
+from portal.libs.agave.models.systems.storage import StorageSystem
 from django.conf import settings
 import json
 import logging
@@ -51,9 +52,15 @@ class KeyServiceCreationStep(AbstractStep):
         }
         self.logger.debug("KeyService variables substituted: {}".format(systems))
 
+        # Create only storage systems that are not currently accessible
+        systemList = filter(
+            lambda systemId: not StorageSystem(self.user.agave_oauth.client, id=systemId).test()[0],
+            systems.keys()
+        )
+
         # Store requested systemIds
         data = {
-            'requested': list(systems.keys()),
+            'requested': list(systemList),
             'failed': [],
             'successful': []
         }

--- a/server/portal/apps/onboarding/steps/key_service_creation.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation.py
@@ -53,14 +53,21 @@ class KeyServiceCreationStep(AbstractStep):
         self.logger.debug("KeyService variables substituted: {}".format(systems))
 
         # Create only storage systems that are not currently accessible
-        systemList = filter(
-            lambda systemId: not StorageSystem(self.user.agave_oauth.client, id=systemId).test()[0],
-            systems.keys()
-        )
+        systemList = []
+        for systemId in systems.keys():
+            success, result = StorageSystem(self.user.agave_oauth.client, id=systemId).test()
+            if success:
+                self.loggger.info(
+                    "{username} has valid configuration for {systemId}, skipping creation".format(
+                        username=self.user.username, systemId=systemId
+                    )
+                )
+            else:
+                systemList.append(systemId)
 
         # Store requested systemIds
         data = {
-            'requested': list(systemList),
+            'requested': systemList,
             'failed': [],
             'successful': []
         }

--- a/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
@@ -38,6 +38,14 @@ def mock_fail(mocker):
     yield mocker.patch.object(KeyServiceCreationStep, 'fail')
 
 
+def test_process_skip(regular_user, mock_call_reactor, mocker, mock_complete):
+    mock_storage_system = mocker.patch.object(StorageSystem, 'test')
+    mock_storage_system.return_value = (True, None)
+    step = KeyServiceCreationStep(regular_user)
+    step.process()
+    mock_complete.assert_called_with("Found existing storage systems")
+
+
 def test_process(regular_user, mock_call_reactor, mocker):
     mock_storage_system = mocker.patch.object(StorageSystem, 'test')
     mock_storage_system.return_value = (False, None)

--- a/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
@@ -1,4 +1,5 @@
 from portal.apps.onboarding.steps.key_service_creation import KeyServiceCreationStep
+from portal.libs.agave.models.systems.storage import StorageSystem
 from mock import call, ANY, MagicMock
 import pytest
 
@@ -37,7 +38,9 @@ def mock_fail(mocker):
     yield mocker.patch.object(KeyServiceCreationStep, 'fail')
 
 
-def test_process(regular_user, mock_call_reactor):
+def test_process(regular_user, mock_call_reactor, mocker):
+    mock_storage_system = mocker.patch.object(StorageSystem, 'test')
+    mock_storage_system.return_value = (False, None)
     step = KeyServiceCreationStep(regular_user)
     step.process()
     frontera_call = call(


### PR DESCRIPTION
## Overview: ##

Skip portal side requests for new storage systems for any system that is already valid (listable, accessible by user)

## Related Jira tickets: ##

* [FP-898](https://jira.tacc.utexas.edu/browse/FP-898)

## Summary of Changes: ##

- Patched portal.apps.accounts.managers.accounts.setup to skip creation of systems that are accessible (this is called during the system_creation.py onboarding step)
- Patched the key_service_creation onboarding step to skip creation of systems that are accessible

## Testing Steps: ##

### Testing system_creation_step ###

These instructions are for testing the non-keyservice based system creation. Make sure your settings secrets have the following entires:

```
_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
    'frontera': {
        'name': 'My Data (Frontera)',
        'prefix': 'frontera.home.{username}',
        'systemId': 'frontera.home.{username}', 
        'host': 'frontera.tacc.utexas.edu',
        'home_dir': '/home1/{tasdir}',
        'storage_port': 22,
        'icon': None,
    },
    'longhorn': {
        'name': 'My Data (Longhorn)',
        'prefix': 'longhorn.home.{username}',
        'systemId': 'longhorn.home.{username}',
        'host': 'longhorn.tacc.utexas.edu',
        'home_dir': '/home/{tasdir}',
        'storage_port': 22,
        'requires_allocation': 'longhorn3',
        'icon': None,
    },
}

_PORTAL_USER_ACCOUNT_SETUP_STEPS = [
    {
        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
        'settings': {}
    },
    {
        'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
        'settings': {}
    },
    {
        'step': 'portal.apps.onboarding.steps.system_creation.SystemCreationStep',
        'settings': {}
    }
]
```

1. Restart Celery!
2. Make sure your keys to Frontera are pushed
3. Delete your user
4. Log in and let onboarding steps proceed. You should see a logger message "{username} has valid configuration for frontera.home.{username}, skipping creation"

### Testing Key Service based System Creation ###

These instructions are for testing the keyservice based system creation. Make sure you have ngrok started, then use these settings:

```
_WH_BASE_URL = 'https://YOUR_NGROK.IO'
_PORTAL_KEY_SERVICE_ACTOR_ID = "mg06LLyrkG4Rv"
_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT = 'corral'
_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
    'corral': {
        'name': 'My Data (Corral)',
        'description': 'My Data on Corral',
        'site': 'cep.dev',
        'prefix': 'corral.home.{username}',
        'systemId': 'corral.home.{username}', 
        'host': 'cloud.corral.tacc.utexas.edu',
        'rootDir': '/work/{tasdir}',
        'port': 2222,
        'icon': None,
    },
}
_PORTAL_USER_ACCOUNT_SETUP_STEPS = [
    {
        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
        'settings': {}
    },
    {
        'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
        'settings': {}
    },
    {
        'step': 'portal.apps.onboarding.steps.system_creation.SystemCreationStep',
        'settings': {}
    }
]
```

1. Restart Celery!
2. Delete your user
3. Run through the onboarding steps. You should see a system for corral.home.{username} created as your My Data
4. Delete your user
5. Log in again. This time, you should see a log message saying this system was skipped. In addition, the event log for setup events will show a message saying "Found existing storage systems"
```
from portal.apps.onboarding.models import SetupEvent
SetupEvent.objects.all().filter(step="portal.apps.onboarding.steps.key_service_creation.KeyServiceCreationStep")
```

## UI Photos:

## Notes: ##
