### PR TITLE
Disable “Upload Selected” button when no valid files or nothing to up…

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
@@ -49,8 +49,14 @@ const DataFilesUploadModal = ({ className, layout }) => {
         }
       });
   };
-  const disabled =
+  const dropZoneDisabled =
     Object.values(status).filter(s => s === 'UPLOADING').length > 0;
+  const uploadButtonDisabled =
+    dropZoneDisabled ||
+    (!dropZoneDisabled &&
+      uploadedFiles.length ===
+        rejectedFiles.length +
+          Object.values(status).filter(s => s === 'SUCCESS').length);
   const hasFilesToList = uploadedFiles.length > 0;
   const showListing = hasFilesToList || layout === 'default';
 
@@ -118,7 +124,7 @@ const DataFilesUploadModal = ({ className, layout }) => {
     >
       <ModalHeader toggle={toggle}>Upload Files</ModalHeader>
       <ModalBody styleName={containerStyleNames}>
-        <div styleName="dropzone" disabled={disabled}>
+        <div styleName="dropzone" disabled={dropZoneDisabled}>
           <FileInputDropZone
             onSetFiles={selectFiles}
             onRejectedFiles={onRejectedFiles}
@@ -143,7 +149,7 @@ const DataFilesUploadModal = ({ className, layout }) => {
         <Button
           className="data-files-btn"
           onClick={uploadStart}
-          disabled={disabled}
+          disabled={uploadButtonDisabled}
         >
           Upload Selected
         </Button>


### PR DESCRIPTION
## Overview: ##
Disable “Upload Selected” button when no valid files or nothing to upload

## Related Jira tickets: ##

* [FP-1061](https://jira.tacc.utexas.edu/browse/FP-1061)

## Summary of Changes: ##

## Testing Steps: ##
On Upload File modal window select files to upload.

"Upload Selected" button should be disabled when:

- All selected files are too large to upload
- After all files are uploaded
- If no files are selected

## UI Photos:

<img width="1081" alt="Screen Shot 2021-05-28 at 9 05 56 AM" src="https://user-images.githubusercontent.com/62672123/119996124-f8312480-bf93-11eb-9682-11b35c55e8bc.png">
<img width="1081" alt="Screen Shot 2021-05-28 at 9 05 33 AM" src="https://user-images.githubusercontent.com/62672123/119996125-f8c9bb00-bf93-11eb-965b-84e418ff8f30.png">


## Notes: ##
