### PR TITLE
bug/FP-973: Enable `Copy` button/operation in Public Data and Community Data

### DIFF
--- a/client/src/utils/filePermissions.js
+++ b/client/src/utils/filePermissions.js
@@ -39,7 +39,7 @@ export default function getFilePermissions(name, { files, scheme, api }) {
     case 'compress':
       return !isArchive && files.length > 0 && isPrivate && api === 'tapis';
     case 'copy':
-      return files.length > 0 && isPrivate;
+      return files.length > 0;
     case 'move':
       return (
         !isProtected && files.length > 0 && isPrivate && api !== 'googledrive'

--- a/client/src/utils/filePermissions.test.js
+++ b/client/src/utils/filePermissions.test.js
@@ -1,6 +1,6 @@
 import getFilePermissions from './filePermissions';
 
-const fixture = {
+const privateFixture = {
   files: [
     {
       name: 'test.tar.gz',
@@ -11,6 +11,19 @@ const fixture = {
     },
   ],
   scheme: 'private',
+  api: 'tapis',
+};
+const publicFixture = {
+  files: [
+    {
+      name: 'test.txt',
+      path: '/test/test.txt',
+      lastModified: '2020-08-01T00:00:00-05:00',
+      system: 'frontera.home.test',
+      type: 'file',
+    },
+  ],
+  scheme: 'public',
   api: 'tapis',
 };
 describe('getFilePermissions utility function', () => {
@@ -24,9 +37,14 @@ describe('getFilePermissions utility function', () => {
     'compress',
   ])('Correctly evaluate %s permission', (pem) => {
     if (pem !== 'compress') {
-      expect(getFilePermissions(pem, fixture)).toEqual(true);
+      expect(getFilePermissions(pem, privateFixture)).toEqual(true);
     } else {
-      expect(getFilePermissions(pem, fixture)).toEqual(false);
+      expect(getFilePermissions(pem, privateFixture)).toEqual(false);
+    }
+    if (['copy', 'download'].includes(pem)) {
+      expect(getFilePermissions(pem, publicFixture)).toEqual(true);
+    } else {
+      expect(getFilePermissions(pem, publicFixture)).toEqual(false);
     }
   });
 });


### PR DESCRIPTION
## Overview: ##

Enables the `Copy` toolbar button in any datafiles system.

## Related Jira tickets: ##

* [FP-973](https://jira.tacc.utexas.edu/browse/FP-973)

## Testing Steps: ##
1. Load https://cep.dev/workbench/data/tapis/public/cep.storage.public/ or https://cep.dev/workbench/data/tapis/community/cep.storage.community/
2. Confirm that the `Copy` toolbar button works on any file

## UI Photos:
<img width="1542" alt="Screen Shot 2021-04-14 at 2 56 58 PM" src="https://user-images.githubusercontent.com/20326896/114770997-b032a700-9d31-11eb-8e78-f1034a2fa9b5.png">

## Notes: ##
- If you can think of a reason why this should be disabled, please make a note of that.