### PR TITLE
Hotfix: FP-962: Simpler fix for double padding of table cell button-links

### DIFF
--- a/client/src/styles/trumps/table.css
+++ b/client/src/styles/trumps/table.css
@@ -1,24 +1,16 @@
 /* TRUMPS: Scope: Table */
 
-/* Reduce "double padding" of cell and button link */
-/* FAQ: Overlap padding of cell with invisible padding of button link */
-/* CAVEAT: Using [role="cell"] instead of <td> because DataFiles <div> table */
+/* To remove double padding on buton links within tables */
+/* CAVEAT: The `padding: 0` also exists for specific instances */
+/* TODO: Remove `padding: 0` for all specific instances that inherit this */
 td .btn-link,
-div[role="cell"] .btn-link {
-  /* Overwrite Bootstrap `_button.scss` */
-  margin-left: -0.75rem;
-  margin-right: -0.75rem;
-}
-td .btn-sm.btn-link,
-div[role="cell"] .btn-sm.btn-link {
-  /* Overwrite Bootstrap `_button.scss` */
-  margin-left: -0.5rem;
-  margin-right: -0.5rem;
+/* FAQ: Using [role="cell"] instead of <td> because DataFiles <div> table */
+div[role="cell"] .btn-link  {
+  padding: 0;
 }
 
-td .btn-sm,
-td .btn-group-sm > .btn,
-/* CAVEAT: Using [role="cell"] instead of <td> because DataFiles <div> table */
+/* To ensure small buttons in tables match the table font size */
+/* FAQ: Using [role="cell"] instead of <td> because DataFiles <div> table */
 div[role="cell"] .btn-sm,
 div[role="cell"] .btn-group-sm > .btn {
   /* Overwrite Bootstrap `_button.scss` */


### PR DESCRIPTION
## Overview: ##

- Prevent button links in table cells from being cut off on the left.
- Do not preserve padding on fake link buttons. Instead, let them be padding-less, like links.
- _Tweak a comment in the same file with the relevant changes._

I.e. Fix stuff like [this (screenshot)](https://user-images.githubusercontent.com/62723358/119696920-4b309d80-be15-11eb-83e7-9b6768fa77ae.png) by not trying to preserve button padding, and explain why.

## Related Jira tickets: ##

* [FP-962](https://jira.tacc.utexas.edu/browse/FP-962)

## Summary of Changes: ##

- Replace fix from 6aaab34.
- Obviate the related 6782202.

## Testing Steps: ##

- Data Files
- Data Files > Projects
- Data Files > Projects > File Listing
- Data Files > Projects > Member List
- Onboarding Admin
- Allocations
- _any other tables with a button-as-a-link in any cell_

## UI Photos:

![Data Files](https://user-images.githubusercontent.com/62723358/119696342-b2018700-be14-11eb-9fa7-a16b8ecd5b5b.png)
![Projects Listing](https://user-images.githubusercontent.com/62723358/119696339-b2018700-be14-11eb-8d7d-6f25a1b2b27e.png)
![Projects File Listing](https://user-images.githubusercontent.com/62723358/119696335-b0d05a00-be14-11eb-9295-b208c3cb9b1e.png)
![Projects Member Listing](https://user-images.githubusercontent.com/62723358/119696330-b037c380-be14-11eb-810f-5f49bfa07db3.png)
![Onboarding Admin](https://user-images.githubusercontent.com/62723358/119696344-b29a1d80-be14-11eb-827a-88bb7a6956c8.png)
![Allocations](https://user-images.githubusercontent.com/62723358/119696337-b168f080-be14-11eb-83ab-24a993919d99.png)

## Notes: ##

Both hotfix PRs (#405 and this #406) are failing all tests. But, when I run `npm run lint` and `npm run test`, I receive no errors nor warnings.