### PR TITLE
bug/FP-1013: Disable copying to non-private systems in copy modal

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
@@ -163,7 +163,9 @@ const DataFilesCopyModal = React.memo(() => {
                 section="modal"
                 disabled={disabled}
                 showProjects={showProjects}
-                excludedSystems={systems.filter(s => s.scheme !== 'private').map(s => s.system)}
+                excludedSystems={systems
+                  .filter(s => s.scheme !== 'private')
+                  .map(s => s.system)}
               />
             </div>
             {!showProjects && (

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
@@ -163,6 +163,7 @@ const DataFilesCopyModal = React.memo(() => {
                 section="modal"
                 disabled={disabled}
                 showProjects={showProjects}
+                excludedSystems={systems.filter(s => s.scheme !== 'private').map(s => s.system)}
               />
             </div>
             {!showProjects && (

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
@@ -1,8 +1,8 @@
 import renderComponent from 'utils/testing';
 import React from 'react';
 import configureStore from 'redux-mock-store';
-import DataFilesPreviewModal from './DataFilesPreviewModal';
-import { initialFilesState } from '../../../redux/reducers/datafiles.reducers';
+import DataFilesPreviewModal from '../DataFilesPreviewModal';
+import { initialFilesState } from '../../../../redux/reducers/datafiles.reducers';
 
 const files = {
   ...initialFilesState,

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.test.js
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.test.js
@@ -9,15 +9,23 @@ import renderComponent from 'utils/testing';
 const mockStore = configureStore();
 
 describe('DataFilesSystemSelector', () => {
-  it('contains options for all of the systems', () => {
+  it('contains options for non-private systems', () => {
     const history = createMemoryHistory();
     const store = mockStore({ systems: systemsFixture });
-    const { getByText } = renderComponent(
-      <DataFilesSystemSelector section="modal"/>,
+    const { queryByText } = renderComponent(
+      <DataFilesSystemSelector section="modal"
+                excludedSystems={systemsFixture.storage.configuration
+                  .filter(s => s.scheme !== 'private')
+                  .map(s => s.system)}/>,
       store,
       history
     );
-    expect(getByText(/My Data \(Frontera\)/)).toBeDefined();
-    expect(getByText(/My Data \(Longhorn\)/)).toBeDefined();
+    expect(queryByText(/My Data \(Work\)/)).toBeDefined();
+    expect(queryByText(/My Data \(Frontera\)/)).toBeDefined();
+    expect(queryByText(/My Data \(Longhorn\)/)).toBeDefined();
+    expect(queryByText(/Google Drive/)).toBeDefined();
+    expect(queryByText(/Shared Workspaces/)).toBeDefined();
+    expect(queryByText(/Public Data/)).toBeNull();
+    expect(queryByText(/Community Data/)).toBeNull();
   });
 });

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -58,93 +58,18 @@ const systemsFixture = {
   definitions: {
     list: [
       {
-        owner: 'wma_prtl',
-        _links: {
-          metadata: {
-            href:
-              'https://portals-api.tacc.utexas.edu/meta/v2/data/?q=%7B%22associationIds%22%3A%226239522116455886359-242ac113-0001-006%22%7D'
-          },
-          roles: {
-            href:
-              'https://portals-api.tacc.utexas.edu/systems/v2/cep.storage.public/roles'
-          },
-          self: {
-            href:
-              'https://portals-api.tacc.utexas.edu/systems/v2/cep.storage.public'
-          }
-        },
-        available: true,
-        description: 'CEP public data system',
+        id: 'frontera.home.username',
         storage: {
-          proxy: null,
-          protocol: 'SFTP',
-          mirror: false,
-          port: 22,
-          auth: {
-            type: 'SSHKEYS'
-          },
-          publicAppsDir: null,
-          host: 'data.tacc.utexas.edu',
-          rootDir: '/corral-repl/tacc/aci/CEP/public',
-          homeDir: '/'
-        },
-        type: 'STORAGE',
-        uuid: '6239522116455886359-242ac113-0001-006',
-        revision: 2,
-        site: 'portal.dev',
-        default: false,
-        public: true,
-        globalDefault: false,
-        name: 'cep.storage.public',
-        id: 'cep.storage.public',
-        lastModified: '2019-06-28T14:50:24-05:00',
-        status: 'UP'
+          host: 'frontera.tacc.utexas.edu',
+          rootDir: '/home1/012345/username'
+        }
       },
       {
-        owner: 'wma_prtl',
-        _links: {
-          owner: {
-            href: 'https://portals-api.tacc.utexas.edu/profiles/v2/wma_prtl'
-          },
-          metadata: {
-            href:
-              'https://portals-api.tacc.utexas.edu/meta/v2/data/?q=%7B%22associationIds%22%3A%224422418841996825067-242ac114-0001-006%22%7D'
-          },
-          roles: {
-            href:
-              'https://portals-api.tacc.utexas.edu/systems/v2/corral.home.username/roles'
-          },
-          self: {
-            href:
-              'https://portals-api.tacc.utexas.edu/systems/v2/corral.home.username'
-          }
-        },
-        available: true,
-        description: 'Home system for user: username',
+        id: 'longhorn.home.username',
         storage: {
-          proxy: null,
-          protocol: 'SFTP',
-          mirror: false,
-          port: 22,
-          auth: {
-            type: 'SSHKEYS'
-          },
-          publicAppsDir: null,
-          host: 'data.tacc.utexas.edu',
-          rootDir: '/work/05089/username',
-          homeDir: '/'
-        },
-        type: 'STORAGE',
-        uuid: '4422418841996825067-242ac114-0001-006',
-        revision: 1,
-        site: 'portal.dev',
-        default: false,
-        public: false,
-        globalDefault: false,
-        name: 'corral.home.username',
-        id: 'corral.home.username',
-        lastModified: '2021-04-08T16:35:26-05:00',
-        status: 'UP'
+          host: 'longhorn.tacc.utexas.edu',
+          rootDir: '/home/012345/username'
+        }
       }
     ],
     error: false,

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -1,49 +1,155 @@
 const systemsFixture = {
   storage: {
-    defaultHost: 'frontera.tacc.utexas.edu',
     configuration: [
+      {
+        name: 'My Data (Work)',
+        system: 'corral.home.username',
+        scheme: 'private',
+        api: 'tapis',
+        icon: null
+      },
       {
         name: 'My Data (Frontera)',
         system: 'frontera.home.username',
         scheme: 'private',
-        api: 'tapis'
+        api: 'tapis',
+        icon: null
       },
       {
         name: 'My Data (Longhorn)',
         system: 'longhorn.home.username',
         scheme: 'private',
-        api: 'tapis'
+        api: 'tapis',
+        icon: null
+      },
+      {
+        name: 'Community Data',
+        system: 'cep.storage.community',
+        scheme: 'community',
+        api: 'tapis',
+        icon: null
+      },
+      {
+        name: 'Public Data',
+        system: 'cep.storage.public',
+        scheme: 'public',
+        api: 'tapis',
+        icon: null
       },
       {
         name: 'Shared Workspaces',
         scheme: 'projects',
-        api: 'tapis'
+        api: 'tapis',
+        icon: null
+      },
+      {
+        name: 'Google Drive',
+        system: 'googledrive',
+        scheme: 'private',
+        api: 'googledrive',
+        icon: null
+      }
+    ],
+    error: false,
+    errorMessage: null,
+    loading: false,
+    defaultHost: 'frontera.tacc.utexas.edu'
+  },
+  definitions: {
+    list: [
+      {
+        owner: 'wma_prtl',
+        _links: {
+          metadata: {
+            href:
+              'https://portals-api.tacc.utexas.edu/meta/v2/data/?q=%7B%22associationIds%22%3A%226239522116455886359-242ac113-0001-006%22%7D'
+          },
+          roles: {
+            href:
+              'https://portals-api.tacc.utexas.edu/systems/v2/cep.storage.public/roles'
+          },
+          self: {
+            href:
+              'https://portals-api.tacc.utexas.edu/systems/v2/cep.storage.public'
+          }
+        },
+        available: true,
+        description: 'CEP public data system',
+        storage: {
+          proxy: null,
+          protocol: 'SFTP',
+          mirror: false,
+          port: 22,
+          auth: {
+            type: 'SSHKEYS'
+          },
+          publicAppsDir: null,
+          host: 'data.tacc.utexas.edu',
+          rootDir: '/corral-repl/tacc/aci/CEP/public',
+          homeDir: '/'
+        },
+        type: 'STORAGE',
+        uuid: '6239522116455886359-242ac113-0001-006',
+        revision: 2,
+        site: 'portal.dev',
+        default: false,
+        public: true,
+        globalDefault: false,
+        name: 'cep.storage.public',
+        id: 'cep.storage.public',
+        lastModified: '2019-06-28T14:50:24-05:00',
+        status: 'UP'
+      },
+      {
+        owner: 'wma_prtl',
+        _links: {
+          owner: {
+            href: 'https://portals-api.tacc.utexas.edu/profiles/v2/wma_prtl'
+          },
+          metadata: {
+            href:
+              'https://portals-api.tacc.utexas.edu/meta/v2/data/?q=%7B%22associationIds%22%3A%224422418841996825067-242ac114-0001-006%22%7D'
+          },
+          roles: {
+            href:
+              'https://portals-api.tacc.utexas.edu/systems/v2/corral.home.username/roles'
+          },
+          self: {
+            href:
+              'https://portals-api.tacc.utexas.edu/systems/v2/corral.home.username'
+          }
+        },
+        available: true,
+        description: 'Home system for user: username',
+        storage: {
+          proxy: null,
+          protocol: 'SFTP',
+          mirror: false,
+          port: 22,
+          auth: {
+            type: 'SSHKEYS'
+          },
+          publicAppsDir: null,
+          host: 'data.tacc.utexas.edu',
+          rootDir: '/work/05089/username',
+          homeDir: '/'
+        },
+        type: 'STORAGE',
+        uuid: '4422418841996825067-242ac114-0001-006',
+        revision: 1,
+        site: 'portal.dev',
+        default: false,
+        public: false,
+        globalDefault: false,
+        name: 'corral.home.username',
+        id: 'corral.home.username',
+        lastModified: '2021-04-08T16:35:26-05:00',
+        status: 'UP'
       }
     ],
     error: false,
     errorMessage: null,
     loading: false
-  },
-  definitions: {
-    list: [
-      {
-        id: 'frontera.home.username',
-        storage: {
-          host: 'frontera.tacc.utexas.edu',
-          rootDir: '/home1/012345/username'
-        }
-      },
-      {
-        id: 'longhorn.home.username',
-        storage: {
-          host: 'longhorn.tacc.utexas.edu',
-          rootDir: '/home/012345/username'
-        }
-      }
-    ],
-    error: false,
-    errorMessage: null,
-    loading: true
   }
 };
 

--- a/client/src/components/DataFiles/tests/DataFiles.test.js
+++ b/client/src/components/DataFiles/tests/DataFiles.test.js
@@ -44,7 +44,7 @@ describe('DataFiles', () => {
       history
     )
     expect(history.location.pathname).toEqual(
-      '/workbench/data/tapis/private/frontera.home.username/'
+      '/workbench/data/tapis/private/corral.home.username/'
     );
     expect(getAllByText(/My Data \(Frontera\)/)).toBeDefined();
     expect(getByText(/My Data \(Longhorn\)/)).toBeDefined();


### PR DESCRIPTION
## Overview: ##
Excludes non-private systems from the Copy Modal system selector dropdown.

## Related Jira tickets: ##

* [FP-1013](https://jira.tacc.utexas.edu/browse/FP-1013)

## Testing Steps: ##
1. Go to https://cep.dev/workbench/data/tapis/private/
2. Select a file, click the "Copy" toolbar, and verify Public and Community systems are excluded from the dropdown

## UI Photos:
<img width="1108" alt="Screen Shot 2021-04-14 at 3 47 40 PM" src="https://user-images.githubusercontent.com/20326896/114777086-dc9df180-9d38-11eb-8fec-14310e2aa597.png">

