### PR TITLE
bug/FP-1038: Fix race condition causing `Cannot read property 'system' of undefined` bug

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
@@ -44,10 +44,6 @@ const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
   };
 
   useEffect(() => {
-    dispatch({ type: 'FETCH_SYSTEMS' });
-  }, [dispatch]);
-
-  useEffect(() => {
     dispatch({
       type: 'STORE_SELECTOR_REF',
       payload: selectRef.current

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -25,7 +25,7 @@ function Workbench() {
   // showUIPatterns: Show some entries only in local development
   const { loading, setupComplete, showUIPatterns, isStaff } = useSelector(
     state => ({
-      loading: state.workbench.loading,
+      loading: state.workbench.loading || state.systems.storage.loading,
       setupComplete: state.workbench.setupComplete,
       showUIPatterns: state.workbench.config.debug,
       isStaff:

--- a/client/src/components/Workbench/Workbench.test.js
+++ b/client/src/components/Workbench/Workbench.test.js
@@ -67,4 +67,19 @@ describe('workbench', () => {
       )
     ).toBeDefined();
   });
+  it('shows loading spinner if systems request not finished', () => {
+    const history = createMemoryHistory();
+    const store = mockStore({
+      ...state,
+      systems: {
+        ...systems,
+        storage: {
+          ...systems.storage,
+          loading: true
+        }
+      }
+    });
+    const { getByTestId } = renderComponent(<Workbench />, store, history);
+    expect(getByTestId(/loading-spinner/)).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Overview: ##

Sometimes, when selecting a file to use as an input in a job, this bug will pop up and crash the frontend. It's caused by an extraneous dispatch to `FETCH_SYSTEMS` which clears and reloads systems again, without accounting for an empty systems configuration array.

## Related Jira tickets: ##

* [FP-1038](https://jira.tacc.utexas.edu/browse/FP-1038)

## Summary of Changes: ##
- Remove extraneous dispatch to `FETCH_SYSTEMS`
- Render `<LoadingSpinner>` if initial `FETCH_SYSTEMS` request is not done loading on the Workbench

## Testing Steps: ##
1. Load an app, and confirm that no matter how many times you click the `Select Input` button on an app, it does not crash the app.
