### PR TITLE
task/FP-935 - onboarding admin pagination

### DIFF
--- a/client/src/components/Onboarding/OnboardingAdmin.js
+++ b/client/src/components/Onboarding/OnboardingAdmin.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { LoadingSpinner, Message, Paginator } from '_common';
+import { LoadingSpinner, Message, SectionMessage, Paginator } from '_common';
 import './OnboardingAdmin.module.scss';
 import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -207,7 +207,7 @@ const OnboardingAdmin = () => {
   );
 
   const paginationCallback = useCallback(
-    (page) => {
+    page => {
       dispatch({
         type: 'FETCH_ONBOARDING_ADMIN_LIST',
         payload: {
@@ -215,7 +215,7 @@ const OnboardingAdmin = () => {
           limit,
           query
         }
-      })
+      });
     },
     [offset, limit, query]
   );
@@ -240,39 +240,50 @@ const OnboardingAdmin = () => {
 
   const current = Math.floor(offset / limit) + 1;
   const pages = Math.ceil(total / limit);
-
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+  if (error) {
+    return (
+      <Message type="warn">Unable to access Onboarding administration</Message>
+    );
+  }
   return (
-    <div styleName="container">
-      <div styleName="container-header">
-        <h5>Administrator Controls</h5>
-        <OnboardingAdminSearchbar />
-      </div>
-      {loading && (
-        <div>
-          <LoadingSpinner />
+    <div styleName="root">
+      <div styleName="container">
+        <div styleName="container-header">
+          <h5>Administrator Controls</h5>
+          <OnboardingAdminSearchbar />
         </div>
-      )}
-      {error && (
-        <div>
-          <Message type="warn">
-            Unable to access Onboarding administration
-          </Message>
+        {users.length === 0 && (
+          <div styleName="no-users-placeholder">
+            <SectionMessage type="warn">No users to show.</SectionMessage>
+          </div>
+        )}
+        <div styleName="user-container">
+          {users.length > 0 && (
+            <OnboardingAdminList
+              users={users}
+              viewLogCallback={viewLogCallback}
+            />
+          )}
         </div>
-      )}
-      {!loading && !error && (
-        <>
-          <OnboardingAdminList users={users} viewLogCallback={viewLogCallback} />
+        {users.length > 0 && (
           <div styleName="paginator-container">
-            <Paginator current={current} pages={pages} callback={paginationCallback} />
-          </div>          
-        </>
-      )}
-      {eventLogModalParams && (
-        <OnboardingEventLogModal
-          params={eventLogModalParams}
-          toggle={toggleViewLogModal}
-        />
-      )}
+            <Paginator
+              current={current}
+              pages={pages}
+              callback={paginationCallback}
+            />
+          </div>
+        )}
+        {eventLogModalParams && (
+          <OnboardingEventLogModal
+            params={eventLogModalParams}
+            toggle={toggleViewLogModal}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/client/src/components/Onboarding/OnboardingAdmin.js
+++ b/client/src/components/Onboarding/OnboardingAdmin.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { LoadingSpinner, Message } from '_common';
+import { LoadingSpinner, Message, Paginator } from '_common';
 import './OnboardingAdmin.module.scss';
 import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -169,7 +169,7 @@ OnboardingAdminListUser.propTypes = {
 
 const OnboardingAdminList = ({ users, viewLogCallback }) => {
   return (
-    <table styleName="root">
+    <table styleName="users">
       <thead>
         <tr>
           <th>User</th>
@@ -202,8 +202,22 @@ const OnboardingAdmin = () => {
   const dispatch = useDispatch();
   const [eventLogModalParams, setEventLogModalParams] = useState(null);
 
-  const { users, offset, limit, loading, error } = useSelector(
+  const { users, offset, limit, total, query, loading, error } = useSelector(
     state => state.onboarding.admin
+  );
+
+  const paginationCallback = useCallback(
+    (page) => {
+      dispatch({
+        type: 'FETCH_ONBOARDING_ADMIN_LIST',
+        payload: {
+          offset: (page - 1) * limit,
+          limit,
+          query
+        }
+      })
+    },
+    [offset, limit, query]
   );
 
   const viewLogCallback = useCallback(
@@ -220,9 +234,12 @@ const OnboardingAdmin = () => {
   useEffect(() => {
     dispatch({
       type: 'FETCH_ONBOARDING_ADMIN_LIST',
-      payload: { offset, limit }
+      payload: { offset, limit, query: null }
     });
   }, [dispatch, offset, limit]);
+
+  const current = Math.floor(offset / limit) + 1;
+  const pages = Math.ceil(total / limit);
 
   return (
     <div styleName="container">
@@ -243,7 +260,10 @@ const OnboardingAdmin = () => {
         </div>
       )}
       {!loading && !error && (
-        <OnboardingAdminList users={users} viewLogCallback={viewLogCallback} />
+        <>
+          <OnboardingAdminList users={users} viewLogCallback={viewLogCallback} />
+          <Paginator current={current} pages={pages} callback={paginationCallback} />
+        </>
       )}
       {eventLogModalParams && (
         <OnboardingEventLogModal

--- a/client/src/components/Onboarding/OnboardingAdmin.js
+++ b/client/src/components/Onboarding/OnboardingAdmin.js
@@ -262,7 +262,9 @@ const OnboardingAdmin = () => {
       {!loading && !error && (
         <>
           <OnboardingAdminList users={users} viewLogCallback={viewLogCallback} />
-          <Paginator current={current} pages={pages} callback={paginationCallback} />
+          <div styleName="paginator-container">
+            <Paginator current={current} pages={pages} callback={paginationCallback} />
+          </div>          
         </>
       )}
       {eventLogModalParams && (

--- a/client/src/components/Onboarding/OnboardingAdmin.module.scss
+++ b/client/src/components/Onboarding/OnboardingAdmin.module.scss
@@ -1,7 +1,6 @@
 .container {
   display: flex;
   flex-direction: column;
-
   padding: 20px 40px 0 20px;
 }
 
@@ -13,14 +12,14 @@
     margin-bottom: 1.5em;
 }
 
-.root {
+.users {
   --cell-horizontal-padding: 0.35em; /* horizontal cell padding for inter-column buffer */
   /* TODO: After, FP-103, use `composes:` not `@extend` */
 
   position: relative;
   align-items: stretch;
   width: 100%;
-  overflow: scroll;
+  overflow-y: scroll;
   max-height: inherit; /* inherit max-height from parent wrapper */
   font-size: 12px;
 

--- a/client/src/components/Onboarding/OnboardingAdmin.module.scss
+++ b/client/src/components/Onboarding/OnboardingAdmin.module.scss
@@ -12,6 +12,13 @@
     margin-bottom: 1.5em;
 }
 
+.paginator-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 1em;
+}
+
 .users {
   --cell-horizontal-padding: 0.35em; /* horizontal cell padding for inter-column buffer */
   /* TODO: After, FP-103, use `composes:` not `@extend` */
@@ -20,7 +27,6 @@
   align-items: stretch;
   width: 100%;
   overflow-y: scroll;
-  max-height: inherit; /* inherit max-height from parent wrapper */
   font-size: 12px;
 
   thead {

--- a/client/src/components/Onboarding/OnboardingAdmin.module.scss
+++ b/client/src/components/Onboarding/OnboardingAdmin.module.scss
@@ -1,7 +1,17 @@
+// Required to constrain table within flex box
+.root {
+  position: relative;
+}
+
 .container {
   display: flex;
   flex-direction: column;
-  padding: 20px 40px 0 20px;
+  padding: 20px 40px 20px 20px;
+  position: absolute;
+  max-height: 100%;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
 }
 
 .container-header {
@@ -19,11 +29,16 @@
   margin-top: 1em;
 }
 
+.user-container {
+  flex-grow: 0;
+  overflow-y: scroll;
+  position: relative;
+}
+
 .users {
   --cell-horizontal-padding: 0.35em; /* horizontal cell padding for inter-column buffer */
   /* TODO: After, FP-103, use `composes:` not `@extend` */
-
-  position: relative;
+  height: 100%;
   align-items: stretch;
   width: 100%;
   overflow-y: scroll;
@@ -124,4 +139,10 @@ tbody {
   td:nth-child(4) {
     width: 20%;
   }
+}
+
+.no-users-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/client/src/components/Onboarding/OnboardingAdminSearchbar.js
+++ b/client/src/components/Onboarding/OnboardingAdminSearchbar.js
@@ -16,9 +16,9 @@ const OnboardingAdminSearchbar = ({ className, disabled }) => {
     dispatch({
       type: 'FETCH_ONBOARDING_ADMIN_LIST',
       payload: {
-        limit: 10,
+        limit: 25,
         offset: 0,
-        q: query
+        query
       }
     });
     setSearched(true);
@@ -29,8 +29,9 @@ const OnboardingAdminSearchbar = ({ className, disabled }) => {
     dispatch({
       type: 'FETCH_ONBOARDING_ADMIN_LIST',
       payload: {
-        limit: 10,
-        offset: 0
+        limit: 25,
+        offset: 0,
+        query: null
       }
     });
     setSearched(false);

--- a/client/src/redux/reducers/onboarding.reducers.js
+++ b/client/src/redux/reducers/onboarding.reducers.js
@@ -2,7 +2,7 @@ export const initialState = {
   admin: {
     users: [],
     offset: 0,
-    limit: 10,
+    limit: 25,
     total: 0,
     query: null,
     loading: false,

--- a/client/src/redux/reducers/onboarding.reducers.js
+++ b/client/src/redux/reducers/onboarding.reducers.js
@@ -4,6 +4,7 @@ export const initialState = {
     offset: 0,
     limit: 10,
     total: 0,
+    query: null,
     loading: false,
     error: null
   },
@@ -65,7 +66,6 @@ export function onboarding(state = initialState, action) {
       return {
         ...state,
         admin: {
-          ...state.admin,
           ...action.payload,
           loading: false,
           error: null

--- a/client/src/redux/sagas/fixtures/onboarding.fixture.js
+++ b/client/src/redux/sagas/fixtures/onboarding.fixture.js
@@ -170,7 +170,7 @@ export const onboardingUserFixture = {
 export const onboardingAdminFixture = {
   users: [{ ...onboardingUserFixture }],
   offset: 0,
-  limit: 10,
+  limit: 25,
   total: 1
 };
 
@@ -186,7 +186,7 @@ export const onboardingAdminState = {
   admin: {
     users: onboardingAdminFixture.users,
     offset: 0,
-    limit: 10,
+    limit: 25,
     total: 1,
     query: null,
     loading: false,
@@ -208,7 +208,7 @@ export const onboardingUserState = {
   admin: {
     users: [],
     offset: 0,
-    limit: 10,
+    limit: 25,
     total: 0,
     query: null,
     loading: false,
@@ -226,7 +226,7 @@ export const onboardingActionState = {
   admin: {
     users: [],
     offset: 0,
-    limit: 10,
+    limit: 25,
     total: 0,
     query: null,
     loading: false,

--- a/client/src/redux/sagas/fixtures/onboarding.fixture.js
+++ b/client/src/redux/sagas/fixtures/onboarding.fixture.js
@@ -188,6 +188,7 @@ export const onboardingAdminState = {
     offset: 0,
     limit: 10,
     total: 1,
+    query: null,
     loading: false,
     error: null
   },
@@ -209,6 +210,7 @@ export const onboardingUserState = {
     offset: 0,
     limit: 10,
     total: 0,
+    query: null,
     loading: false,
     error: null
   },
@@ -226,6 +228,7 @@ export const onboardingActionState = {
     offset: 0,
     limit: 10,
     total: 0,
+    query: null,
     loading: false,
     error: null
   },

--- a/client/src/redux/sagas/onboarding.sagas.js
+++ b/client/src/redux/sagas/onboarding.sagas.js
@@ -18,11 +18,14 @@ export async function fetchOnboardingAdminList(offset, limit, q) {
 export function* getOnboardingAdminList(action) {
   yield put({ type: 'FETCH_ONBOARDING_ADMIN_LIST_PROCESSING' });
   try {
-    const { offset, limit, q } = action.payload;
-    const adminList = yield call(fetchOnboardingAdminList, offset, limit, q);
+    const { offset, limit, query } = action.payload;
+    const result = yield call(fetchOnboardingAdminList, offset, limit, query );
     yield put({
       type: 'FETCH_ONBOARDING_ADMIN_LIST_SUCCESS',
-      payload: adminList
+      payload: {
+        ...result,
+        query: query ? query : null
+      }
     });
   } catch (error) {
     yield put({ type: 'FETCH_ONBOARDING_ADMIN_LIST_ERROR', payload: error });

--- a/client/src/redux/sagas/onboarding.sagas.js
+++ b/client/src/redux/sagas/onboarding.sagas.js
@@ -19,12 +19,12 @@ export function* getOnboardingAdminList(action) {
   yield put({ type: 'FETCH_ONBOARDING_ADMIN_LIST_PROCESSING' });
   try {
     const { offset, limit, query } = action.payload;
-    const result = yield call(fetchOnboardingAdminList, offset, limit, query );
+    const result = yield call(fetchOnboardingAdminList, offset, limit, query);
     yield put({
       type: 'FETCH_ONBOARDING_ADMIN_LIST_SUCCESS',
       payload: {
         ...result,
-        query: query ? query : null
+        query: query || null
       }
     });
   } catch (error) {

--- a/client/src/redux/sagas/onboarding.sagas.test.js
+++ b/client/src/redux/sagas/onboarding.sagas.test.js
@@ -22,19 +22,19 @@ jest.mock('cross-fetch');
 
 describe('getOnboardingAdminList Saga', () => {
   it('should fetch list of onboarding users and transform state', () =>
-    expectSaga(getOnboardingAdminList, { payload: { offset: 0, limit: 10, query: null } })
+    expectSaga(getOnboardingAdminList, { payload: { offset: 0, limit: 25, query: null } })
       .withReducer(onboarding)
       .provide([
         [matchers.call.fn(fetchOnboardingAdminList), onboardingAdminFixture]
       ])
       .put({ type: 'FETCH_ONBOARDING_ADMIN_LIST_PROCESSING' })
-      .call(fetchOnboardingAdminList, 0, 10, null)
+      .call(fetchOnboardingAdminList, 0, 25, null)
       .put({
         type: 'FETCH_ONBOARDING_ADMIN_LIST_SUCCESS',
         payload: {
           users: onboardingAdminFixture.users,
           offset: 0,
-          limit: 10,
+          limit: 25,
           query: null,
           total: 1
         }

--- a/client/src/redux/sagas/onboarding.sagas.test.js
+++ b/client/src/redux/sagas/onboarding.sagas.test.js
@@ -22,19 +22,20 @@ jest.mock('cross-fetch');
 
 describe('getOnboardingAdminList Saga', () => {
   it('should fetch list of onboarding users and transform state', () =>
-    expectSaga(getOnboardingAdminList, { payload: { offset: 0, limit: 10 } })
+    expectSaga(getOnboardingAdminList, { payload: { offset: 0, limit: 10, query: null } })
       .withReducer(onboarding)
       .provide([
         [matchers.call.fn(fetchOnboardingAdminList), onboardingAdminFixture]
       ])
       .put({ type: 'FETCH_ONBOARDING_ADMIN_LIST_PROCESSING' })
-      .call(fetchOnboardingAdminList, 0, 10)
+      .call(fetchOnboardingAdminList, 0, 10, null)
       .put({
         type: 'FETCH_ONBOARDING_ADMIN_LIST_SUCCESS',
         payload: {
           users: onboardingAdminFixture.users,
           offset: 0,
           limit: 10,
+          query: null,
           total: 1
         }
       })

--- a/server/portal/apps/onboarding/api/views.py
+++ b/server/portal/apps/onboarding/api/views.py
@@ -255,6 +255,8 @@ class SetupAdminView(BaseApiView):
             results = results.filter(query)
         # Get users, with users that do not have setup_complete, first
         results = results.order_by('profile__setup_complete', 'last_name', 'first_name')
+        # Uncomment this line to simulate many user results
+        # results = list(results) * 105
         total = len(results)
         page = results[offset:offset + limit]
 


### PR DESCRIPTION
## Overview: ##

Pagination support for onboarding admin

## Related Jira tickets: ##

* [FP-935](https://jira.tacc.utexas.edu/browse/FP-935)
* [FP-877](https://jira.tacc.utexas.edu/browse/FP-877)

## Summary of Changes: ##

- Set pagination default at 25 users per page
- Add pagination component

## Testing Steps: ##
1. Make your user staff so that you can view /workbench/onboarding/admin
2. To view simulated large results, uncomment [this line](https://github.com/TACC/Core-Portal/blob/9d6e8e98ee545488f502154b375a9a7093e4a96b/server/portal/apps/onboarding/api/views.py#L259) in views.py

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/109565741-876b9080-7aa8-11eb-99e3-06914315b5f7.png)

## Notes: ##

- Need to handle 0 user results in search during pagination
- User table needs to scroll within component