### PR TITLE
Task/fp 980 project id command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ OR
     python3 manage.py migrate
     python3 manage.py collectstatic --noinput
     python3 manage.py createsuperuser  # Unless you will only login with your TACC account
-    python3 manage.py projects_id --update-using-storage-system-id # Update projects id counter
+    python3 manage.py projects_id --update-using-max-value-found # Update projects id counter
     python3 manage.py import-apps # Add set of example apps used in Frontnera portal (optional)
 
 #### Initialize the CMS in the `core_portal_cms` container:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ After you clone the repository locally, there are several configuration steps re
 
 Create `server/portal/settings/settings_secret.py` containing what is in `secret` field in the `Core Portal Settings Secret` entry secured on [UT Stache](https://stache.security.utexas.edu)
 
+_Note: Update `__PORTAL_PROJECTS_NAME_PREFIX` (or `_PORTAL_DATA_DEPOT_PROJECTS_SYSTEM_PREFIX`) in `settings_secret.py`to
+be something unique so that project creation in your local development does not clash with other development work (as
+directories and Tapis storage system names will be created using this prefix)._
+
 Copy `server/conf/cms/secrets.sample.py` to `server/conf/cms/secrets.py`
 
 #### Build the image for the portal's django container:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ OR
     python3 manage.py migrate
     python3 manage.py collectstatic --noinput
     python3 manage.py createsuperuser  # Unless you will only login with your TACC account
+    python3 manage.py projects_id --update-using-storage-system-id # Update projects id counter
     python3 manage.py import-apps # Add set of example apps used in Frontnera portal (optional)
 
 #### Initialize the CMS in the `core_portal_cms` container:
@@ -77,7 +78,7 @@ Finally, create a home page in the CMS.
 
 *NOTE*: TACC VPN or physical connection to the TACC network is required To log-in to CMS using LDAP, otherwise the password set with `python3 manage.py createsuperuser` is used
 
-### Setting up search index and initial project id locally:
+### Setting up search index:
 
 At least one page in CMS is needed (see above), then rebuild the cms search index
 ```
@@ -89,15 +90,12 @@ Then use the django shell in the `core_portal_django` container:
     docker exec -it core_portal_django /bin/bash
     python3 manage.py shell
 ```
-to run the following code to set up the projects index and initial project id
+to run the following code to set up the search index
 ```
 from portal.libs.elasticsearch.indexes import setup_files_index, setup_projects_index, setup_allocations_index
 setup_files_index(force=True)
 setup_projects_index(force=True)
 setup_allocations_index(force=True)
-
-from portal.apps.projects.models.base import ProjectId
-ProjectId.objects.create(value=1).save()
 ```
 
 ### Setting up notifications locally:

--- a/server/portal/apps/projects/conftest.py
+++ b/server/portal/apps/projects/conftest.py
@@ -23,10 +23,10 @@ def project_model(mocker):
 
 @pytest.fixture()
 def mock_projects(project_model, service_account, mock_storage_system, mock_agave_client, regular_user):
-    prj1 = project_model.create(mock_agave_client, 'First Project', 'test.project-123', regular_user)
+    prj1 = Project.create(mock_agave_client, 'First Project', 'test.project-123', regular_user)
     prj1.storage.name = 'test.project-123'
     prj1.storage.id = 'test.project-123'
-    prj2 = project_model.create(mock_agave_client, 'Second Project', 'test.project-124', regular_user)
+    prj2 = Project.create(mock_agave_client, 'Second Project', 'test.project-124', regular_user)
     prj2.storage.name = 'test.project-124'
     prj2.storage.id = 'test.project-124'
     yield [prj1, prj2]

--- a/server/portal/apps/projects/conftest.py
+++ b/server/portal/apps/projects/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from portal.apps.projects.models.base import Project
+
+
+@pytest.mark.django_db
+@pytest.fixture()
+def service_account(mocker):
+    yield mocker.patch('portal.apps.projects.models.base.service_account')
+
+
+@pytest.fixture()
+def mock_storage_system(mocker):
+    yield mocker.patch('portal.apps.projects.models.base.StorageSystem')
+
+
+@pytest.fixture()
+@pytest.mark.django_db
+def project_model(mocker):
+    mocker.patch('portal.apps.projects.models.base.Project._create_dir')
+    mocker.patch('portal.apps.projects.models.base.Project._delete_dir')
+    yield Project
+
+
+@pytest.fixture()
+def mock_projects(project_model, service_account, mock_storage_system, mock_agave_client, regular_user):
+    prj1 = project_model.create(mock_agave_client, 'First Project', 'test.project-123', regular_user)
+    prj1.storage.name = 'test.project-123'
+    prj1.storage.id = 'test.project-123'
+    prj2 = project_model.create(mock_agave_client, 'Second Project', 'test.project-124', regular_user)
+    prj2.storage.name = 'test.project-124'
+    prj2.storage.id = 'test.project-124'
+    yield [prj1, prj2]
+
+
+@pytest.fixture()
+def mock_projects_storage_systems(mock_projects):
+    yield [prj.storage for prj in mock_projects]

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -9,68 +9,67 @@ from portal.apps.projects.models.base import ProjectId, Project
 from portal.libs.agave.operations import iterate_listing
 
 
+def get_latest_project_storage(ignore_above_value=None):
+    """Get latest agave project storage.
+
+    :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
+    """
+    offset = 0
+    limit = 1000
+    latest = -1
+    all_projects = []
+    while True:
+        prjs = [p for p in Project.listing(
+            service_account(),
+            offset=offset,
+            limit=limit
+        )]
+        all_projects += prjs
+        offset += limit
+        if len(prjs) < limit:
+            break
+
+    for prj in all_projects:
+        prj_id = prj.storage.id.replace(
+            settings.PORTAL_PROJECTS_NAME_PREFIX,
+            ''
+        )
+        if '-' not in prj_id:
+            continue
+        _, prj_id = prj_id.rsplit('-')
+        prj_id = int(prj_id)
+
+        if prj_id > latest and (ignore_above_value is None or prj_id < ignore_above_value):
+            latest = prj_id
+
+    return latest
+
+
+def get_latest_project_directory(ignore_above_value=None):
+    """Get latest agave project directory.
+
+    :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
+    """
+    latest = -1
+    for f in iterate_listing(service_account(),
+                             system=settings.PORTAL_PROJECTS_ROOT_SYSTEM_NAME,
+                             path='/'):
+        name = f["name"]
+        if '-' not in name or not name.startswith(settings.PORTAL_PROJECTS_ID_PREFIX):
+            continue
+        _, dir_id = name.rsplit('-', 1)
+        dir_id = int(dir_id)
+        if dir_id > latest and (ignore_above_value is None or dir_id < ignore_above_value):
+            latest = dir_id
+    return latest
+
+
 class Command(BaseCommand):
     help = (
         'Manage projects latest project id. By default this command will print '
         'the current latest project id, the last project id used in '
         'storage systems, and the last project id used in folders created.'
     )
-
-    @staticmethod
-    def get_latest_project_storage(ignore_above_value=None):
-        """Get latest agave project storage.
-
-        :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
-        """
-        offset = 0
-        limit = 1000
-        latest = -1
-        all_projects = []
-        while True:
-            prjs = [p for p in Project.listing(
-                service_account(),
-                offset=offset,
-                limit=limit
-            )]
-            all_projects += prjs
-            offset += limit
-            if len(prjs) < limit:
-                break
-
-        for prj in all_projects:
-            prj_id = prj.storage.id.replace(
-                settings.PORTAL_PROJECTS_NAME_PREFIX,
-                ''
-            )
-            if '-' not in prj_id:
-                continue
-            _, prj_id = prj_id.rsplit('-')
-            prj_id = int(prj_id)
-
-            if prj_id > latest and (ignore_above_value is None or prj_id < ignore_above_value):
-                latest = prj_id
-
-
-        return latest
-
-    @staticmethod
-    def get_latest_project_directory(ignore_above_value=None):
-        """Get latest agave project directory.
-
-        :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
-        """
-        latest = -1
-        for f in iterate_listing(service_account(),
-                                 system=settings.PORTAL_PROJECTS_ROOT_SYSTEM_NAME,
-                                 path='/'):
-            name = f["name"]
-            if '-' not in name or not name.startswith(settings.PORTAL_PROJECTS_ID_PREFIX):
-                continue
-            _, dir_id = name.rsplit('-', 1)
-            dir_id = int(dir_id)
-            if dir_id > latest and (ignore_above_value is None or dir_id < ignore_above_value):
-                latest = dir_id
-        return latest
 
     def add_arguments(self, parser):
         """Add arguments."""
@@ -100,8 +99,8 @@ class Command(BaseCommand):
             self.stdout.write('NOTE(!!!!): Ignoring project ids >= {} when '
                               'processing/updating the storage systems and directories'.format(ignore_large_ids))
 
-        latest_storage_system_id = Command.get_latest_project_storage(ignore_above_value=ignore_large_ids)
-        latest_project_id = Command.get_latest_project_directory(ignore_above_value=ignore_large_ids)
+        latest_storage_system_id = get_latest_project_storage(ignore_above_value=ignore_large_ids)
+        latest_project_id = get_latest_project_directory(ignore_above_value=ignore_large_ids)
 
         if latest_storage_system_id == -1:
             self.stdout.write('There are no project storage systems.')

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -1,96 +1,72 @@
 """Management command."""
 
 from django.conf import settings
+from django.db import transaction
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
 from portal.libs.agave.utils import service_account
-from portal.libs.agave.models.files import BaseFile
 from portal.apps.projects.models.base import ProjectId, Project
+from portal.libs.agave.operations import iterate_listing
 
 
 class Command(BaseCommand):
-    """Command class."""
-
     help = (
-        'Manage projects next Id. By default this command will print '
+        'Manage projects latest project i. By default this command will print '
         'the current latest project id, the last project id used in '
-        'storage systems and the last project id used in folders created '
-        'in corral.'
+        'storage systems and the last project id used in folders created.'
     )
 
-    def _get_latest_project_storage(self):  # pylint:disable=no-self-use
-        """Get latest agave project storage."""
+    @staticmethod
+    def get_latest_project_storage(ignore_above_value=None):
+        """Get latest agave project storage.
+
+        :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
+        """
         offset = 0
-        limit = 100
-        prjs = Project.listing(
-            service_account(),
-            offset=offset,
-            limit=limit
-        )
-        done = False
+        limit = 1000
         latest = -1
-        while not done:
-            prj_id = -1
+        while True:
+            prjs = Project.listing(
+                service_account(),
+                offset=offset,
+                limit=limit
+            )
+            prjs = [p for p in prjs]
             for prj in prjs:
                 prj_id = prj.storage.id.replace(
-                    settings._PORTAL_DATA_DEPOT_PROJECTS_SYSTEM_PREFIX,
+                    settings.PORTAL_PROJECTS_NAME_PREFIX,
                     ''
                 )
                 if '-' not in prj_id:
                     continue
                 _, prj_id = prj_id.rsplit('-')
-                try:
-                    prj_id = int(prj_id)
-                except ValueError:
-                    # prj_id is not an int
-                    pass
+                prj_id = int(prj_id)
 
-                if prj_id > latest:
+                if prj_id > latest and (ignore_above_value is None or prj_id < ignore_above_value):
                     latest = prj_id
-            if prj_id == -1:
-                done = True
-            else:
-                offset += 100
-                prjs = Project.listing(
-                    service_account(),
-                    offset=offset,
-                    limit=limit
-                )
+
+            offset += limit
+            if len(prjs) < limit:
+                break
         return latest
 
-    def _get_latest_project_directory(self):  # pylint:disable=no-self-use
-        """Get latest agave project directory."""
-        offset = 0
-        limit = 100
-        _file = BaseFile(
-            service_account(),
-            system=settings.PORTAL_PROJECTS_ROOT_SYSTEM_NAME,
-            path='/'
-        )
-        dirs = _file.children(offset=offset, limit=limit)
-        done = False
+    @staticmethod
+    def get_latest_project_directory(ignore_above_value=None):
+        """Get latest agave project directory.
+
+        :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
+        """
         latest = -1
-        while not done:
-            dir_id = -1
-            for _dir in dirs:
-                if ('-' not in _dir.name or
-                        not _dir.name.startswith(settings.PORTAL_PROJECTS_ID_PREFIX)):
-                    continue
-                _, dir_id = _dir.name.rsplit('-', 1)
-                try:
-                    dir_id = int(dir_id)
-                except ValueError:
-                    # dir_id is not an int
-                    pass
-
-                if dir_id > latest:
-                    latest = dir_id
-
-            if dir_id == -1:
-                done = True
-            else:
-                offset += 100
-                _file.set_children(None)
-                dirs = _file.children(offset=offset, limit=limit)
+        for f in iterate_listing(service_account(),
+                                 system=settings.PORTAL_PROJECTS_ROOT_SYSTEM_NAME,
+                                 path='/'):
+            name = f["name"]
+            if '-' not in name or not name.startswith(settings.PORTAL_PROJECTS_ID_PREFIX):
+                continue
+            _, dir_id = name.rsplit('-', 1)
+            dir_id = int(dir_id)
+            if dir_id > latest and (ignore_above_value is None or dir_id < ignore_above_value):
+                latest = dir_id
         return latest
 
     def add_arguments(self, parser):
@@ -99,29 +75,50 @@ class Command(BaseCommand):
             '--update',
             action='store',
             type=int,
-            help='Integer to update saved DB value.'
+            help='Update project id DB value.'
+        )
+        parser.add_argument(
+            '--update-using-storage-system-id',
+            action='store_true',
+            help='Update project id DB value using value derived from latest storage system project id.'
+        )
+        parser.add_argument(
+            '--ignore-large-project-ids',
+            action='store',
+            type=int,
+            help='Ignore project ids larger than a certain value'
         )
 
     def handle(self, *args, **options):
         """Handle command."""
