### PR TITLE
Task/FP-1065 - Fix issues with site search header and spacing

### DIFF
--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.css
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.css
@@ -1,7 +1,13 @@
+.site-search__icons{
+    width: 5%;
+    text-align: center;
+}
+
 .site-search__full-width-result{
-    width: 100%;
+    width: 85%;
 }
 
 .site-search__no-overflow {
     overflow: visible !important;
+    width: 10%;
 }

--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.css
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.css
@@ -1,3 +1,6 @@
+.site-search {
+    table-layout: auto;
+}
 .site-search__icons{
     width: 5%;
     text-align: center;

--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.js
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.js
@@ -55,7 +55,8 @@ export const SiteSearchFileListing = ({ listing, filter }) => {
     {
       id: 'icon',
       accessor: 'format',
-      Cell: FileIconCell
+      Cell: FileIconCell,
+      className: 'site-search__icons'
     },
     {
       accessor: 'name',

--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.js
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.js
@@ -76,6 +76,7 @@ export const SiteSearchFileListing = ({ listing, filter }) => {
         tableColumns={tableColumns}
         tableData={listing}
         columnMemoProps={[filter]}
+        className="site-search"
       />
     </>
   );

--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.module.scss
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.module.scss
@@ -36,9 +36,6 @@
   flex-direction: column;
   flex-grow: 1;
 }
-.container thead {
-  display: none;
-}
 
 .placeholder {
   margin: 25px var(--space--listing-horz);

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
@@ -6,7 +6,6 @@
   /* FAQ: Table is wider than container when row content is wider than table */
   /* CAVEAT: All tables' column widths must be % values whose sum is 100% */
   /* SEE: https://stackoverflow.com/a/6601257 */
-  table-layout: fixed;
   width: 100%;
 
   max-height: inherit; /* inherit max-height from parent wrapper */

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
@@ -6,6 +6,7 @@
   /* FAQ: Table is wider than container when row content is wider than table */
   /* CAVEAT: All tables' column widths must be % values whose sum is 100% */
   /* SEE: https://stackoverflow.com/a/6601257 */
+  table-layout: fixed;
   width: 100%;
 
   max-height: inherit; /* inherit max-height from parent wrapper */


### PR DESCRIPTION
## Overview: ##
After checking with design, there is supposed to be a header, but no header labels on the SiteSearchListing. These changes should fix the column spacing issues for anything using the `InfiniteScrollTable` for Site Search

## Related Jira tickets: ##

* [FP-1065](https://jira.tacc.utexas.edu/browse/FP-1065)

## Testing Steps: ##
1. Go to the files area of Site Search and view the table listing. You should not see any overlapping or cut off columns

## UI Photos:

![Screen Shot 2021-05-28 at 5 16 40 PM](https://user-images.githubusercontent.com/29575979/120047234-b88d2b80-bfd9-11eb-8606-0e68b7bbc4d7.png)
