### PR TITLE
bug/FP-970 - Make columns dependent on fileNavCellCallback to handle scheme changes

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
@@ -120,7 +120,7 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
       });
     }
     return cells;
-  }, [api, showViewPath]);
+  }, [api, showViewPath, fileNavCellCallback]);
 
   return (
     <div styleName="root">


### PR DESCRIPTION
## Overview: ##

Fix bug by making `columns` dependent on `fileNavCellCallback` to ensure that an updated `fileNavCellCallback` is used if scheme changes.  See [FP-970](https://jira.tacc.utexas.edu/browse/FP-970) for notes on re-creating bug

## Related Jira tickets: ##

* [FP-970](https://jira.tacc.utexas.edu/browse/FP-970)

## Summary of Changes: ##
* Make `columns` dependent on `fileNavCellCallback` to ensure that an updated `fileNavCellCallback` is used if scheme changes

## Testing Steps: ##
1. Go directly to route https://cep.dev/workbench/data/tapis/public/cep.storage.public/
2. Then click on your My Data which is `private`.
3) Confirm links to files/folders have correct scheme of `private` (and not `public`) in the route and than you can go to a subfolder and upload a file.

