### PR TITLE
task/FP-976: Add configurable work2 Alert message

### DIFF
--- a/client/src/components/Workbench/WelcomeMessages.js
+++ b/client/src/components/Workbench/WelcomeMessages.js
@@ -53,9 +53,8 @@ const WelcomeMessages = () => {
                 Notice: The Stockyard <code>/work</code> filesystem is being
                 deprecated. A new filesystem <code>/work2</code> is now
                 available and will eventually replace <code>/work</code>. During
-                the transition period, users must migrate any current data they
-                wish to retain. You can read more information about this change
-                in the{' '}
+                the transition period, migrate any data you wish to retain. Read
+                more information about this change in the{' '}
                 <a
                   href="https://portal.tacc.utexas.edu/tutorials/stockyard-work-migration"
                   target="_blank"

--- a/client/src/components/Workbench/WelcomeMessages.js
+++ b/client/src/components/Workbench/WelcomeMessages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Route, Switch, useRouteMatch, Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert } from 'reactstrap';
 import * as ROUTES from '../../constants/routes';
@@ -8,7 +8,10 @@ const WelcomeMessages = () => {
   const { path } = useRouteMatch();
   const dispatch = useDispatch();
 
-  const welcomeMessages = useSelector(state => state.welcomeMessages);
+  const { welcomeMessages, showWork2Message } = useSelector(state => ({
+    welcomeMessages: state.welcomeMessages,
+    showWork2Message: state.workbench.config.showWork2Message
+  }));
 
   const onDismissWelcome = section => {
     const newMessagesState = {
@@ -32,14 +35,46 @@ const WelcomeMessages = () => {
         </Alert>
       </Route>
       <Route path={`${path}${ROUTES.DATA}`}>
-        <Alert
-          isOpen={welcomeMessages.datafiles}
-          toggle={() => onDismissWelcome('datafiles')}
-          color="secondary"
-          className="welcomeMessage"
-        >
-          This page allows you to upload and manage your files.
-        </Alert>
+        <div className="welcomeMessage">
+          <Alert
+            isOpen={welcomeMessages.datafiles}
+            toggle={() => onDismissWelcome('datafiles')}
+            color="secondary"
+          >
+            This page allows you to upload and manage your files.
+          </Alert>
+          {showWork2Message && (
+            <Alert
+              isOpen={welcomeMessages.work2}
+              toggle={() => onDismissWelcome('work2')}
+              color="warning"
+            >
+              <>
+                Notice: The Stockyard <code>/work</code> filesystem is being
+                deprecated. A new filesystem <code>/work2</code> is now
+                available and will eventually replace <code>/work</code>. During
+                the transition period, users must migrate any current data they
+                wish to retain. You can read more information about this change
+                in the{' '}
+                <a
+                  href="https://portal.tacc.utexas.edu/tutorials/stockyard-work-migration"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  /work Migration and Transition Guide
+                </a>
+                , or{' '}
+                <Link
+                  className="wb-link"
+                  to={`${ROUTES.WORKBENCH}${ROUTES.DASHBOARD}${ROUTES.TICKETS}/create`}
+                >
+                  submit a ticket
+                </Link>{' '}
+                for help.
+              </>
+            </Alert>
+          )}
+        </div>
       </Route>
       <Route path={`${path}${ROUTES.APPLICATIONS}`}>
         <Alert

--- a/client/src/components/Workbench/WelcomeMessages.js
+++ b/client/src/components/Workbench/WelcomeMessages.js
@@ -60,6 +60,7 @@ const WelcomeMessages = () => {
                   href="https://portal.tacc.utexas.edu/tutorials/stockyard-work-migration"
                   target="_blank"
                   rel="noreferrer"
+                  className="wb-link"
                 >
                   /work Migration and Transition Guide
                 </a>

--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -122,4 +122,8 @@
 .welcomeMessage {
   margin: 20px 20px 0 20px;
   flex-grow: 0;
+
+  code {
+      font-weight: bold;
+  }
 }

--- a/client/src/redux/reducers/welcome.reducers.js
+++ b/client/src/redux/reducers/welcome.reducers.js
@@ -2,6 +2,7 @@ export const initialWelcomeMessages = {
   dashboard: true,
   applications: true,
   datafiles: true,
+  work2: true,
   allocations: true,
   history: true,
   profile: true,

--- a/server/portal/settings/settings_secret.example.py
+++ b/server/portal/settings/settings_secret.example.py
@@ -290,5 +290,6 @@ _WORKBENCH_SETTINGS = {
     "viewPath": True,
     "compressApp": 'zippy',
     "extractApp": 'extract',
-    "makePublic": True
+    "makePublic": True,
+    "showWork2Message": True
 }


### PR DESCRIPTION
## Overview: ##

Shows an Alert message with details about the impending [work2 migration](https://portal.tacc.utexas.edu/tutorials/stockyard-work-migration). To make it show up in only the portals that need it, we add another setting to `_WORKBENCH_SETTINGS`:
```
_WORKBENCH_SETTINGS = {
    "debug": _DEBUG,
    "makeLink": True,
    "viewPath": True,
    "compressApp": 'zippy',
    "extractApp": 'extract',
    "makePublic": True,
    "showWork2Message": True,
}
```


## Related Jira tickets: ##

* [FP-976](https://jira.tacc.utexas.edu/browse/FP-976)

## Summary of Changes: ##

## Testing Steps: ##
1. Add the `"showWork2Message": True` configuration to your `_WORKBENCH_SETTINGS` in `settings_secret.py`
2. Open [datafiles](https://cep.dev/workbench/data/)
3. Confirm the alert message displays and the links work
4. Close the message, refresh the page, and confirm it does not show up again.

## UI Photos:
<img width="1561" alt="Screen Shot 2021-04-01 at 3 59 26 PM" src="https://user-images.githubusercontent.com/20326896/113353435-419e2400-9303-11eb-931f-80b7c4e5aa3d.png">

## Notes: ##
