### PR TITLE
Quick: Have Data List Cells use Util Functions

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
@@ -12,6 +12,9 @@ import { Button } from 'reactstrap';
 import { useSelector, useDispatch } from 'react-redux';
 import './DataFilesListingCells.scss';
 
+import formatSize from 'utils/sizeFormat';
+import { formatDateTimeFromValue } from 'utils/timeFormat';
+
 export const CheckboxHeaderCell = () => {
   const selected = useSelector(state => state.files.selectAll.FilesListing);
   const listingLength = useSelector(
@@ -122,37 +125,17 @@ FileNavCell.defaultProps = {
 
 export const FileLengthCell = ({ cell }) => {
   const bytes = cell.value;
-  const units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
-  const number = bytes === 0 ? 0 : Math.floor(Math.log(bytes) / Math.log(1024));
-  const bytesString = (bytes / 1024 ** Math.floor(number)).toFixed(1);
 
-  return (
-    <span>
-      {bytesString} {units[number]}
-    </span>
-  );
+  return <span>{formatSize(bytes)}</span>;
 };
 FileLengthCell.propTypes = {
   cell: PropTypes.shape({ value: PropTypes.number }).isRequired
 };
 
 export const LastModifiedCell = ({ cell }) => {
-  const date = new Date(cell.value);
-  const dateString = date.toLocaleDateString(undefined, {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric'
-  });
-  const timeString = date.toLocaleTimeString(undefined, {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit'
-  });
-  return (
-    <span>
-      {dateString} {timeString}
-    </span>
-  );
+  const timeValue = cell.value;
+
+  return <span>{formatDateTimeFromValue(timeValue)}</span>;
 };
 LastModifiedCell.propTypes = {
   cell: PropTypes.shape({ value: PropTypes.string }).isRequired

--- a/client/src/utils/sizeFormat.js
+++ b/client/src/utils/sizeFormat.js
@@ -1,0 +1,14 @@
+/**
+ * Create a string representation of a file/folder size using internal standard
+ * @param {number} bytes - The size of an entity
+ * @returns {string}
+ */
+function createSizeString(bytes) {
+  const units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
+  const number = bytes === 0 ? 0 : Math.floor(Math.log(bytes) / Math.log(1024));
+  const bytesString = (bytes / 1024 ** Math.floor(number)).toFixed(1);
+
+  return `${bytesString} ${units[number]}`;
+}
+
+export default createSizeString;

--- a/client/src/utils/timeFormat.js
+++ b/client/src/utils/timeFormat.js
@@ -1,3 +1,8 @@
+/**
+ * Create a string representation of date using internal standard
+ * @param {Date} timeDateValue - A date object
+ * @returns {string}
+ */
 export function formatDate(timeDateValue) {
   return timeDateValue.toLocaleDateString('en-US', {
     day: '2-digit',
@@ -6,6 +11,11 @@ export function formatDate(timeDateValue) {
   });
 }
 
+/**
+ * Create a string representation of time using internal standard
+ * @param {Date} timeDateValue - A date object
+ * @returns {string}
+ */
 export function formatTime(timeDateValue) {
   return timeDateValue.toLocaleTimeString('en-US', {
     hour12: false,
@@ -14,6 +24,27 @@ export function formatTime(timeDateValue) {
   });
 }
 
+/**
+ * Create a string representation of date/time using internal standard
+ * @param {Date} dateTime - A date object
+ * @returns {string}
+ */
 export function formatDateTime(timeDateValue) {
   return `${formatDate(timeDateValue)} ${formatTime(timeDateValue)}`;
+}
+
+/**
+ * A standard-format date string or UNIX timestamp
+ * @typedef {string|number} dateTime
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
+ */
+/**
+ * Create a string representation of date/time using internal standard
+ * @param {dateTime} dateTimeValue - A single value date-time representation
+ * @returns {string}
+ */
+export function formatDateTimeFromValue(dateTimeValue) {
+  const date = new Date(dateTimeValue);
+
+  return formatDateTime(date);
 }

--- a/client/src/utils/timeFormat.js
+++ b/client/src/utils/timeFormat.js
@@ -35,12 +35,12 @@ export function formatDateTime(dateTime) {
 
 /**
  * A standard-format date string or UNIX timestamp
- * @typedef {string|number} DateTimeString
+ * @typedef {string|number} DateTimeValue
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
  */
 /**
  * Create a string representation of date/time using internal standard
- * @param {DateTimeString} dateTimeValue - A single value date-time representation
+ * @param {DateTimeValue} dateTimeValue - A single value date-time representation
  * @returns {string}
  */
 export function formatDateTimeFromValue(dateTimeValue) {

--- a/client/src/utils/timeFormat.js
+++ b/client/src/utils/timeFormat.js
@@ -1,10 +1,10 @@
 /**
  * Create a string representation of date using internal standard
- * @param {Date} timeDateValue - A date object
+ * @param {Date} dateTime - A date object
  * @returns {string}
  */
-export function formatDate(timeDateValue) {
-  return timeDateValue.toLocaleDateString('en-US', {
+export function formatDate(dateTime) {
+  return dateTime.toLocaleDateString('en-US', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric'
@@ -13,11 +13,11 @@ export function formatDate(timeDateValue) {
 
 /**
  * Create a string representation of time using internal standard
- * @param {Date} timeDateValue - A date object
+ * @param {Date} dateTime - A date object
  * @returns {string}
  */
-export function formatTime(timeDateValue) {
-  return timeDateValue.toLocaleTimeString('en-US', {
+export function formatTime(dateTime) {
+  return dateTime.toLocaleTimeString('en-US', {
     hour12: false,
     hour: '2-digit',
     minute: '2-digit'
@@ -29,18 +29,18 @@ export function formatTime(timeDateValue) {
  * @param {Date} dateTime - A date object
  * @returns {string}
  */
-export function formatDateTime(timeDateValue) {
-  return `${formatDate(timeDateValue)} ${formatTime(timeDateValue)}`;
+export function formatDateTime(dateTime) {
+  return `${formatDate(dateTime)} ${formatTime(dateTime)}`;
 }
 
 /**
  * A standard-format date string or UNIX timestamp
- * @typedef {string|number} dateTime
+ * @typedef {string|number} DateTimeString
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
  */
 /**
  * Create a string representation of date/time using internal standard
- * @param {dateTime} dateTimeValue - A single value date-time representation
+ * @param {DateTimeString} dateTimeValue - A single value date-time representation
  * @returns {string}
  */
 export function formatDateTimeFromValue(dateTimeValue) {

--- a/client/src/utils/timeFormat.js
+++ b/client/src/utils/timeFormat.js
@@ -25,7 +25,7 @@ export function formatTime(timeDateValue) {
 }
 
 /**
- * Create a string representation of date/time using internal standard
+ * Create a string representation of date and time using internal standard
  * @param {Date} dateTime - A date object
  * @returns {string}
  */


### PR DESCRIPTION
## Overview: ##

Make two Data Files Cell components use existing and new utils (to DRY up code a little).

> The new `sizeFormat` util allows `task/`[`FP-388`](https://jira.tacc.utexas.edu/browse/FP-388)`-file-uploader-ui--wip-improvement` to create a common component that does rely on `components/DataFiles/`.

## Related Jira tickets: ##

* (tangential) <del>[FP-388](https://jira.tacc.utexas.edu/browse/FP-388)</del> <ins>[FP-993](https://jira.tacc.utexas.edu/browse/FP-993)</ins>

## Summary of Changes: ##

- __New__: Add utility `sizeFormat`
- __New__: Update `FileLengthCell` and `LastModifiedCell` to use `sizeFormat` and `timeFormat`.
- __Doc__: Document functions in existing utility `timeFormat`.
- __New__: Add new function `formatDateTimeFromValue ` to existing utility `timeFormat`

## Testing Steps: ##
1. Load any Data Files table that lists file size.
2. Ensure size format has not changed from `main`.
1. Load any Data Files table that lists file modified date.
2. Ensure date format has not changed from `main`.

## UI Photos:

![Data Files Size - Dates Unchanged](https://user-images.githubusercontent.com/62723358/113943068-8a545200-97c7-11eb-85f4-d841d491caa3.png)

## Notes: ##

I started cleaning up a bit while working on something else, so I isolated it into its own PR.