### PR TITLE
Quick: Add Portal Templates to CMS Sample Secrets

### DIFF
--- a/server/conf/cms/secrets.sample.py
+++ b/server/conf/cms/secrets.sample.py
@@ -60,6 +60,16 @@ _CMS_TEMPLATES = (
     # NOTE: To have per-project styles, the custom default template is required
     ('fullwidth.html', 'Fullwidth'),
     # ('example-cms/templates/fullwidth.html', 'Fullwidth (Custom Example)'),
+
+    # Any portal whose homepage has NO design must enable and use this template
+    ('home_portal.html', 'Standard Portal Homepage'),
+
+    # All portals should enable all of these templates
+    ('guide.html', 'Guide'),
+    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/data_transfer.html', 'Guide: Data Transfer'),
+    ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
+    ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
 
 ########################


### PR DESCRIPTION
## Overview: ##

Update CMS sample secrets so any portal instance can easily provide standard homepage and guide pages.

## Related Jira tickets: ##

N/A

## Summary of Changes: ##

- __New__: Add templates to CMS sample secrets.

## Testing Steps: ##

N/A

- All templates already available and tested on [cep](https://cep.tacc.utexas.edu/) and [3dem-staging](https://3dem-staging.tacc.utexas.edu/).
- Guide templates already available and tested on [frontera-portal](https://frontera-portal.tacc.utexas.edu/) and [pprd.protx](https://pprd.protx.tacc.utexas.edu/).

## UI Photos:

![Quick CMS Templates for Portal](https://user-images.githubusercontent.com/62723358/116314724-162d1e80-a775-11eb-95de-260c41e27742.png)
