### PR TITLE
Task/FP-1039 push keys job submission fix

### DIFF
--- a/client/src/redux/sagas/fixtures/jobSubmit.fixture.js
+++ b/client/src/redux/sagas/fixtures/jobSubmit.fixture.js
@@ -1,0 +1,16 @@
+const jobSubmitFixture = {
+  inputs: {},
+  parameters: { email: 'user@username.com' },
+  name: 'frontera-hpc-jupyter-1.0u12_2021-05-19T21:13:46',
+  batchQueue: 'development',
+  nodeCount: 1,
+  processorsOnEachNode: 1,
+  maxRunTime: '00:05:00',
+  archivePath: '',
+  archive: true,
+  archiveOnAppError: true,
+  appId: 'frontera-hpc-jupyter-1.0u12',
+  allocation: 'TACC-ACI'
+};
+
+export default jobSubmitFixture;

--- a/client/src/redux/sagas/jobs.sagas.js
+++ b/client/src/redux/sagas/jobs.sagas.js
@@ -45,23 +45,42 @@ export function* getJobs(action) {
   }
 }
 
-function* submitJob(action) {
+export async function postSubmitJobUtil(jobPayload) {
+  const result = await fetchUtil({
+    url: '/api/workspace/jobs',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': Cookies.get('csrftoken')
+    },
+    body: JSON.stringify(jobPayload)
+  });
+  return result;
+}
+
+export function* submitJob(action) {
   yield put({ type: 'FLUSH_SUBMIT' });
   yield put({ type: 'TOGGLE_SUBMITTING' });
   try {
-    const res = yield call(fetchUtil, {
-      url: '/api/workspace/jobs',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': Cookies.get('csrftoken')
-      },
-      body: JSON.stringify(action.payload)
-    });
-    yield put({
-      type: 'SUBMIT_JOB_SUCCESS',
-      payload: res.response
-    });
+    const res = yield call(postSubmitJobUtil, action.payload);
+    if (res.response.execSys) {
+      yield put({
+        type: 'SYSTEMS_TOGGLE_MODAL',
+        payload: {
+          operation: 'pushKeys',
+          props: {
+            onSuccess: { type: 'SUBMIT_JOB', payload: action.payload },
+            system: res.response.execSys
+          }
+        }
+      });
+      yield put({ type: 'TOGGLE_SUBMITTING' });
+    } else {
+      yield put({
+        type: 'SUBMIT_JOB_SUCCESS',
+        payload: res.response
+      });
+    }
   } catch (error) {
     yield put({
       type: 'SUBMIT_JOB_ERROR',

--- a/client/src/redux/sagas/jobs.sagas.js
+++ b/client/src/redux/sagas/jobs.sagas.js
@@ -80,6 +80,7 @@ export function* submitJob(action) {
         type: 'SUBMIT_JOB_SUCCESS',
         payload: res.response
       });
+      yield put({ type: 'TOGGLE_SUBMITTING' });
     }
   } catch (error) {
     yield put({

--- a/client/src/redux/sagas/jobs.sagas.test.js
+++ b/client/src/redux/sagas/jobs.sagas.test.js
@@ -93,13 +93,14 @@ describe('submitJob Saga', () => {
         type: 'SUBMIT_JOB_SUCCESS',
         payload: jobDetailFixture
       })
+      .put({ type: 'TOGGLE_SUBMITTING' })
       .hasFinalState({
         ...jobsInitalState,
         submit: {
           ...jobsInitalState.submit,
           error: false,
           response: jobDetailFixture,
-          submitting: true /* TODO: fix reducer/saga */
+          submitting: false
         }
       })
       .run());

--- a/client/src/redux/sagas/jobs.sagas.test.js
+++ b/client/src/redux/sagas/jobs.sagas.test.js
@@ -1,15 +1,23 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { jobDetail as jobDetailReducer } from '../reducers/jobs.reducers';
+import {
+  jobs as jobsReducer,
+  jobDetail as jobDetailReducer,
+  initialState as jobsInitalState
+} from '../reducers/jobs.reducers';
 
 import {
   fetchJobDetailsUtil,
   getJobDetails,
-  watchJobDetails
+  postSubmitJobUtil,
+  watchJobDetails,
+  submitJob
 } from './jobs.sagas';
 import { fetchAppDefinitionUtil } from './apps.sagas';
+import executionSystemDetailFixture from './fixtures/executionsystemdetail.fixture';
 import jobDetailFixture from './fixtures/jobdetail.fixture';
 import appDetailFixture from './fixtures/appdetail.fixture';
+import jobSubmitFixture from './fixtures/jobSubmit.fixture';
 import jobDetailDisplayFixture from './fixtures/jobdetaildisplay.fixture';
 
 jest.mock('cross-fetch');
@@ -30,16 +38,19 @@ describe('getJobDetails Saga', () => {
       .withReducer(jobDetailReducer)
       .provide([
         [matchers.call.fn(fetchJobDetailsUtil), jobDetailFixture],
-        [matchers.call.fn(fetchAppDefinitionUtil), appDetailFixture],
+        [matchers.call.fn(fetchAppDefinitionUtil), appDetailFixture]
       ])
       .put({ type: 'JOB_DETAILS_FETCH_STARTED', payload: 'job_id' })
       .call(fetchJobDetailsUtil, 'job_id')
-      .call(fetchAppDefinitionUtil, 'prtl.clone.username.FORK.compress-0.1u3-3.0')
+      .call(
+        fetchAppDefinitionUtil,
+        'prtl.clone.username.FORK.compress-0.1u3-3.0'
+      )
       .put({
         type: 'JOB_DETAILS_FETCH_SUCCESS',
         payload: {
           app: appDetailFixture,
-          job: jobDetailFixture,
+          job: jobDetailFixture
         }
       })
 
@@ -61,4 +72,71 @@ test('Effect Creators should dispatch sagas', () => {
     .takeLatest('GET_JOB_DETAILS', getJobDetails)
     .next()
     .isDone();
+});
+
+describe('submitJob Saga', () => {
+  it('should submit a job', () =>
+    expectSaga(submitJob, {
+      payload: jobSubmitFixture
+    })
+      .withReducer(jobsReducer)
+      .provide([
+        [
+          matchers.call.fn(postSubmitJobUtil),
+          { response: jobDetailFixture } /* TODO: fix response */
+        ]
+      ])
+      .put({ type: 'FLUSH_SUBMIT' })
+      .put({ type: 'TOGGLE_SUBMITTING' })
+      .call(postSubmitJobUtil, jobSubmitFixture)
+      .put({
+        type: 'SUBMIT_JOB_SUCCESS',
+        payload: jobDetailFixture
+      })
+      .hasFinalState({
+        ...jobsInitalState,
+        submit: {
+          ...jobsInitalState.submit,
+          error: false,
+          response: jobDetailFixture,
+          submitting: true /* TODO: fix reducer/saga */
+        }
+      })
+      .run());
+  it('should open a push-key modal when submitting a job for system requiring keys', () =>
+    expectSaga(submitJob, {
+      payload: jobSubmitFixture
+    })
+      .withReducer(jobsReducer)
+      .provide([
+        [
+          matchers.call.fn(postSubmitJobUtil),
+          { response: { execSys: executionSystemDetailFixture } }
+        ]
+      ])
+      .put({ type: 'FLUSH_SUBMIT' })
+      .put({ type: 'TOGGLE_SUBMITTING' })
+      .call(postSubmitJobUtil, jobSubmitFixture)
+      .put({
+        type: 'SYSTEMS_TOGGLE_MODAL',
+        payload: {
+          operation: 'pushKeys',
+          props: {
+            onSuccess: {
+              type: 'SUBMIT_JOB',
+              payload: jobSubmitFixture
+            },
+            system: executionSystemDetailFixture
+          }
+        }
+      })
+      .put({ type: 'TOGGLE_SUBMITTING' })
+      .hasFinalState({
+        ...jobsInitalState,
+        submit: {
+          ...jobsInitalState.submit,
+          submitting: false
+        }
+      })
+      .run());
 });


### PR DESCRIPTION
## Overview: ##

Adding back the code that shows the push-key modal when execution system is missing keys (dropped in https://github.com/TACC/Core-Portal/pull/381/). 

## Related Jira tickets: ##

* [FP-1039](https://jira.tacc.utexas.edu/browse/FP-1039)

## Summary of Changes: ##
* Adding back the code that shows the push-key modal when execution system is missing keys
* Add unit test
* Ensure `loading` is false when job is successfully submitted.

## Testing Steps: ##
1. Run unit tests
2. Log into frontera and edit .ssh/authorized keys to remove keys associated with Frontera execution system (i.e. those lines containing `.TACC-ACI.exec.frontera.HPC`)
3. Run Frontera HPC app (https://cep.dev/workbench/applications/frontera-hpc-jupyter-1.0u12). **NOTE make sure to use `develop` queue as there are known bugs for using rtx or normal queues.**
