### PR TITLE
task/FP-813: Download Filesize Metrics

### DIFF
--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -539,7 +539,8 @@ export function* preview(action) {
       action.payload.scheme,
       action.payload.system,
       action.payload.path,
-      action.payload.href
+      action.payload.href,
+      action.payload.length
     );
     yield put({
       type: 'DATA_FILES_SET_PREVIEW_CONTENT',
@@ -558,8 +559,8 @@ export function* preview(action) {
   }
 }
 
-export async function previewUtil(api, scheme, system, path, href) {
-  const q = stringify({ href });
+export async function previewUtil(api, scheme, system, path, href, length) {
+  const q = stringify({ href, length });
   const url = `/api/datafiles/${api}/preview/${scheme}/${system}${path}/?${q}`;
   const request = await fetch(url);
   const requestJson = await request.json();

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -681,8 +681,8 @@ export function* fileLink(action) {
   }
 }
 
-export async function downloadUtil(api, scheme, system, path, href) {
-  const q = stringify({ href });
+export async function downloadUtil(api, scheme, system, path, href, length) {
+  const q = stringify({ href, length });
   const url = `/api/datafiles/${api}/download/${scheme}/${system}${path}/?${q}`;
   const request = await fetch(url);
 
@@ -706,13 +706,15 @@ export function* watchDownload() {
 
 export function* download(action) {
   const { href } = action.payload.file._links.self;
+  const { length } = action.payload.file;
   yield call(
     downloadUtil,
     'tapis',
     'private',
     action.payload.file.system,
     action.payload.file.path,
-    href
+    href,
+    length
   );
 }
 

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -77,11 +77,12 @@ class TapisFilesView(BaseApiView):
                     status=403)
         try:
             METRICS.info("user:{} op:{} api:tapis scheme:{} "
-                         "system:{} path:{}".format(request.user.username,
+                         "system:{} path:{} filesize:{}".format(request.user.username,
                                                     operation,
                                                     scheme,
                                                     system,
-                                                    path))
+                                                    path,
+                                                    request.GET.get('length')))
             response = tapis_get_handler(
                 client, scheme, system, path, operation, **request.GET.dict())
 

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -190,13 +190,13 @@ def logging_metric_mock(mocker):
 def test_tapis_file_view_get_is_logged_for_metrics(client, authenticated_user, mock_agave_client,
                                                    agave_file_listing_mock, agave_listing_indexer, logging_metric_mock):
     mock_agave_client.files.list.return_value = agave_file_listing_mock
-    response = client.get("/api/datafiles/tapis/listing/private/frontera.home.username/test.txt/")
+    response = client.get("/api/datafiles/tapis/listing/private/frontera.home.username/test.txt/?length=1234")
     assert response.status_code == 200
     assert response.json() == {"data": {"listing": agave_file_listing_mock, "reachedEnd": True}}
 
     # Ensure metric-related logging is being performed
     logging_metric_mock.assert_called_with(
-        "user:{} op:listing api:tapis scheme:private system:frontera.home.username path:test.txt".format(
+        "user:{} op:listing api:tapis scheme:private system:frontera.home.username path:test.txt filesize:1234".format(
             authenticated_user.username))
 
 

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -117,7 +117,7 @@ def search(client, system, path, offset=0, limit=100, query_string='', **kwargs)
             'reachedEnd': len(hits) < int(limit)}
 
 
-def download(client, system, path, href, force=True, max_uses=3, lifetime=600):
+def download(client, system, path, href, force=True, max_uses=3, lifetime=600, **kwargs):
     """Creates a postit pointing to this file.
 
     Params
@@ -423,7 +423,7 @@ def upload(client, system, path, uploaded_file):
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
-    
+
     # the fileName param does not seem to accept a different file name
     resp = client.files.importData(systemId=system,
                                    filePath=urllib.parse.quote(path),


### PR DESCRIPTION
## Overview: ##

Adds a `filesize` attribute to the metrics logs for downloads, for splunk queries.

## Related Jira tickets: ##

* [FP-813](https://jira.tacc.utexas.edu/browse/FP-813)

## Testing Steps: ##
1. Download a file, and verify that the `filesize` is logged in the docker logs.
