### PR TITLE
bug/FP-985: Fix window search overwriting site search query

### DIFF
--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchSearchbar/SiteSearchSearchbar.js
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchSearchbar/SiteSearchSearchbar.js
@@ -9,8 +9,8 @@ import './SiteSearchSearchbar.module.css';
 const SiteSearchSearchbar = () => {
   const history = useHistory();
   const { filter } = useParams();
-  const [query, setQuery] = useState('');
   const urlQueryParam = queryString.parse(window.location.search).query_string;
+  const [query, setQuery] = useState(urlQueryParam);
 
   const baseUrl = filter ? `/search/${filter}` : '/search';
   const routeSearch = () => {
@@ -41,7 +41,7 @@ const SiteSearchSearchbar = () => {
         <input
           type="search"
           onChange={onChange}
-          value={query || urlQueryParam || ''}
+          value={query || ''}
           name="query"
           aria-label="Search"
           styleName="input"


### PR DESCRIPTION
## Overview: ##

The current url's `window.location.search` `query_string` was overwriting the searchbox when the query was erased.

## Related Jira tickets: ##

* [FP-985](https://jira.tacc.utexas.edu/browse/FP-985)

## Summary of Changes: ##

- Only load `window.location.search` initially

## Testing Steps: ##
1. Type something in site search in the top navbar, like "test"
2. On the site search page, delete the query in the site search searchbox (not in the nav), and ensure it is not reset to the initial value

## UI Photos:
<img width="1340" alt="Screen Shot 2021-04-08 at 12 01 18 PM" src="https://user-images.githubusercontent.com/20326896/114067203-2763c900-9862-11eb-82f1-57582f891c1d.png">
