### PR TITLE
FP-1064:  Stop the spinning / remove problematic TOGGLE_SUBMITTING action from saga

### DIFF
--- a/client/src/redux/sagas/jobs.sagas.js
+++ b/client/src/redux/sagas/jobs.sagas.js
@@ -80,7 +80,6 @@ export function* submitJob(action) {
         type: 'SUBMIT_JOB_SUCCESS',
         payload: res.response
       });
-      yield put({ type: 'TOGGLE_SUBMITTING' });
     }
   } catch (error) {
     yield put({

--- a/client/src/redux/sagas/jobs.sagas.test.js
+++ b/client/src/redux/sagas/jobs.sagas.test.js
@@ -93,14 +93,14 @@ describe('submitJob Saga', () => {
         type: 'SUBMIT_JOB_SUCCESS',
         payload: jobDetailFixture
       })
-      .put({ type: 'TOGGLE_SUBMITTING' })
       .hasFinalState({
         ...jobsInitalState,
         submit: {
           ...jobsInitalState.submit,
           error: false,
           response: jobDetailFixture,
-          submitting: false
+          submitting: true /* submitting stays `true` after successful submission as AppForm.js scrolls user to top of
+           page before dispatching TOGGLE_SUBMITTING */
         }
       })
       .run());


### PR DESCRIPTION
## Overview: ##

Fixes regression introduced in https://github.com/TACC/Core-Portal/pull/400. 

I had had added that TOGGLE_SUBMITTING during the adding of some unit tests without understanding its use in AppForm.js.

## Related Jira tickets: ##

* [FP-1064](https://jira.tacc.utexas.edu/browse/FP-1064)

## Summary of Changes: ##
* remove problematic TOGGLE_SUBMITTING action from saga
* add comment in saga unit test to explain why the state is unique after job submission

## Testing Steps: ##
1. Run job
2. Ensure that job submission occurs.  Scroll down to ensure that the submitting spinner is no longer there.
