### PR TITLE
task/FP-1014: Add Onboarding Admin link to User Nav Dropdown

### DIFF
--- a/server/portal/apps/workbench/urls.py
+++ b/server/portal/apps/workbench/urls.py
@@ -9,6 +9,6 @@ app_name = 'workbench'
 urlpatterns = [
     re_path('account', IndexView.as_view(), name='account'),
     re_path('dashboard', IndexView.as_view(), name='dashboard'),
-    re_path('onboarding/admin', IndexView.as_view(), name='onboardingadmin'),
+    re_path('onboarding/admin', IndexView.as_view(), name='onboarding_admin'),
     re_path('', IndexView.as_view(), name='index'),
 ]

--- a/server/portal/apps/workbench/urls.py
+++ b/server/portal/apps/workbench/urls.py
@@ -9,5 +9,6 @@ app_name = 'workbench'
 urlpatterns = [
     re_path('account', IndexView.as_view(), name='account'),
     re_path('dashboard', IndexView.as_view(), name='dashboard'),
+    re_path('onboarding/admin', IndexView.as_view(), name='onboardingadmin'),
     re_path('', IndexView.as_view(), name='index'),
 ]

--- a/server/portal/templates/includes/nav_portal.html
+++ b/server/portal/templates/includes/nav_portal.html
@@ -17,7 +17,7 @@
           <i class="fas fa-desktop nav-icon"></i> My Dashboard
         </a>
         {% if user.is_staff %}
-        <a class="dropdown-item" href="{% url 'workbench:onboardingadmin' %}">
+        <a class="dropdown-item" href="{% url 'workbench:onboarding_admin' %}">
           <i class="fas fa-tasks nav-icon"></i> Onboarding Admin
         </a>
         {% endif %}

--- a/server/portal/templates/includes/nav_portal.html
+++ b/server/portal/templates/includes/nav_portal.html
@@ -18,7 +18,7 @@
         </a>
         {% if user.is_staff %}
         <a class="dropdown-item" href="{% url 'workbench:onboardingadmin' %}">
-          <i class="fas fa-desktop nav-icon"></i> Onboarding Admin
+          <i class="fas fa-tasks nav-icon"></i> Onboarding Admin
         </a>
         {% endif %}
         <a class="dropdown-item" href="{% url 'portal_accounts:manage_profile' %}">

--- a/server/portal/templates/includes/nav_portal.html
+++ b/server/portal/templates/includes/nav_portal.html
@@ -16,6 +16,11 @@
         <a class="dropdown-item" href="{% url 'workbench:dashboard' %}">
           <i class="fas fa-desktop nav-icon"></i> My Dashboard
         </a>
+        {% if user.is_staff %}
+        <a class="dropdown-item" href="{% url 'workbench:onboardingadmin' %}">
+          <i class="fas fa-desktop nav-icon"></i> Onboarding Admin
+        </a>
+        {% endif %}
         <a class="dropdown-item" href="{% url 'portal_accounts:manage_profile' %}">
           <i class="fas fa-user-circle nav-icon"></i> My Account
         </a>


### PR DESCRIPTION
## Overview: ##
Add link to Onboarding Admin in User Account Nav Dropdown

## Related Jira tickets: ##

* [FP-1014](https://jira.tacc.utexas.edu/browse/FP-1014)

## Summary of Changes: ##

Add link to Onboarding Admin in User Account Nav Dropdown for Staff users.

## Testing Steps: ##
1. Click over User Account Nav Dropdown
2. Click on Onboarding Admin

## UI Photos:

<img width="503" alt="Screen Shot 2021-04-27 at 4 05 14 PM" src="https://user-images.githubusercontent.com/62672123/116313268-2a701c00-a773-11eb-90f7-9273878d111b.png">


## Notes: ##
