### PR TITLE
bug/FP-984: Fix Onboarding Search Query

### DIFF
--- a/client/src/redux/sagas/fixtures/onboarding.fixture.js
+++ b/client/src/redux/sagas/fixtures/onboarding.fixture.js
@@ -188,7 +188,7 @@ export const onboardingAdminState = {
     offset: 0,
     limit: 25,
     total: 1,
-    query: null,
+    query: 'query',
     loading: false,
     error: null
   },

--- a/client/src/redux/sagas/onboarding.sagas.js
+++ b/client/src/redux/sagas/onboarding.sagas.js
@@ -24,7 +24,7 @@ export function* getOnboardingAdminList(action) {
       type: 'FETCH_ONBOARDING_ADMIN_LIST_SUCCESS',
       payload: {
         ...result,
-        query: (query && query.length > 0) || null
+        query: query && query.length > 0 ? query : null
       }
     });
   } catch (error) {

--- a/client/src/redux/sagas/onboarding.sagas.test.js
+++ b/client/src/redux/sagas/onboarding.sagas.test.js
@@ -22,20 +22,20 @@ jest.mock('cross-fetch');
 
 describe('getOnboardingAdminList Saga', () => {
   it('should fetch list of onboarding users and transform state', () =>
-    expectSaga(getOnboardingAdminList, { payload: { offset: 0, limit: 25, query: null } })
+    expectSaga(getOnboardingAdminList, { payload: { offset: 0, limit: 25, query: 'query' } })
       .withReducer(onboarding)
       .provide([
         [matchers.call.fn(fetchOnboardingAdminList), onboardingAdminFixture]
       ])
       .put({ type: 'FETCH_ONBOARDING_ADMIN_LIST_PROCESSING' })
-      .call(fetchOnboardingAdminList, 0, 25, null)
+      .call(fetchOnboardingAdminList, 0, 25, 'query')
       .put({
         type: 'FETCH_ONBOARDING_ADMIN_LIST_SUCCESS',
         payload: {
           users: onboardingAdminFixture.users,
           offset: 0,
           limit: 25,
-          query: null,
+          query: 'query',
           total: 1
         }
       })


### PR DESCRIPTION
## Overview: ##
Onboarding admin search works, but Admin search input was being replaced with `"true"`

## Related Jira tickets: ##

* [FP-984](https://jira.tacc.utexas.edu/browse/FP-984)

## Testing Steps: ##
1. Go to https://cep.dev/workbench/onboarding/admin/
2. Search for your username in the admin searchbar
3. Confirm the string is maintained after searching, and not replaced with "true"
