### PR TITLE
Ensuring search result matches contain the entire search query

### DIFF
--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -99,7 +99,7 @@ def search(client, system, path, offset=0, limit=100, query_string='', **kwargs)
     """
     ngram_query = Q("query_string", query=query_string,
                     fields=["name"],
-                    minimum_should_match='80%',
+                    minimum_should_match='100%',
                     default_operator='or')
     match_query = Q("query_string", query=query_string,
                     fields=[

--- a/server/portal/libs/agave/operations_unit_test.py
+++ b/server/portal/libs/agave/operations_unit_test.py
@@ -46,7 +46,7 @@ class TestOperations(TestCase):
 
         mock_search().query.assert_called_with(Q("query_string", query='query',
                                                  fields=["name"],
-                                                 minimum_should_match='80%',
+                                                 minimum_should_match='100%',
                                                  default_operator='or') |
                                                Q("query_string", query='query',
                                                  fields=[

--- a/server/portal/libs/elasticsearch/analyzers.py
+++ b/server/portal/libs/elasticsearch/analyzers.py
@@ -13,7 +13,7 @@ path_analyzer = analyzer('path_analyzer',
                          tokenizer=tokenizer('path_hierarchy'))
 
 file_analyzer = analyzer('file_analyzer',
-                         tokenizer=tokenizer('trigram', 'nGram', min_gram=3, max_gram=3, token_chars=["letter", "digit", "punctuation", "symbol"]),
+                         tokenizer=tokenizer('trigram', 'nGram', min_gram=3, max_gram=3, token_chars=["letter", "digit", "punctuation", "symbol", "whitespace"]),
                          filter='lowercase')
 
 file_query_analyzer = analyzer('file_query_analyzer',


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* https://jira.tacc.utexas.edu/browse/FP-594

## Summary of Changes: ##
Ensuring search result matches contain the entire search query
keep spaces in ngrams so results match user input that uses spaces

## Testing Steps: ##
1.
See jira ticket for bug description


## UI Photos:

## Notes: ##
