### PR TITLE
Support Count of Search Results in UI.

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
@@ -129,6 +129,7 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
           api={api}
           scheme={scheme}
           system={system}
+          resultCount={files.length}
           styleName="searchbar"
         />
       )}

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
@@ -1,9 +1,9 @@
-import React from "react"
-import { createMemoryHistory } from "history";
-import  DataFilesListing  from "./DataFilesListing";
-import { CheckboxCell, FileNavCell } from "./DataFilesListingCells";
-import configureStore from "redux-mock-store";
+import React from 'react';
+import { createMemoryHistory } from 'history';
+import configureStore from 'redux-mock-store';
 import renderComponent from 'utils/testing';
+import DataFilesListing from './DataFilesListing';
+import { CheckboxCell, FileNavCell } from './DataFilesListingCells';
 import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 
 const mockStore = configureStore();
@@ -17,8 +17,8 @@ const initialMockState = {
     },
     params: {
       FilesListing: {
-        system: "test.system",
-        path: "test/path"
+        system: 'test.system',
+        path: 'test/path'
       }
     },
     loadingScroll: {
@@ -31,7 +31,7 @@ const initialMockState = {
       FilesListing: []
     },
     selected: {
-      FilesListing: [],
+      FilesListing: []
     },
     selectAll: {
       FilesListing: false
@@ -43,8 +43,8 @@ const initialMockState = {
   systems: systemsFixture
 };
 
-describe("CheckBoxCell", () => {
-  it("shows checkbox when checked", () => {
+describe('CheckBoxCell', () => {
+  it('shows checkbox when checked', () => {
     const history = createMemoryHistory();
     const store = mockStore({ files: { selected: { FilesListing: [0] } } });
     const { getAllByRole } = renderComponent(
@@ -53,12 +53,11 @@ describe("CheckBoxCell", () => {
       history
     );
     expect(
-      getAllByRole("img", { hidden: true })[1]
-        .getAttribute("data-icon")
-    ).toEqual("check-square");
+      getAllByRole('img', { hidden: true })[1].getAttribute('data-icon')
+    ).toEqual('check-square');
   });
 
-  it("shows square when unchecked", () => {
+  it('shows square when unchecked', () => {
     const history = createMemoryHistory();
     const store = mockStore({ files: { selected: { FilesListing: [] } } });
     const { getAllByRole } = renderComponent(
@@ -67,57 +66,71 @@ describe("CheckBoxCell", () => {
       history
     );
     expect(
-      getAllByRole("img", { hidden: true })
+      getAllByRole('img', { hidden: true })
         .pop()
-        .getAttribute("data-icon")
-    ).toEqual("square");
+        .getAttribute('data-icon')
+    ).toEqual('square');
   });
 });
 
-describe("FileNavCell", () => {
-  it("renders name and link for dir", () => {
+describe('FileNavCell', () => {
+  it('renders name and link for dir', () => {
     const history = createMemoryHistory();
     const store = mockStore({});
     const { getByText } = renderComponent(
-      <FileNavCell system="test.system" path= "/path/to/file" name="Filename" format="folder" api="tapis" scheme="private" href="href" />,
+      <FileNavCell
+        system="test.system"
+        path="/path/to/file"
+        name="Filename"
+        format="folder"
+        api="tapis"
+        scheme="private"
+        href="href"
+      />,
       store,
       history
     );
-    expect(getByText("Filename")).toBeDefined();
+    expect(getByText('Filename')).toBeDefined();
     expect(
-      getByText("Filename")
-        .closest("a")
-        .getAttribute("href")
-    ).toEqual("/workbench/data/tapis/private/test.system/path/to/file/");
+      getByText('Filename')
+        .closest('a')
+        .getAttribute('href')
+    ).toEqual('/workbench/data/tapis/private/test.system/path/to/file/');
   });
 
-  it("renders name if not directory", () => {
+  it('renders name if not directory', () => {
     const history = createMemoryHistory();
     const store = mockStore({});
     const { getByText } = renderComponent(
-      <FileNavCell system="test.system" path= "/path/to/file" name="Filename" format="file" api="tapis" scheme="private" href="href" />,
+      <FileNavCell
+        system="test.system"
+        path="/path/to/file"
+        name="Filename"
+        format="file"
+        api="tapis"
+        scheme="private"
+        href="href"
+      />,
       store,
       history
     );
-    expect(getByText("Filename")).toBeDefined();
+    expect(getByText('Filename')).toBeDefined();
   });
 });
 
-
-describe("DataFilesListing", () => {
-
-  it("renders listing", () => {
+describe('DataFilesListing', () => {
+  it('renders listing', () => {
     const testfile = {
-      system: "test.system",
-      path: "/path/to/file",
-      name: "testfile",
-      format: "file",
+      system: 'test.system',
+      path: '/path/to/file',
+      name: 'testfile',
+      format: 'file',
       length: 4096,
-      lastModified: "2019-06-17T15:49:53-05:00",
-      _links: {self: {href: "href.test"}}
+      lastModified: '2019-06-17T15:49:53-05:00',
+      _links: { self: { href: 'href.test' } }
     };
     const history = createMemoryHistory();
-    history.push("/workbench/data/tapis/private/test.system/");
+    history.push('/workbench/data/tapis/private/test.system/');
     const store = mockStore({
       ...initialMockState,
       files: {
@@ -127,12 +140,18 @@ describe("DataFilesListing", () => {
     });
 
     const { getByText, getAllByRole } = renderComponent(
-        <DataFilesListing api="tapis" scheme="private" system="test.system" path="/" />,
+      <DataFilesListing
+        api="tapis"
+        scheme="private"
+        system="test.system"
+        resultCount={4}
+        path="/"
+      />,
       store,
       history
     );
-    expect(getByText("testfile")).toBeDefined();
-    expect(getByText("4.0 kB")).toBeDefined();
+    expect(getByText('testfile')).toBeDefined();
+    expect(getByText('4.0 kB')).toBeDefined();
     /*
     expect(getByText("06/17/2019 15:49")).toBeDefined();
     const row = getAllByRole("row")[0];
@@ -143,14 +162,19 @@ describe("DataFilesListing", () => {
     */
   });
 
-  
-  it("renders message when no files to show", () => {
+  it('renders message when no files to show', () => {
     const history = createMemoryHistory();
-    history.push("/workbench/data/tapis/private/test.system/");
+    history.push('/workbench/data/tapis/private/test.system/');
     const store = mockStore(initialMockState);
 
     const { getByText, debug } = renderComponent(
-        <DataFilesListing api="tapis" scheme="private" system="test.system" path="/"  />,
+      <DataFilesListing
+        api="tapis"
+        scheme="private"
+        system="test.system"
+        resultCount={4}
+        path="/"
+      />,
       store,
       history
     );
@@ -158,27 +182,35 @@ describe("DataFilesListing", () => {
     expect(getByText(/No files or folders to show/)).toBeDefined();
   });
 
-  it.each(
+  it.each([
+    ['500', /There was a problem accessing this file system./],
     [
-      ['500', /There was a problem accessing this file system./],
-      ['502', /There was a problem accessing this file system. If this is your first time logging in/],
-      ['404', 'The file or folder that you are attempting to access does not exist.']
-    ])(
-    'Renders "%s" error message correctly',
-    (errorCode, message) => {
-      const history = createMemoryHistory();
-      history.push("/workbench/data/tapis/private/test.system/");
-      const errorMockState = {...initialMockState};
-      errorMockState.files.error.FilesListing=errorCode;
-      const store = mockStore(errorMockState);
+      '502',
+      /There was a problem accessing this file system. If this is your first time logging in/
+    ],
+    [
+      '404',
+      'The file or folder that you are attempting to access does not exist.'
+    ]
+  ])('Renders "%s" error message correctly', (errorCode, message) => {
+    const history = createMemoryHistory();
+    history.push('/workbench/data/tapis/private/test.system/');
+    const errorMockState = { ...initialMockState };
+    errorMockState.files.error.FilesListing = errorCode;
+    const store = mockStore(errorMockState);
 
-      const { getByText } = renderComponent(
-        <DataFilesListing api="tapis" scheme="private" system="test.system" path="/"  />,
-        store,
-        history
-      );
+    const { getByText } = renderComponent(
+      <DataFilesListing
+        api="tapis"
+        scheme="private"
+        system="test.system"
+        resultCount={4}
+        path="/"
+      />,
+      store,
+      history
+    );
 
-      expect(getByText(message)).toBeDefined();
-    }
-  );
+    expect(getByText(message)).toBeDefined();
+  });
 });

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
@@ -9,7 +9,14 @@ import { useSelector } from 'react-redux';
 
 import './DataFilesSearchbar.module.css';
 
-const DataFilesSearchbar = ({ api, scheme, system, className, publicData }) => {
+const DataFilesSearchbar = ({
+  api,
+  scheme,
+  system,
+  resultCount,
+  className,
+  publicData
+}) => {
   const disabled = useSelector(
     state =>
       state.files.loading.FilesListing === true ||
@@ -83,6 +90,11 @@ const DataFilesSearchbar = ({ api, scheme, system, className, publicData }) => {
           autoComplete="off"
           disabled={disabled}
         />
+        {hasQuery && (
+          <div aria-label="Summary of Search Results" styleName="results">
+            {resultCount} Results Found for: &quot;<span>{hasQuery}</span>&quot;
+          </div>
+        )}
       </div>
       {hasQuery && (
         <Button
@@ -103,13 +115,15 @@ DataFilesSearchbar.propTypes = {
   api: PropTypes.string.isRequired,
   scheme: PropTypes.string.isRequired,
   system: PropTypes.string.isRequired,
+  resultCount: PropTypes.number,
   /** Additional `className` (or transpiled `styleName`) for the root element */
   className: PropTypes.string,
   publicData: PropTypes.bool
 };
 DataFilesSearchbar.defaultProps = {
   className: '',
-  publicData: false
+  publicData: false,
+  resultCount: 0
 };
 
 export default DataFilesSearchbar;

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
@@ -92,7 +92,7 @@ const DataFilesSearchbar = ({
         />
         {hasQuery && (
           <div aria-label="Summary of Search Results" styleName="results">
-            {resultCount} Results Found for: &quot;<span>{hasQuery}</span>&quot;
+            {resultCount} Results Found for <span>{hasQuery}</span>
           </div>
         )}
       </div>

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
@@ -59,7 +59,7 @@
 
 .results {
   padding-left: 5px;
-  padding-top: 5px;
+  align-self: center;
   span {
     font-weight: 600;
   }

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
@@ -58,7 +58,7 @@
 }
 
 .results {
-  padding-left: 10px;
+  padding-left: 20px;
   align-self: center;
   span {
     font-weight: bold;

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
@@ -61,7 +61,7 @@
   padding-left: 10px;
   align-self: center;
   span {
-    font-weight: 600;
+    font-weight: bold;
   }
 }
 

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
@@ -57,6 +57,14 @@
     /* … */
 }
 
+.results {
+  padding-left: 5px;
+  padding-top: 5px;
+  span {
+    font-weight: 600;
+  }
+}
+
 /* Hacks */
 
 .container,

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css
@@ -58,7 +58,7 @@
 }
 
 .results {
-  padding-left: 5px;
+  padding-left: 10px;
   align-self: center;
   span {
     font-weight: 600;

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.test.js
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { fireEvent, wait } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import DataFilesSearchbar from './DataFilesSearchbar';
-import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 import configureStore from 'redux-mock-store';
 import renderComponent from 'utils/testing';
+import DataFilesSearchbar from './DataFilesSearchbar';
+import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 
 const mockStore = configureStore();
 
@@ -90,6 +90,7 @@ describe('DataFilesSearchbar', () => {
         api="tapis"
         scheme="private"
         system="frontera.home.username"
+        resultCount={4}
       />,
       store,
       history


### PR DESCRIPTION
## Overview: ##

Support Count of Search Results in UI


## Related Jira tickets: ##

* [FP-563](https://jira.tacc.utexas.edu/browse/FP-563)

## Summary of Changes: ##

Implementing search results message for Data Files.

## Testing Steps: ##
1. On Data Files type a query and hit Enter

## UI Photos:

<img width="1070" alt="Screen Shot 2021-05-20 at 1 24 26 PM" src="https://user-images.githubusercontent.com/62672123/119029933-e2f23f80-b96e-11eb-8b0f-94b724c444ab.png">
<img width="1070" alt="Screen Shot 2021-05-20 at 1 24 00 PM" src="https://user-images.githubusercontent.com/62672123/119029948-e5ed3000-b96e-11eb-9b66-c7f8a004e22a.png">
<img width="1070" alt="Screen Shot 2021-05-20 at 1 24 12 PM" src="https://user-images.githubusercontent.com/62672123/119029951-e5ed3000-b96e-11eb-9ada-b49a367e6fbf.png">


## Notes: ##

For further consideration, Search the query_string is not showing in input box when is passed as URL parameter.
<img width="1074" alt="Screen Shot 2021-05-20 at 1 35 25 PM" src="https://user-images.githubusercontent.com/62672123/119031025-3fa22a00-b970-11eb-8fae-d03a432fed23.png">

