### PR TITLE
FP-972: Unsqueeze onboarding status loading icon

### DIFF
--- a/client/src/components/Onboarding/OnboardingActions.scss
+++ b/client/src/components/Onboarding/OnboardingActions.scss
@@ -1,5 +1,9 @@
 .onboarding-action__loading {
   display: inline-block;
-  width: inherit;
+  width: auto;
 }
 
+.onboarding-action__loading .inline {
+  width: 16px;
+  height: 16px;
+}

--- a/client/src/components/Onboarding/OnboardingStatus.js
+++ b/client/src/components/Onboarding/OnboardingStatus.js
@@ -46,7 +46,6 @@ const getContents = step => {
           <Pill type={type}>Processing</Pill>
           <LoadingSpinner
             placement="inline"
-            styleName="loading"
             className="onboarding-status__loading"
           />
         </span>

--- a/client/src/components/Onboarding/OnboardingStatus.js
+++ b/client/src/components/Onboarding/OnboardingStatus.js
@@ -46,6 +46,7 @@ const getContents = step => {
           <Pill type={type}>Processing</Pill>
           <LoadingSpinner
             placement="inline"
+            styleName="loading"
             className="onboarding-status__loading"
           />
         </span>

--- a/client/src/components/Onboarding/OnboardingStatus.module.scss
+++ b/client/src/components/Onboarding/OnboardingStatus.module.scss
@@ -3,9 +3,8 @@
   margin-right: 0.5em;
 }
 
-.loading-icon {
-  display: inherit;
-  width: inherit;
+.loading {
+  width: auto;
 }
 
 .processing {

--- a/client/src/components/Onboarding/OnboardingStatus.module.scss
+++ b/client/src/components/Onboarding/OnboardingStatus.module.scss
@@ -4,7 +4,7 @@
 }
 
 .loading {
-  width: auto;
+  width: auto; /* overwrite <LoadingSpinner> */
 }
 
 .processing {

--- a/client/src/components/Onboarding/OnboardingStatus.module.scss
+++ b/client/src/components/Onboarding/OnboardingStatus.module.scss
@@ -3,10 +3,6 @@
   margin-right: 0.5em;
 }
 
-.loading {
-  width: auto; /* overwrite <LoadingSpinner> */
-}
-
 .processing {
   display: flex;
   align-items: center;

--- a/client/src/components/Onboarding/OnboardingStatus.scss
+++ b/client/src/components/Onboarding/OnboardingStatus.scss
@@ -1,5 +1,6 @@
 .onboarding-status__loading {
   display: inline-block;
+  width: auto;
 }
 
 .onboarding-status__loading .inline {


### PR DESCRIPTION
## Overview: ##

- Remove unused code.
- Simplify and consistently replicate code for fix.
- Incidentally, fix loading icon size inconsistency.

## Related Jira tickets: ##

* [FP-972](https://jira.tacc.utexas.edu/browse/FP-972)

## Summary of Changes: ##

- __Fix__: Remove unused styles.
- __Fix__: Make consistent duplicate fixes for loading UI bug.
- _Minor_: Simplify pre-existing fix for loading UI bug.

## Testing Steps: ##

- [Be a staff user.](https://github.com/TACC/Core-Portal/wiki/How-to-Set-Your-User-to-Staff)
- Have a user with incomplete onboarding.
- Have an onboarding state for that user that is "Processing".

1. Load user onboarding (`/workbench/onboarding/setup/`).
2. See that any state in Processing has a pill whose text "Processing" can be read without truncation.
1. Load user onboarding administration (`/workbench/onboarding/admin/`).
2. See that any state in Processing has a pill whose text "Processing" can be read without truncation.

<details><summary>How to Fake Onboarding States to Get Loading Icons</summary>

![OnboardingActions Load](https://user-images.githubusercontent.com/62723358/112178889-25460d00-8bc8-11eb-9e80-65335e52e740.png)
![OnboardingState Load](https://user-images.githubusercontent.com/62723358/112178894-25dea380-8bc8-11eb-9278-bba355c0765b.png)

</details>

## UI Photos:

<details><summary>Admin</summary>

__Before__\
![FP-972 Admin](https://user-images.githubusercontent.com/62723358/112062143-81a81e80-8b2d-11eb-929c-0dd8950325a0.png)

__After__\
(Unavailable. I was not able to replicate "Before" state. The "Before" state image was captured by @rstijerina.)

</details>
<details><summary>User (Simulated Status Loading State)</summary>

> This is what the UI can actually look like, __but__ it only shows the `<OnboardingStatus>` loading state.

__Before__\
![FP-972 User](https://user-images.githubusercontent.com/62723358/112062150-82d94b80-8b2d-11eb-9c88-52b551b6a881.png)

__After__\
![FP-972 User (Fixed)](https://user-images.githubusercontent.com/62723358/112063384-545c7000-8b2f-11eb-9c02-d42fae95fbf1.png)

</details>
<details><summary>User (Fake: Simulated Status & Step Loading States)</summary>

> This is __not__ what the UI can actually look like, __but__ it shows both possible loading states.

__Before__\
![FP-972 User - Fake](https://user-images.githubusercontent.com/62723358/112177026-9a184780-8bc6-11eb-9090-81566726bba4.png)

__After__\
![FP-972 User - Fake (Fixed)](https://user-images.githubusercontent.com/62723358/112177022-997fb100-8bc6-11eb-9b39-e3db123f697f.png)

</details>

## Notes: ##
