### PR TITLE
hotfix: Change stampede2 `homeDir` to `/home1`; add maverick2

### DIFF
--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -469,7 +469,7 @@ PORTAL_EXEC_SYSTEMS = {
     },
     'stampede2.tacc.utexas.edu': {
         'scratch_dir': '/scratch/{}',
-        'home_dir': '/home/{}'
+        'home_dir': '/home1/{}'
     },
     'lonestar5.tacc.utexas.edu': {
         'scratch_dir': '/scratch/{}',
@@ -481,6 +481,10 @@ PORTAL_EXEC_SYSTEMS = {
     },
     'frontera.tacc.utexas.edu': {
         'scratch_dir': '/scratch1/{}',
+        'home_dir': '/home1/{}'
+    },
+    'maverick2.tacc.utexas.edu': {
+        'scratch_dir': '/work/{}',
         'home_dir': '/home1/{}'
     }
 }


### PR DESCRIPTION
## Overview: ##
We must have crossed wires at some point thinking Stampede2 used `/home`, when in actuality it is `/home1`. This was causing an issue where the tapis exec system always failed the files list test to validate the system.

## Testing Steps: ##
1. Disable a stampede2 execution system of yours via tapis cli, i.e. `sal.TACC-ACI.exec.stampede2.HPC`
2. Run an app on stampede2 using that sys allocation
2. Confirm that keys push successfully and the job is submitted

## Notes: ##
We will need to either manually disable every user exec system using `/home` as a storage `homeDir`, or add a mechanism in the code to disable/re-clone the system if the test fails.