### PR TITLE
Task/FP-881 unit testing for toast message

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.test.js
@@ -11,7 +11,7 @@ const files = {
     preview: {
       api: 'tapis',
       scheme: 'projects',
-      system: 'test.site.project.FRONTERA-3',
+      system: 'test.site.project.PROJECT-3',
       path: 'something/test.txt',
       href: 'href',
       name: 'test.txt'

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesCopyModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesCopyModal.test.js
@@ -73,7 +73,7 @@ describe('DataFilesCopyModal', () => {
         payload: {
           api: 'tapis',
           scheme: 'projects',
-          system: 'test.site.project.FRONTERA-3',
+          system: 'test.site.project.PROJECT-3',
           path: '',
           section: 'modal'
         }

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesMakePublicModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesMakePublicModal.test.js
@@ -39,7 +39,7 @@ describe('DataFilesMakePublicModal', () => {
     history.push('/workbench/data/tapis/private/test.system/');
     const store = mockStore(initialMockState);
 
-    const { getByText, getAllByRole } = renderComponent(
+    const { getByText } = renderComponent(
       <DataFilesMakePublicModal />,
       store,
       history

--- a/client/src/components/Toasts/Toast.js
+++ b/client/src/components/Toasts/Toast.js
@@ -73,8 +73,8 @@ const NotificationToast = () => {
   );
 };
 
-const ToastMessage = ({ notification }) => {
-  const systemList = useSelector(state => state.systems.systemList);
+export const ToastMessage = ({ notification }) => {
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const projectList = useSelector(state => state.projects.listing.projects);
   return (
     <>

--- a/client/src/components/Toasts/Toast.js
+++ b/client/src/components/Toasts/Toast.js
@@ -74,7 +74,7 @@ const NotificationToast = () => {
 };
 
 const ToastMessage = ({ notification }) => {
-  const systemList = useSelector(state => state.systems.storage.configuration);
+  const systemList = useSelector(state => state.systems.systemList);
   const projectList = useSelector(state => state.projects.listing.projects);
   return (
     <>

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import renderComponent from 'utils/testing';
+import truncateMiddle from 'utils/truncateMiddle';
 import NotificationToast, { ToastMessage, getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
@@ -119,13 +120,16 @@ describe('Toast Message', () => {
 describe('getToastMessage', () => {
   it('returns expected job response', () => {
     expect(getToastMessage(jobStatusUpdatePending)).toEqual(
-      'RStudio-S...cvserver is processing'
+      `${truncateMiddle(jobStatusUpdatePending.extra.name, 20)} is processing`
     );
   });
 
   it('returns expected interactive_session_ready response', () => {
     expect(getToastMessage(jobInteractiveSessionReady)).toEqual(
-      'RStudio-S...cvserver ready to view.'
+      `${truncateMiddle(
+        jobInteractiveSessionReady.extra.name,
+        20
+      )} ready to view.`
     );
   });
 

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import renderComponent from 'utils/testing';
-import NotificationToast, { ToastMessage, getToastMessage } from './Toast';
+import NotificationToast, { getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
 import systemsFixture from '../DataFiles/fixtures/DataFiles.systems.fixture';
@@ -41,6 +41,20 @@ const exampleToasts = [
   }
 ];
 
+const getToastStore = eventToasts => {
+  return {
+    systems: systemsFixture,
+    projects: projectsFixture,
+    notifications: {
+      ...notifications,
+      list: {
+        ...notifications.list,
+        toasts: eventToasts
+      }
+    }
+  };
+};
+
 describe('Notification Toast', () => {
   it('shows no toast on init', () => {
     const { queryByRole } = renderComponent(
@@ -53,21 +67,7 @@ describe('Notification Toast', () => {
   it('shows first toast in array', () => {
     const { queryByRole } = renderComponent(
       <NotificationToast />,
-      mockStore({
-        systems: initialSystemState,
-        notifications: {
-          ...notifications,
-          list: {
-            ...notifications.list,
-            toasts: exampleToasts
-          }
-        },
-        projects: {
-          listing: {
-            projects: []
-          }
-        }
-      })
+      mockStore(getToastStore(exampleToasts))
     );
     expect(queryByRole('alert')).toBeDefined();
     expect(queryByRole('alert')).toHaveTextContent(
@@ -81,17 +81,7 @@ describe('Notification Toast', () => {
   it('shows toast including system information', () => {
     const { queryByRole } = renderComponent(
       <NotificationToast />,
-      mockStore({
-        systems: systemsFixture,
-        projects: projectsFixture,
-        notifications: {
-          ...notifications,
-          list: {
-            ...notifications.list,
-            toasts: [dataFilesUpload]
-          }
-        }
-      })
+      mockStore(getToastStore([dataFilesUpload]))
     );
     expect(queryByRole('alert')).toHaveTextContent(
       'File uploaded to My Data (Frontera)/'
@@ -101,17 +91,7 @@ describe('Notification Toast', () => {
   it('shows toast including system information for shared workspace', () => {
     const { queryByRole } = renderComponent(
       <NotificationToast />,
-      mockStore({
-        systems: systemsFixture,
-        projects: projectsFixture,
-        notifications: {
-          ...notifications,
-          list: {
-            ...notifications.list,
-            toasts: [dataFilesUploadToSharedWorkSpace]
-          }
-        }
-      })
+      mockStore(getToastStore([dataFilesUploadToSharedWorkSpace]))
     );
     expect(queryByRole('alert')).toHaveTextContent(
       /File uploaded to Test Project Title\//
@@ -121,21 +101,9 @@ describe('Notification Toast', () => {
   it('shows toast for data file error', () => {
     const { queryByRole } = renderComponent(
       <NotificationToast />,
-      mockStore({
-        systems: systemsFixture,
-        projects: projectsFixture,
-        notifications: {
-          ...notifications,
-          list: {
-            ...notifications.list,
-            toasts: [dataFilesError]
-          }
-        }
-      })
+      mockStore(getToastStore([dataFilesError]))
     );
-    expect(queryByRole('alert')).toHaveTextContent(
-      /Move failed/
-    );
+    expect(queryByRole('alert')).toHaveTextContent(/Move failed/);
   });
 });
 

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -10,7 +10,8 @@ import { projectsFixture } from '../../redux/sagas/fixtures/projects.fixture';
 import {
   dataFilesRename,
   dataFilesError,
-  dataFilesUpload
+  dataFilesUpload,
+  dataFilesUploadToSharedWorkSpace
 } from '../../redux/sagas/fixtures/notificationsDataFilesEvents.fixture';
 import {
   jobStatusUpdatePending,
@@ -78,7 +79,6 @@ describe('Notification Toast', () => {
   });
 });
 
-
 describe('Toast Message', () => {
   it('shows data file error toast message', () => {
     const { getByText } = renderComponent(
@@ -103,6 +103,16 @@ describe('Toast Message', () => {
       })
     );
     expect(getByText('File uploaded to My Data (Frontera)/')).toBeDefined();
+  });
+  it('shows upload message including system information for shared workspace', () => {
+    const { getByText } = renderComponent(
+      <ToastMessage notification={dataFilesUploadToSharedWorkSpace} />,
+      mockStore({
+        systems: systemsFixture,
+        projects: projectsFixture
+      })
+    );
+    expect(getByText('File uploaded to Test Project Title/')).toBeDefined();
   });
 });
 

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import renderComponent from 'utils/testing';
-import NotificationToast, { getToastMessage } from './Toast';
+import NotificationToast, { ToastMessage, getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
 import {
@@ -72,6 +72,24 @@ describe('Notification Toast', () => {
     expect(queryByRole('alert')).not.toHaveTextContent(
       /RStudio-S...cvserver finished successfully/
     );
+  });
+});
+
+
+describe('Toast Message', () => {
+  it('shows data file error toast message', () => {
+    const { getByText } = renderComponent(
+      <ToastMessage notification={dataFilesError} />,
+      mockStore({
+        systems: initialSystemState,
+        projects: {
+          listing: {
+            projects: []
+          }
+        }
+      })
+    );
+    expect(getByText('Move failed')).toBeDefined();
   });
 });
 

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -5,9 +5,12 @@ import renderComponent from 'utils/testing';
 import NotificationToast, { ToastMessage, getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
+import systemsFixture from '../DataFiles/fixtures/DataFiles.systems.fixture';
+import { projectsFixture } from '../../redux/sagas/fixtures/projects.fixture';
 import {
   dataFilesRename,
-  dataFilesError
+  dataFilesError,
+  dataFilesUpload
 } from '../../redux/sagas/fixtures/notificationsDataFilesEvents.fixture';
 import {
   jobStatusUpdatePending,
@@ -90,6 +93,16 @@ describe('Toast Message', () => {
       })
     );
     expect(getByText('Move failed')).toBeDefined();
+  });
+  it('shows upload message including system information', () => {
+    const { getByText } = renderComponent(
+      <ToastMessage notification={dataFilesUpload} />,
+      mockStore({
+        systems: systemsFixture,
+        projects: projectsFixture
+      })
+    );
+    expect(getByText('File uploaded to My Data (Frontera)/')).toBeDefined();
   });
 });
 

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
+import renderComponent from 'utils/testing';
 import NotificationToast, { getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
@@ -38,24 +37,18 @@ const exampleToasts = [
   }
 ];
 
-function renderToastComponent(store) {
-  return render(
-    <Provider store={store}>
-      <NotificationToast />
-    </Provider>
-  );
-}
-
 describe('Notification Toast', () => {
   it('shows no toast on init', () => {
-    const { queryByRole } = renderToastComponent(
+    const { queryByRole } = renderComponent(
+      <NotificationToast />,
       mockStore({ notifications, systems: initialSystemState })
     );
     expect(queryByRole('alert')).toBeNull();
   });
 
   it('shows first toast in array', () => {
-    const { queryByRole } = renderToastComponent(
+    const { queryByRole } = renderComponent(
+      <NotificationToast />,
       mockStore({
         systems: initialSystemState,
         notifications: {

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -6,8 +6,14 @@ import '@testing-library/jest-dom/extend-expect';
 import NotificationToast, { getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
-import { dataFilesRename, dataFilesError } from '../../redux/sagas/fixtures/notificationsDataFilesEvents.fixture';
-import { jobStatusUpdatePending, jobInteractiveSessionReady } from '../../redux/sagas/fixtures/notificationsJobsEvents.fixture';
+import {
+  dataFilesRename,
+  dataFilesError
+} from '../../redux/sagas/fixtures/notificationsDataFilesEvents.fixture';
+import {
+  jobStatusUpdatePending,
+  jobInteractiveSessionReady
+} from '../../redux/sagas/fixtures/notificationsJobsEvents.fixture';
 
 const mockStore = configureStore();
 
@@ -18,8 +24,8 @@ const exampleToasts = [
     message: 'This is a test message',
     extra: {
       name: 'RStudio-Stampede2-1.1.423u4_2020-08-04T22:55:35-dcvserver',
-      status: 'RUNNING',
-    },
+      status: 'RUNNING'
+    }
   },
   {
     pk: '2',
@@ -27,9 +33,9 @@ const exampleToasts = [
     message: 'This is another test message',
     extra: {
       name: 'RStudio-Stampede2-1.1.423u4_2020-08-04T22:55:35-dcvserver',
-      status: 'FINISHED',
-    },
-  },
+      status: 'FINISHED'
+    }
+  }
 ];
 
 function renderToastComponent(store) {
@@ -43,7 +49,7 @@ function renderToastComponent(store) {
 describe('Notification Toast', () => {
   it('shows no toast on init', () => {
     const { queryByRole } = renderToastComponent(
-      mockStore({ notifications: notifications, systems: initialSystemState })
+      mockStore({ notifications, systems: initialSystemState })
     );
     expect(queryByRole('alert')).toBeNull();
   });
@@ -56,8 +62,8 @@ describe('Notification Toast', () => {
           ...notifications,
           list: {
             ...notifications.list,
-            toasts: exampleToasts,
-          },
+            toasts: exampleToasts
+          }
         },
         projects: {
           listing: {
@@ -67,23 +73,32 @@ describe('Notification Toast', () => {
       })
     );
     expect(queryByRole('alert')).toBeDefined();
-    expect(queryByRole('alert')).toHaveTextContent(/RStudio-S...cvserver is now running/);
-    expect(queryByRole('alert')).not.toHaveTextContent(/RStudio-S...cvserver finished successfully/);
+    expect(queryByRole('alert')).toHaveTextContent(
+      /RStudio-S...cvserver is now running/
+    );
+    expect(queryByRole('alert')).not.toHaveTextContent(
+      /RStudio-S...cvserver finished successfully/
+    );
   });
 });
 
 describe('getToastMessage', () => {
   it('returns expected job response', () => {
-    expect(getToastMessage(jobStatusUpdatePending)).toEqual('RStudio-S...cvserver is processing');
+    expect(getToastMessage(jobStatusUpdatePending)).toEqual(
+      'RStudio-S...cvserver is processing'
+    );
   });
 
   it('returns expected interactive_session_ready response', () => {
-    expect(getToastMessage(jobInteractiveSessionReady)).toEqual('RStudio-S...cvserver ready to view.');
+    expect(getToastMessage(jobInteractiveSessionReady)).toEqual(
+      'RStudio-S...cvserver ready to view.'
+    );
   });
 
   it('returns expected data_files responses', () => {
-    expect(getToastMessage(dataFilesRename)).toEqual('File renamed to test2.png');
+    expect(getToastMessage(dataFilesRename)).toEqual(
+      'File renamed to test2.png'
+    );
     expect(getToastMessage(dataFilesError)).toEqual('Move failed');
   });
-
 });

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -77,42 +77,65 @@ describe('Notification Toast', () => {
       /RStudio-S...cvserver finished successfully/
     );
   });
-});
 
-describe('Toast Message', () => {
-  it('shows data file error toast message', () => {
-    const { getByText } = renderComponent(
-      <ToastMessage notification={dataFilesError} />,
+  it('shows toast including system information', () => {
+    const { queryByRole } = renderComponent(
+      <NotificationToast />,
       mockStore({
-        systems: initialSystemState,
-        projects: {
-          listing: {
-            projects: []
+        systems: systemsFixture,
+        projects: projectsFixture,
+        notifications: {
+          ...notifications,
+          list: {
+            ...notifications.list,
+            toasts: [dataFilesUpload]
           }
         }
       })
     );
-    expect(getByText('Move failed')).toBeDefined();
+    expect(queryByRole('alert')).toHaveTextContent(
+      'File uploaded to My Data (Frontera)/'
+    );
   });
-  it('shows upload message including system information', () => {
-    const { getByText } = renderComponent(
-      <ToastMessage notification={dataFilesUpload} />,
+
+  it('shows toast including system information for shared workspace', () => {
+    const { queryByRole } = renderComponent(
+      <NotificationToast />,
       mockStore({
         systems: systemsFixture,
-        projects: projectsFixture
+        projects: projectsFixture,
+        notifications: {
+          ...notifications,
+          list: {
+            ...notifications.list,
+            toasts: [dataFilesUploadToSharedWorkSpace]
+          }
+        }
       })
     );
-    expect(getByText('File uploaded to My Data (Frontera)/')).toBeDefined();
+    expect(queryByRole('alert')).toHaveTextContent(
+      /File uploaded to Test Project Title\//
+    );
   });
-  it('shows upload message including system information for shared workspace', () => {
-    const { getByText } = renderComponent(
-      <ToastMessage notification={dataFilesUploadToSharedWorkSpace} />,
+
+  it('shows toast for data file error', () => {
+    const { queryByRole } = renderComponent(
+      <NotificationToast />,
       mockStore({
         systems: systemsFixture,
-        projects: projectsFixture
+        projects: projectsFixture,
+        notifications: {
+          ...notifications,
+          list: {
+            ...notifications.list,
+            toasts: [dataFilesError]
+          }
+        }
       })
     );
-    expect(getByText('File uploaded to Test Project Title/')).toBeDefined();
+    expect(queryByRole('alert')).toHaveTextContent(
+      /Move failed/
+    );
   });
 });
 

--- a/client/src/components/Toasts/Toast.test.js
+++ b/client/src/components/Toasts/Toast.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import renderComponent from 'utils/testing';
-import truncateMiddle from 'utils/truncateMiddle';
 import NotificationToast, { ToastMessage, getToastMessage } from './Toast';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
 import { initialSystemState } from '../../redux/reducers/datafiles.reducers';
@@ -120,16 +119,13 @@ describe('Toast Message', () => {
 describe('getToastMessage', () => {
   it('returns expected job response', () => {
     expect(getToastMessage(jobStatusUpdatePending)).toEqual(
-      `${truncateMiddle(jobStatusUpdatePending.extra.name, 20)} is processing`
+      'RStudio-S...cvserver is processing'
     );
   });
 
   it('returns expected interactive_session_ready response', () => {
     expect(getToastMessage(jobInteractiveSessionReady)).toEqual(
-      `${truncateMiddle(
-        jobInteractiveSessionReady.extra.name,
-        20
-      )} ready to view.`
+      'RStudio-S...cvserver ready to view.'
     );
   });
 

--- a/client/src/redux/sagas/fixtures/notificationsDataFilesEvents.fixture.js
+++ b/client/src/redux/sagas/fixtures/notificationsDataFilesEvents.fixture.js
@@ -277,3 +277,48 @@ export const dataFilesUpload = {
   status: 'SUCCESS',
   user: 'username'
 };
+
+export const dataFilesUploadToSharedWorkSpace = {
+  event_type: 'data_files',
+  datetime: '1614377685',
+  status: 'SUCCESS',
+  operation: 'upload',
+  message: '',
+  extra: {
+    response: {
+      name: 'test.txt',
+      uuid: '610361652746916331-242ac112-0001-002',
+      owner: 'username',
+      internalUsername: null,
+      lastModified: '2021-02-26T16:14:45.881-06:00',
+      source: 'http://129.114.97.130/test7.txt',
+      path: 'test7.txt',
+      status: 'STAGING_QUEUED',
+      systemId: 'test.site.project.PROJECT-3',
+      nativeFormat: 'raw',
+      _links: {
+        self: {
+          href:
+            'https://portals-api.tacc.utexas.edu/files/v2/media/system/test.site.project.PROJECT-3//test7.txt'
+        },
+        system: {
+          href:
+            'https://portals-api.tacc.utexas.edu/systems/v2/test.site.project.PROJECT-3'
+        },
+        profile: {
+          href: 'https://portals-api.tacc.utexas.edu/profiles/v2/username'
+        },
+        history: {
+          href:
+            'https://portals-api.tacc.utexas.edu/files/v2/history/system/test.site.project.PROJECT-3//test7.txt'
+        },
+        notification: []
+      }
+    }
+  },
+  pk: 1,
+  action_link: '',
+  user: 'username',
+  read: true,
+  deleted: false
+};

--- a/client/src/redux/sagas/fixtures/projects.fixture.js
+++ b/client/src/redux/sagas/fixtures/projects.fixture.js
@@ -10,8 +10,8 @@ export const projectsListingFixture = [
     default: false,
     public: false,
     globalDefault: false,
-    name: 'FRONTERA-3',
-    id: 'test.site.project.FRONTERA-3',
+    name: 'PROJECT-3',
+    id: 'test.site.project.PROJECT-3',
     status: 'UP',
     storage: {
       proxy: null,
@@ -29,7 +29,7 @@ export const projectsListingFixture = [
         privateKey: ''
       }
     },
-    absolutePath: '/corral-repl/tacc/aci/CEP/projects/FRONTERA-3'
+    absolutePath: '/corral-repl/tacc/aci/CEP/projects/PROJECT-3'
   }
 ];
 

--- a/client/src/utils/systems.test.js
+++ b/client/src/utils/systems.test.js
@@ -22,10 +22,10 @@ describe('systems utility functions', () => {
   });
   it('get project title from host', () => {
     expect(
-      findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-3')
+      findProjectTitle(projectsListingFixture, 'test.site.project.PROJECT-3')
     ).toEqual('Test Project Title');
     expect(
-      findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-X')
+      findProjectTitle(projectsListingFixture, 'test.site.project.PROJECT-X')
     ).toEqual('');
   });
   it('get project title based on resource', () => {
@@ -35,7 +35,7 @@ describe('systems utility functions', () => {
         'projects',
         systemList,
         projectsListingFixture,
-        'test.site.project.FRONTERA-3'
+        'test.site.project.PROJECT-3'
       )
     ).toEqual('Test Project Title');
     expect(
@@ -43,7 +43,7 @@ describe('systems utility functions', () => {
         'projects',
         systemList,
         projectsListingFixture,
-        'test.site.project.FRONTERA-X'
+        'test.site.project.PROJECT-X'
       )
     ).toEqual('');
   });


### PR DESCRIPTION
## Overview: ##

Add additional testing for toast messages. [This (FP-881)](https://jira.tacc.utexas.edu/browse/FP-881) is a follow on to https://github.com/TACC/Core-Portal/pull/337/files where we missed updating a change to the state and the unit tests did not catch that error.

## Related Jira tickets: ##

* [FP-881](https://jira.tacc.utexas.edu/browse/FP-881)

## Summary of Changes: ##
Use utils/testing renderComponent and some linting related changes.
Add basic test for ToastMessage
Add test for notification related to shared workspace

## Testing Steps: ##
1. Run tests
2. (Optional) Make an error like the one fixed in https://github.com/TACC/Core-Portal/pull/337/file and see if unit tests fail.