+        ignore_large_ids = options["ignore_large_project_ids"]
+        if ignore_large_ids:
+            self.stdout.write('NOTE(!!!!): Ignoring project ids >= {} when '
+                              'processing/updating the storage systems and directories'.format(ignore_large_ids))
+
+        latest_storage_system_id = Command.get_latest_project_storage(ignore_above_value=ignore_large_ids)
+        latest_project_id = Command.get_latest_project_directory(ignore_above_value=ignore_large_ids)
+
+        if latest_storage_system_id == -1:
+            self.stdout.write('There are no project storage systems.')
+        if latest_project_id == -1:
+            self.stdout.write('There are no project directories.')
+
+        self.stdout.write('Latest storage system project id: {}'.format(latest_storage_system_id))
+        self.stdout.write('Latest directory project id: {}'.format(latest_project_id))
+
+        try:
+            with transaction.atomic():
+                model_project_id = ProjectId.objects.select_for_update().latest('last_updated').value
+            self.stdout.write('Latest project id in ProjectId model: {}'.format(model_project_id))
+        except ObjectDoesNotExist:
+            self.stdout.write('Latest project id in ProjectId mode: None')
+            if (options.get('update') or options.get('find-and-update')):
+                ProjectId.objects.create(value=1).save()
+
         if options.get('update'):
