### PR TITLE
quick - Bump poetry version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.0.0
+        poetry-version: 1.1.0
 
     - uses: actions/cache@v1
       with:
@@ -64,7 +64,7 @@ jobs:
     - name: Setup Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.0.0
+        poetry-version: 1.1.0
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
## Overview: ##

Bump poetry version to fix pipelines

## Notes: ##

Poetry 1.0.0 breaks existing pipelines. Might still need to look at build configurations on jenkins.