### PR TITLE
Task/FP-883 - Pass PORTAL_NAMESPACE to front end for use in Feedback Form

### DIFF
--- a/client/src/components/FeedbackForm/FeedbackForm.js
+++ b/client/src/components/FeedbackForm/FeedbackForm.js
@@ -16,6 +16,7 @@ const defaultValues = {
 
 const FeedbackForm = () => {
   const dispatch = useDispatch();
+  const portalName = useSelector(state => state.workbench.portalName);
   const creating = useSelector(state => state.ticketCreate.creating);
   const creatingError = useSelector(state => state.ticketCreate.creatingError);
   const creatingErrorMessage = useSelector(
@@ -30,7 +31,7 @@ const FeedbackForm = () => {
       onSubmit={(values, { resetForm }) => {
         const formData = new FormData();
         Object.keys(values).forEach(key => formData.append(key, values[key]));
-        formData.append('subject', 'Feedback for the Portal');
+        formData.append('subject', `Feedback for ${portalName}`);
         dispatch({
           type: 'TICKET_CREATE',
           payload: {

--- a/client/src/components/FeedbackForm/FeedbackForm.test.js
+++ b/client/src/components/FeedbackForm/FeedbackForm.test.js
@@ -3,6 +3,7 @@ import renderComponent from 'utils/testing';
 import configureStore from 'redux-mock-store';
 import FeedbackForm from './FeedbackForm';
 import { initialTicketCreateState as ticketCreate } from '../../redux/reducers/tickets.reducers';
+import { initialState as workbench } from '../../redux/reducers/workbench.reducers';
 
 import '@testing-library/jest-dom/extend-expect';
 
@@ -11,7 +12,8 @@ const mockStore = configureStore();
 describe('FeedbackForm', () => {
   it('renders form', () => {
     const store = mockStore({
-      ticketCreate
+      ticketCreate,
+      workbench
     });
 
     const { getByText } = renderComponent(<FeedbackForm />, store);
@@ -24,6 +26,10 @@ describe('FeedbackForm', () => {
       ticketCreate: {
         ...ticketCreate,
         creating: true
+      },
+      workbench: {
+        ...workbench,
+        portalName: 'Portal Name'
       }
     });
 

--- a/client/src/components/FeedbackForm/FeedbackForm.test.js
+++ b/client/src/components/FeedbackForm/FeedbackForm.test.js
@@ -27,10 +27,7 @@ describe('FeedbackForm', () => {
         ...ticketCreate,
         creating: true
       },
-      workbench: {
-        ...workbench,
-        portalName: 'Portal Name'
-      }
+      workbench
     });
 
     const { getByTestId } = renderComponent(<FeedbackForm />, store);

--- a/client/src/redux/reducers/workbench.reducers.js
+++ b/client/src/redux/reducers/workbench.reducers.js
@@ -1,6 +1,7 @@
 export const initialState = {
   loading: false,
   config: {},
+  portalName: '',
   setupComplete: window.__INITIAL_SETUP_COMPLETE__
 };
 

--- a/server/portal/apps/workbench/api/unit_test.py
+++ b/server/portal/apps/workbench/api/unit_test.py
@@ -7,3 +7,4 @@ def test_workbench(client, authenticated_user):
     assert response.status_code == 200
     result = json.loads(response.content)
     assert result['response']['config']['debug'] == settings.DEBUG
+    assert result['response']['portalName'] == settings.PORTAL_NAMESPACE

--- a/server/portal/apps/workbench/api/views.py
+++ b/server/portal/apps/workbench/api/views.py
@@ -6,10 +6,8 @@ from django.http import JsonResponse
 @login_required
 def workbench_state(request):
     data = {
-        'setupComplete': request.user.profile.setup_complete
-    }
-    data.update({
+        'setupComplete': request.user.profile.setup_complete,
         'config': settings.WORKBENCH_SETTINGS,
         'portalName': settings.PORTAL_NAMESPACE
-    })
+    }
     return JsonResponse({'response': data})

--- a/server/portal/apps/workbench/api/views.py
+++ b/server/portal/apps/workbench/api/views.py
@@ -8,5 +8,8 @@ def workbench_state(request):
     data = {
         'setupComplete': request.user.profile.setup_complete
     }
-    data.update({'config': settings.WORKBENCH_SETTINGS})
+    data.update({
+        'config': settings.WORKBENCH_SETTINGS,
+        'portalName': settings.PORTAL_NAMESPACE
+    })
     return JsonResponse({'response': data})


### PR DESCRIPTION
## Overview: ##
This PR passes the portal name setting up with the workbench settings. It seemed like an appropriate place, but if it is not, we could make a new view like `/apps/portal_info/` for returning it. I didn't see anything else in the settings we would want to pass up with `portal_info` besides the portal name, so I thought It seemed like overkill.

## Related Jira tickets: ##

* [FP-883](https://jira.tacc.utexas.edu/browse/FP-883)

## Summary of Changes: ##
Returned `PORTAL_NAMESPACE` setting with the workbench_state containing `WORKBENCH_SETTINGS`.
Added portal name to `FeedbackForm` submission.

## Testing Steps: ##
1. Submitting Feedback should create a ticket with a subject `Feedback for ${portalName}`