+            self.stdout.write('Updating to user provided value of: {}'.format(options.get('update')))
             ProjectId.update(options.get('update'))
-        else:
-            latest_storage_prj_id = self._get_latest_project_storage()
-            if latest_storage_prj_id == -1:
-                self.stdout.write('There are no project storage systems.')
-            else:
-                self.stdout.write(
-                    'Latest Storage Project Id: {prj_id}'.format(
-                        prj_id=latest_storage_prj_id
-                    )
-                )
-            latest_project_dir_id = self._get_latest_project_directory()
-            if latest_project_dir_id == -1:
-                self.stdout.write('There are no project directories.')
-            else:
-                self.stdout.write(
-                    'Latest Directory Project Id: {dir_id}'.format(
-                        dir_id=latest_project_dir_id
-                    )
-                )
+        elif options["update_using_storage_system_id"]:
+            self.stdout.write('Updating to user provided value of: {}'.format(latest_storage_system_id))
+            ProjectId.update(latest_storage_system_id)

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -96,13 +96,14 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """Add arguments."""
-        parser.add_argument(
+        update_group = parser.add_mutually_exclusive_group()
+        update_group.add_argument(
             '--update',
             action='store',
             type=int,
             help='Update project id DB value.'
         )
-        parser.add_argument(
+        update_group.add_argument(
             '--update-using-max-value-found',
             action='store_true',
             help='Update project id DB value using value derived from latest storage system project id or latest '

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -73,9 +73,9 @@ class Command(BaseCommand):
 
         >>> ./manage.py projects_id
 
-        Update the project id to a specific nubmer:
+        Update the project id to a specific number:
 
-        >>> ./manage.py project_id --update 42
+        >>> ./manage.py projects_id --update 42
 
         Update the project id to something safe:
 

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -9,10 +9,10 @@ from portal.apps.projects.models.base import ProjectId, Project
 from portal.libs.agave.operations import iterate_listing
 
 
-def get_latest_project_storage(ignore_above_value=None):
+def get_latest_project_storage(max_project_id=None):
     """Get latest agave project storage.
 
-    :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
+    :param max_project_id: If provided, then ignore projects ids that are greater than or equal to this value.
     """
     offset = 0
     limit = 1000
@@ -39,16 +39,16 @@ def get_latest_project_storage(ignore_above_value=None):
         _, prj_id = prj_id.rsplit('-')
         prj_id = int(prj_id)
 
-        if prj_id > latest and (ignore_above_value is None or prj_id < ignore_above_value):
+        if prj_id > latest and (max_project_id is None or prj_id < max_project_id):
             latest = prj_id
 
     return latest
 
 
-def get_latest_project_directory(ignore_above_value=None):
+def get_latest_project_directory(max_project_id=None):
     """Get latest agave project directory.
 
-    :param ignore_above_value: If provided, then ignore projects ids that are greater than or equal to this value.
+    :param max_project_id: If provided, then ignore projects ids that are greater than or equal to this value.
     """
     latest = -1
     for f in iterate_listing(service_account(),
@@ -59,7 +59,7 @@ def get_latest_project_directory(ignore_above_value=None):
             continue
         _, dir_id = name.rsplit('-', 1)
         dir_id = int(dir_id)
-        if dir_id > latest and (ignore_above_value is None or dir_id < ignore_above_value):
+        if dir_id > latest and (max_project_id is None or dir_id < max_project_id):
             latest = dir_id
     return latest
 
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                  'directory project id (whichever is higher).'
         )
         parser.add_argument(
-            '--ignore-large-project-ids',
+            '--max-project-id',
             action='store',
             type=int,
             help='Ignore project ids larger than a certain value'
@@ -94,13 +94,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle command."""
-        ignore_large_ids = options["ignore_large_project_ids"]
-        if ignore_large_ids:
+        max_project_id = options["max_project_id"]
+        if max_project_id:
             self.stdout.write('NOTE(!!!!): Ignoring project ids >= {} when '
-                              'processing/updating the storage systems and directories'.format(ignore_large_ids))
+                              'processing/updating the storage systems and directories'.format(max_project_id))
 
-        latest_storage_system_id = get_latest_project_storage(ignore_above_value=ignore_large_ids)
-        latest_project_id = get_latest_project_directory(ignore_above_value=ignore_large_ids)
+        latest_storage_system_id = get_latest_project_storage(max_project_id=max_project_id)
+        latest_project_id = get_latest_project_directory(max_project_id=max_project_id)
 
         if latest_storage_system_id == -1:
             self.stdout.write('There are no project storage systems.')

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -81,9 +81,10 @@ class Command(BaseCommand):
             help='Update project id DB value.'
         )
         parser.add_argument(
-            '--update-using-storage-system-id',
+            '--update-using-max-value-found',
             action='store_true',
-            help='Update project id DB value using value derived from latest storage system project id.'
+            help='Update project id DB value using value derived from latest storage system project id or latest '
+                 'directory project id (whichever is higher).'
         )
         parser.add_argument(
             '--ignore-large-project-ids',
@@ -120,7 +121,7 @@ class Command(BaseCommand):
         if options.get('update'):
             self.stdout.write('Updating to user provided value of: {}'.format(options.get('update')))
             ProjectId.update(options.get('update'))
-        elif options["update_using_storage_system_id"]:
+        elif options["update_using_max_value_found"]:
             latest_storage_system_id = 0 if latest_storage_system_id == -1 else latest_storage_system_id
             self.stdout.write('Updating to value latest storage system id: {}'.format(latest_storage_system_id))
             ProjectId.update(latest_storage_system_id)

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
             self.stdout.write('Latest project id in ProjectId model: {}'.format(model_project_id))
         except ObjectDoesNotExist:
             self.stdout.write('Latest project id in ProjectId mode: None')
-            if (options.get('update') or options.get('find-and-update')):
+            if (options.get('update') or options.get('update_using_storage_system_id')):
                 ProjectId.objects.create(value=1).save()
 
         if options.get('update'):

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -120,5 +120,6 @@ class Command(BaseCommand):
             self.stdout.write('Updating to user provided value of: {}'.format(options.get('update')))
             ProjectId.update(options.get('update'))
         elif options["update_using_storage_system_id"]:
-            self.stdout.write('Updating to user provided value of: {}'.format(latest_storage_system_id))
+            latest_storage_system_id = 0 if latest_storage_system_id == -1 else latest_storage_system_id
+            self.stdout.write('Updating to value latest storage system id: {}'.format(latest_storage_system_id))
             ProjectId.update(latest_storage_system_id)

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -11,9 +11,9 @@ from portal.libs.agave.operations import iterate_listing
 
 class Command(BaseCommand):
     help = (
-        'Manage projects latest project i. By default this command will print '
+        'Manage projects latest project id. By default this command will print '
         'the current latest project id, the last project id used in '
-        'storage systems and the last project id used in folders created.'
+        'storage systems, and the last project id used in folders created.'
     )
 
     @staticmethod

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -25,29 +25,32 @@ class Command(BaseCommand):
         offset = 0
         limit = 1000
         latest = -1
+        all_projects = []
         while True:
-            prjs = Project.listing(
+            prjs = [p for p in Project.listing(
                 service_account(),
                 offset=offset,
                 limit=limit
-            )
-            prjs = [p for p in prjs]
-            for prj in prjs:
-                prj_id = prj.storage.id.replace(
-                    settings.PORTAL_PROJECTS_NAME_PREFIX,
-                    ''
-                )
-                if '-' not in prj_id:
-                    continue
-                _, prj_id = prj_id.rsplit('-')
-                prj_id = int(prj_id)
-
-                if prj_id > latest and (ignore_above_value is None or prj_id < ignore_above_value):
-                    latest = prj_id
-
+            )]
+            all_projects += prjs
             offset += limit
             if len(prjs) < limit:
                 break
+
+        for prj in all_projects:
+            prj_id = prj.storage.id.replace(
+                settings.PORTAL_PROJECTS_NAME_PREFIX,
+                ''
+            )
+            if '-' not in prj_id:
+                continue
+            _, prj_id = prj_id.rsplit('-')
+            prj_id = int(prj_id)
+
+            if prj_id > latest and (ignore_above_value is None or prj_id < ignore_above_value):
+                latest = prj_id
+
+
         return latest
 
     @staticmethod

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -116,8 +116,6 @@ class Command(BaseCommand):
             self.stdout.write('Latest project id in ProjectId model: {}'.format(model_project_id))
         except ObjectDoesNotExist:
             self.stdout.write('Latest project id in ProjectId model: None')
-            if (options.get('update') or options.get('update_using_storage_system_id')):
-                ProjectId.objects.create(value=1).save()
 
         if options.get('update'):
             self.stdout.write('Updating to user provided value of: {}'.format(options.get('update')))

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -65,6 +65,29 @@ def get_latest_project_directory(max_project_id=None):
 
 
 class Command(BaseCommand):
+    """Manage project latest project id
+
+    Examples:
+
+        Discover what the current latest project ids are:
+
+        >>> ./manage.py projects_id
+
+        Update the project id to a specific nubmer:
+
+        >>> ./manage.py project_id --update 42
+
+        Update the project id to something safe:
+
+        >>> ./manage.py projects_id --update-using-max-value-found
+
+        Update the project id to something safe but don't look for a safe value above 1000000. This could be used if
+        you had previously set the max project id to something super larger (like 1000000) for testing purposes but now
+        want to revert to a safe (but lower) project id.
+
+        >>> ./manage.py projects_id --update-using-max-value-found --max-project-id 1000000
+
+    """
     help = (
         'Manage projects latest project id. By default this command will print '
         'the current latest project id, the last project id used in '

--- a/server/portal/apps/projects/management/commands/projects_id.py
+++ b/server/portal/apps/projects/management/commands/projects_id.py
@@ -112,7 +112,7 @@ class Command(BaseCommand):
                 model_project_id = ProjectId.objects.select_for_update().latest('last_updated').value
             self.stdout.write('Latest project id in ProjectId model: {}'.format(model_project_id))
         except ObjectDoesNotExist:
-            self.stdout.write('Latest project id in ProjectId mode: None')
+            self.stdout.write('Latest project id in ProjectId model: None')
             if (options.get('update') or options.get('update_using_storage_system_id')):
                 ProjectId.objects.create(value=1).save()
 

--- a/server/portal/apps/projects/management/commands/projects_id_unit_test.py
+++ b/server/portal/apps/projects/management/commands/projects_id_unit_test.py
@@ -67,3 +67,11 @@ def test_update_using_storage_system_id(mock_iterate_listings, mock_project_list
     call_command("projects_id", "--update-using-storage-system-id", stdout=out)
     output = out.getvalue()
     assert "Updating to value latest storage system id: 0" in output
+
+
+def test_update_using_storage_system_id_with_two_projects(mock_iterate_listings, mock_project_listing_with_projects):
+    out = StringIO()
+    call_command("projects_id", "--update-using-storage-system-id", stdout=out)
+    output = out.getvalue()
+    assert "Latest storage system project id: 124" in output
+    assert "Updating to value latest storage system id: 124" in output

--- a/server/portal/apps/projects/management/commands/projects_id_unit_test.py
+++ b/server/portal/apps/projects/management/commands/projects_id_unit_test.py
@@ -1,0 +1,69 @@
+from io import StringIO
+import pytest
+from django.core.management import call_command
+from portal.apps.projects.management.commands.projects_id import Command
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_project_listing(mocker):
+    project_mock = mocker.patch('portal.apps.projects.management.commands.projects_id.Project')
+    project_mock.listing.return_value = []
+    yield project_mock
+
+
+@pytest.fixture
+def mock_project_listing_with_projects(mocker, mock_projects):
+    project_mock = mocker.patch('portal.apps.projects.management.commands.projects_id.Project')
+    project_mock.listing.return_value = mock_projects
+
+
+@pytest.fixture
+def mock_iterate_listings(mocker):
+    iterate_listing_mock = mocker.patch('portal.apps.projects.management.commands.projects_id.iterate_listing')
+    iterate_listing_mock.return_value = []
+    yield iterate_listing_mock
+
+
+def test_get_latest_project_storage(mock_project_listing):
+    assert Command.get_latest_project_storage() == -1
+
+
+def test_get_latest_project_directory(mock_iterate_listings):
+    assert Command.get_latest_project_directory() == -1
+
+
+def test_default_command_with_no_projects(mock_iterate_listings, mock_project_listing):
+    out = StringIO()
+    call_command("projects_id", stdout=out)
+    output = out.getvalue()
+    assert "There are no project storage systems" in output
+    assert "There are no project directories" in output
+    assert "Latest storage system project id: -1" in output
+    assert "Latest directory project id: -1" in output
+    assert "Latest project id in ProjectId mode: None" in output
+
+
+def test_default_command_with_two_projects(mock_iterate_listings, mock_project_listing_with_projects):
+    out = StringIO()
+    call_command("projects_id", stdout=out)
+    output = out.getvalue()
+    assert "Latest storage system project id: 124" in output
+    assert "Latest directory project id: -1" in output
+    assert "Latest project id in ProjectId mode: None" in output
+
+
+def test_update(mock_iterate_listings, mock_project_listing):
+    out = StringIO()
+    call_command("projects_id", "--update", "42", stdout=out)
+    output = out.getvalue()
+    assert "Updating to user provided value of: 42" in output
+
+
+def test_update_using_storage_system_id(mock_iterate_listings, mock_project_listing):
+    out = StringIO()
+    call_command("projects_id", "--update-using-storage-system-id", stdout=out)
+    output = out.getvalue()
+    assert "Updating to value latest storage system id: 0" in output

--- a/server/portal/apps/projects/management/commands/projects_id_unit_test.py
+++ b/server/portal/apps/projects/management/commands/projects_id_unit_test.py
@@ -64,14 +64,14 @@ def test_update(mock_iterate_listings, mock_project_listing):
 
 def test_update_using_storage_system_id(mock_iterate_listings, mock_project_listing):
     out = StringIO()
-    call_command("projects_id", "--update-using-storage-system-id", stdout=out)
+    call_command("projects_id", "--update-using-max-value-found", stdout=out)
     output = out.getvalue()
     assert "Updating to value latest storage system id: 0" in output
 
 
 def test_update_using_storage_system_id_with_two_projects(mock_iterate_listings, mock_project_listing_with_projects):
     out = StringIO()
-    call_command("projects_id", "--update-using-storage-system-id", stdout=out)
+    call_command("projects_id", "--update-using-max-value-found", stdout=out)
     output = out.getvalue()
     assert "Latest storage system project id: 124" in output
     assert "Updating to value latest storage system id: 124" in output

--- a/server/portal/apps/projects/management/commands/projects_id_unit_test.py
+++ b/server/portal/apps/projects/management/commands/projects_id_unit_test.py
@@ -1,7 +1,7 @@
 from io import StringIO
 import pytest
 from django.core.management import call_command
-from portal.apps.projects.management.commands.projects_id import Command
+from portal.apps.projects.management.commands.projects_id import get_latest_project_storage, get_latest_project_directory
 
 
 pytestmark = pytest.mark.django_db
@@ -28,11 +28,11 @@ def mock_iterate_listings(mocker):
 
 
 def test_get_latest_project_storage(mock_project_listing):
-    assert Command.get_latest_project_storage() == -1
+    assert get_latest_project_storage() == -1
 
 
 def test_get_latest_project_directory(mock_iterate_listings):
-    assert Command.get_latest_project_directory() == -1
+    assert get_latest_project_directory() == -1
 
 
 def test_default_command_with_no_projects(mock_iterate_listings, mock_project_listing):

--- a/server/portal/apps/projects/management/commands/projects_id_unit_test.py
+++ b/server/portal/apps/projects/management/commands/projects_id_unit_test.py
@@ -43,7 +43,7 @@ def test_default_command_with_no_projects(mock_iterate_listings, mock_project_li
     assert "There are no project directories" in output
     assert "Latest storage system project id: -1" in output
     assert "Latest directory project id: -1" in output
-    assert "Latest project id in ProjectId mode: None" in output
+    assert "Latest project id in ProjectId model: None" in output
 
 
 def test_default_command_with_two_projects(mock_iterate_listings, mock_project_listing_with_projects):
@@ -52,7 +52,7 @@ def test_default_command_with_two_projects(mock_iterate_listings, mock_project_l
     output = out.getvalue()
     assert "Latest storage system project id: 124" in output
     assert "Latest directory project id: -1" in output
-    assert "Latest project id in ProjectId mode: None" in output
+    assert "Latest project id in ProjectId model: None" in output
 
 
 def test_update(mock_iterate_listings, mock_project_listing):

--- a/server/portal/apps/projects/models/base.py
+++ b/server/portal/apps/projects/models/base.py
@@ -487,11 +487,17 @@ class ProjectId(models.Model):
     @classmethod
     @transaction.atomic
     def update(cls, value):
-        """Atomically updates value of next project id."""
-        row = cls.objects.select_for_update().latest('last_updated')
-        row.value = value
-        row.save()
-        return row.value
+        """Atomically updates value of next project id.
+
+        If there is no project id row to update, one is created.
+        """
+        try:
+            row = cls.objects.select_for_update().latest('last_updated')
+            row.value = value
+            row.save()
+        except ObjectDoesNotExist:
+            cls.objects.create(value=value).save()
+        return value
 
     @classmethod
     @transaction.atomic

--- a/server/portal/libs/agave/models/systems/base.py
+++ b/server/portal/libs/agave/models/systems/base.py
@@ -258,7 +258,7 @@ class BaseSystem(BaseAgaveResource):
         """
         query['limit'] = limit
         query['offset'] = offset
-        if client.token:
+        if hasattr(client, "token") and hasattr(client.token, "token_info"):
             token = client.token.token_info['access_token']
         else:
             token = client._token  # pylint: disable=protected-access


### PR DESCRIPTION
## Overview: ##

Update project id management command to allow users to determine what the project id should be and to automatically update it.   See jira ticket for more background

## Related Jira tickets: ##

* [FP-980](https://jira.tacc.utexas.edu/browse/FP-980)

## Summary of Changes: ##

- Update project id management command to support automatically updating project id value and ignore high value numbers
- Update README for local dev use of the command
- Add info to README about personalizing the project prefix for developers
- Fix use of token in agave libs

## Testing Steps: ##

Run unit tests and run command in your local environment see idea below on a suggested way to test things:

-  `python3 manage.py projects_id --help`
-  see what the project ids are: `python3 manage.py projects_id`
-  (possibly) kill your local dev database to mimic new dev environment and see what the status of your projects are: ` python3 manage.py projects_id`
-  update them: `python3 manage.py projects_id ----update-using-max-value`
-  set to project id to high value: `python3 manage.py projects_id --update 1000000`
-  create some projects using the portal with these high numbers
-  then revert back to the earlier value:  `python3 manage.py projects_id --update-using-max-value --max-project-id 1000000`

## Notes: ##

- [x] unit tests
- [x] add related PR to `cep1to2` repo to add instructions there (see https://github.com/TACC/cep1to2/pull/13).