### PR TITLE
Only open data files select modal when pushing keys to access data files

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
@@ -43,13 +43,6 @@ const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
     toggle();
   };
 
-  useEffect(() => {
-    dispatch({
-      type: 'STORE_SELECTOR_REF',
-      payload: selectRef.current
-    });
-  }, [selectRef]);
-
   return (
     <Modal
       isOpen={isOpen}

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -376,7 +376,7 @@ export function files(state = initialFilesState, action) {
             ...state.refs,
             FileSelector: action.payload
           }
-        };
+      };
     case 'CLEAR_REFS':
       return { ...state, refs: {} };
     case 'DATA_FILES_SET_MODAL_PROPS':

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -370,7 +370,6 @@ export function files(state = initialFilesState, action) {
         }
       };
     case 'STORE_SELECTOR_REF':
-      if(action.payload.props.isOpen){
         return {
           ...state,
           refs: {
@@ -378,7 +377,6 @@ export function files(state = initialFilesState, action) {
             FileSelector: action.payload
           }
         };
-      };
     case 'CLEAR_REFS':
       return { ...state, refs: {} };
     case 'DATA_FILES_SET_MODAL_PROPS':

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -370,12 +370,14 @@ export function files(state = initialFilesState, action) {
         }
       };
     case 'STORE_SELECTOR_REF':
-      return {
-        ...state,
-        refs: {
-          ...state.refs,
-          FileSelector: action.payload
-        }
+      if(action.payload.props.isOpen){
+        return {
+          ...state,
+          refs: {
+            ...state.refs,
+            FileSelector: action.payload
+          }
+        };
       };
     case 'CLEAR_REFS':
       return { ...state, refs: {} };

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -370,12 +370,12 @@ export function files(state = initialFilesState, action) {
         }
       };
     case 'STORE_SELECTOR_REF':
-        return {
-          ...state,
-          refs: {
-            ...state.refs,
-            FileSelector: action.payload
-          }
+      return {
+        ...state,
+        refs: {
+          ...state.refs,
+          FileSelector: action.payload
+        }
       };
     case 'CLEAR_REFS':
       return { ...state, refs: {} };


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [FP-1062](https://jira.tacc.utexas.edu/browse/FP-1062)

## Summary of Changes: ##
Check that the data-files modal is open and tried to push keys before refreshing data files

## Testing Steps: ##
1. Running an app with an optional working directory field on a system that requires keys to be pushed (Matlab, Paraview)
2. Push Keys modal should appear, enter password and token
3. Data Files modal should not appear

## UI Photos:

## Notes: ##
