### PR TITLE
Quick: Page reload link should reload page

### DIFF
--- a/client/src/components/Allocations/AllocationsTables.js
+++ b/client/src/components/Allocations/AllocationsTables.js
@@ -80,7 +80,7 @@ const ErrorMessage = () => {
     <Message type="warn">
       Unable to retrieve your allocations.{' '}
       <a
-        href="#"
+        href=""
         style={{ color: '#9d85ef' }}
         onClick={e => {
           e.preventDefault();


### PR DESCRIPTION
## Overview: ##

Fix link that suggests it will reload page, but does not.

> A blank (but present) href attribute will do that. A "#" value will not. ([source](https://stackoverflow.com/a/21397285/11817077))

## Related Jira tickets: ##

N/A

## Summary of Changes: ##

- __Fix__: Change link to reload page.

## Testing Steps: ##
1. For Allocations section to load error message.
    - _In `AllocationsTable.js` replace the `<tbody>` content of `<table class="allocations-table">` with just `<ErrorMessage />`._
2. Load the app.
3. Navigate to Allocations page.
4. Click the "… reload …" link.
5. Ensure page reloads.
    - _It might be quick, but you should at least notice a blip of loading icon in the table._

## UI Photos:

<details><summary>picture of error state—unchanged—just reference</summary>

![Allocations Error Link](https://user-images.githubusercontent.com/62723358/116718958-2543e480-a9a0-11eb-99b2-53a8d35e0b6c.png)

</details>

## Notes: ##
