### PR TITLE
FP-1015: Allow Portal Nav to be Cloned

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -125,7 +125,7 @@ services:
     container_name: core_portal_workers
 
   docs:
-    image: taccwma/frontera-docs:7af12ae
+    image: taccwma/frontera-docs:d4b36ba
     volumes:
       - ../../docs:/docs/site
     command: ["mkdocs", "build"]

--- a/server/portal/templates/includes/nav_portal.html
+++ b/server/portal/templates/includes/nav_portal.html
@@ -1,35 +1,7 @@
-{# @var className, user #}
+{# @var className #}
 
 {# WARNING: Some markup is duplicated in other repositories #}
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
-{# NOTE: The `id` attr's in the CMS version are not necessary here #}
 <ul class="s-portal-nav  {{ className }}">
-  {% if user.is_authenticated %}
-  <div class="navbar-nav">
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <i class="fas fa-user-circle fa-lg nav-icon"></i>
-        <span>{{ user.get_username }}</span>
-        <span class="sr-only">Toggle Dropdown</span>
-      </a>
-      <div class="dropdown-menu dropdown-menu-right">
-        <a class="dropdown-item" href="{% url 'workbench:dashboard' %}">
-          <i class="fas fa-desktop nav-icon"></i> My Dashboard
-        </a>
-        <a class="dropdown-item" href="{% url 'portal_accounts:manage_profile' %}">
-          <i class="fas fa-user-circle nav-icon"></i> My Account
-        </a>
-        <a class="dropdown-item" href="{% url 'portal_accounts:logout' %}">
-          <i class="fas fa-sign-out-alt nav-icon"></i> Log Out
-        </a>
-      </div>
-    </li>
-  </div>
-  {% else %}
-  <li class="nav-item">
-    <a class="nav-link" href="{% url 'portal_auth:agave_oauth' %}">
-      <i class="fas fa-sign-in-alt nav-icon"></i> Log in
-    </a>
-  </li>
-  {% endif %}
+  {% include "./nav_portal.raw.html" %}
 </ul>

--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -1,0 +1,30 @@
+{# @var user #}
+<!-- FAQ: This template loads independently at a unique url (see `urls.py`)
+          so CMS and User Guide can render this markup into their markup. -->
+  
+{% if user.is_authenticated %}
+<li class="nav-item dropdown">
+  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i class="fas fa-user-circle fa-lg nav-icon"></i>
+    <span>{{ user.get_username }}</span>
+    <span class="sr-only">Toggle Dropdown</span>
+  </a>
+  <nav class="dropdown-menu dropdown-menu-right">
+    <a class="dropdown-item" href="{% url 'workbench:dashboard' %}">
+      <i class="fas fa-desktop nav-icon"></i> My Dashboard
+    </a>
+    <a class="dropdown-item" href="{% url 'portal_accounts:manage_profile' %}">
+      <i class="fas fa-user-circle nav-icon"></i> My Account
+    </a>
+    <a class="dropdown-item" href="{% url 'portal_accounts:logout' %}">
+      <i class="fas fa-sign-out-alt nav-icon"></i> Log Out
+    </a>
+  </nav>
+</li>
+{% else %}
+<li class="nav-item">
+  <a class="nav-link" href="{% url 'portal_auth:agave_oauth' %}">
+    <i class="fas fa-sign-in-alt nav-icon"></i> Log in
+  </a>
+</li>
+{% endif %}

--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -24,6 +24,7 @@ from django.conf.urls.static import static
 from portal.apps.auth.views import agave_oauth as login
 from portal.views.views import project_version as portal_version
 from django.views.generic import RedirectView
+from django.views.generic.base import TemplateView
 from django.urls import path, re_path, include
 admin.autodiscover()
 
@@ -46,6 +47,9 @@ urlpatterns = [
     # auth.
     path('auth/', include('portal.apps.auth.urls', namespace='portal_auth')),
     re_path('login/$', login),
+
+    # markup
+    re_path('core/markup/nav', TemplateView.as_view(template_name='includes/nav_portal.raw.html'), name='portal_nav_markup'),
 
     # api
     path('api/users/', include('portal.apps.users.urls', namespace='users')),


### PR DESCRIPTION
## Overview: ##

- Support loading Portal nav markup independently via URL
- Update Docs image tag in the Docker compose file.

## Related: ##

### Issues

- Portal & Docs: [FP-1015](https://jira.tacc.utexas.edu/browse/FP-1015)
- CMS: GH-195

### PRs

- CMS: https://github.com/TACC/Core-CMS/pull/211
- Portal: https://github.com/TACC/Core-Portal/pull/390
- Docs: https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/17/fp-1015-clone-portal-nav

## Summary of Changes: ##

- __New__: Update `docs` image.
- __New__: Separate Portal nav wrapper from content.
- __New__: Load Portal nav content as markup at stand-alone URL.

## Testing Steps: ##

See https://github.com/TACC/Core-CMS/pull/211 "Testing".

## UI Photos:

See https://github.com/TACC/Core-CMS/pull/211 "Screenshots".

## Notes: ##

See https://github.com/TACC/Core-CMS/pull/211 "Notes".