### PR TITLE
bug/FP-975: Fix `StopIteration` error for backend Jobs listing

### DIFF
--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -230,8 +230,8 @@ class JobsView(BaseApiView):
             user_job_ids = all_user_job_ids[offset:offset + limit]
             if user_job_ids:
                 data = agave.jobs.list(query={'id.in': ','.join(user_job_ids)})
-                # filter agave jobs response to match our time-ordered jobs
-                data = [job for job in data if job["id"] in user_job_ids]
+                # re-order agave job info to match our time-ordered jobs
+                data = list(filter(None, [next((job for job in data if job["id"] == id), None) for id in user_job_ids]))
             else:
                 data = []
 

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -230,8 +230,8 @@ class JobsView(BaseApiView):
             user_job_ids = all_user_job_ids[offset:offset + limit]
             if user_job_ids:
                 data = agave.jobs.list(query={'id.in': ','.join(user_job_ids)})
-                # re-order agave job info to match our time-ordered jobs
-                data = [next(job for job in data if job["id"] == id) for id in user_job_ids]
+                # filter agave jobs response to match our time-ordered jobs
+                data = [job for job in data if job["id"] in user_job_ids]
             else:
                 data = []
 

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -231,6 +231,8 @@ class JobsView(BaseApiView):
             if user_job_ids:
                 data = agave.jobs.list(query={'id.in': ','.join(user_job_ids)})
                 # re-order agave job info to match our time-ordered jobs
+                # while also taking care that tapis in rare cases might no longer
+                # have that job (see https://jira.tacc.utexas.edu/browse/FP-975)
                 data = list(filter(None, [next((job for job in data if job["id"] == id), None) for id in user_job_ids]))
             else:
                 data = []

--- a/server/portal/apps/workspace/api/views_unit_test.py
+++ b/server/portal/apps/workspace/api/views_unit_test.py
@@ -3,6 +3,7 @@ from mock import MagicMock
 from django.conf import settings
 from portal.apps.workspace.api.views import JobsView, AppsTrayView
 from portal.apps.workspace.models import AppTrayCategory
+from portal.apps.workspace.models import JobSubmission
 import json
 import os
 import pytest
@@ -88,8 +89,19 @@ def request_jobs_util(rf, authenticated_user, query_params={}):
     return json.loads(response.content)["response"]
 
 
-def test_get_no_jobs(rf, authenticated_user, mock_agave_client):
+def test_get_no_tapis_jobs(rf, authenticated_user, mock_agave_client):
     mock_agave_client.jobs.list.return_value = []
+    jobs = request_jobs_util(rf, authenticated_user)
+    assert len(jobs) == 0
+
+
+def test_get_no_portal_jobs(rf, authenticated_user, mock_agave_client):
+    JobSubmission.objects.create(
+        user=authenticated_user,
+        jobId="9876"
+    )
+    mock_agave_client.jobs.list.return_value = [
+    ]
     jobs = request_jobs_util(rf, authenticated_user)
     assert len(jobs) == 0
 


### PR DESCRIPTION
## Overview: ##
When the `next` iterator reaches the end of the list, it raises a `StopIteration` exception. This error can be raised when a `JobSubmission` object exists in the database, but does not exist in Tapis. We can fix this by including a `default` param with the `next` method.

## Related Jira tickets: ##

* [FP-975](https://jira.tacc.utexas.edu/browse/FP-975)

## Testing Steps: ##
1. Have a `JobSubmission` in the database with an id that does not exist in Tapis. You can recreate this by finding one of your portal jobs and deleting it from Tapis via the CLI.
