### PR TITLE
FP-526: Update Header Dropdown to Use Cortal Icons

### DIFF
--- a/server/portal/templates/base.html
+++ b/server/portal/templates/base.html
@@ -20,7 +20,7 @@
     <link id="css-site-font" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link id="css-site-header" rel="stylesheet" href="/static/site_cms/css/build/site.header.css" />
     <!-- Vendor CSS -->
-    {# FP-526: Stop using Font Awesome icons; start using Cortal icons #}
+    {# FP-636: Stop using Font Awesome icons #}
     <link id="css-portal-font" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css">
     <link id="css-bootstrap" rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 

--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -1,35 +1,49 @@
 {# @var user #}
 <!-- FAQ: This template loads independently at a unique url (see `urls.py`)
           so CMS and User Guide can render this markup into their markup. -->
-  
+
+{# GH-101: Remove style tag i.e. rely only on `site.header.css` #}
+<style type="text/css">
+  .s-portal-nav .icon {
+    margin-right: 0.25em;
+
+    /* Copied from FontAwesome `.fa-lg` */
+    font-size: 1.3em;
+    vertical-align: text-bottom; /* tweaked to align better */
+  }
+  .s-portal-nav .nav-link .icon {
+      font-size: 1.5em;
+      vertical-align: middle; /* tweaked to align better */
+  }
+</style>
 {% if user.is_authenticated %}
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <i class="icon icon-user-reverse nav-icon"></i>
+    <i class="icon icon-user"></i>
     <span>{{ user.get_username }}</span>
     <span class="sr-only">Toggle Dropdown</span>
   </a>
   <nav class="dropdown-menu dropdown-menu-right">
     <a class="dropdown-item" href="{% url 'workbench:dashboard' %}">
-      <i class="icon icon-dashboard nav-icon"></i> My Dashboard
+      <i class="icon icon-dashboard"></i> My Dashboard
     </a>
     {% if user.is_staff %}
     <a class="dropdown-item" href="{% url 'workbench:onboarding_admin' %}">
-      <i class="icon icon-approved-boxed nav-icon"></i> Onboarding Admin
+      <i class="icon icon-approved-boxed"></i> Onboarding Admin
     </a>
     {% endif %}
     <a class="dropdown-item" href="{% url 'portal_accounts:manage_profile' %}">
-      <i class="icon icon-user nav-icon"></i> My Account
+      <i class="icon icon-user"></i> My Account
     </a>
     <a class="dropdown-item" href="{% url 'portal_accounts:logout' %}">
-      <i class="icon icon-exit nav-icon"></i> Log Out
+      <i class="icon icon-exit"></i> Log Out
     </a>
   </nav>
 </li>
 {% else %}
 <li class="nav-item">
   <a class="nav-link" href="{% url 'portal_auth:agave_oauth' %}">
-    <i class="icon icon-user-reverse nav-icon"></i> Log in
+    <i class="icon icon-user"></i> Log in
   </a>
 </li>
 {% endif %}

--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -5,31 +5,31 @@
 {% if user.is_authenticated %}
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <i class="fas fa-user-circle fa-lg nav-icon"></i>
+    <i class="icon icon-user-reverse nav-icon"></i>
     <span>{{ user.get_username }}</span>
     <span class="sr-only">Toggle Dropdown</span>
   </a>
   <nav class="dropdown-menu dropdown-menu-right">
     <a class="dropdown-item" href="{% url 'workbench:dashboard' %}">
-      <i class="fas fa-desktop nav-icon"></i> My Dashboard
+      <i class="icon icon-dashboard nav-icon"></i> My Dashboard
     </a>
     {% if user.is_staff %}
     <a class="dropdown-item" href="{% url 'workbench:onboarding_admin' %}">
-      <i class="fas fa-tasks nav-icon"></i> Onboarding Admin
+      <i class="icon icon-approved-boxed nav-icon"></i> Onboarding Admin
     </a>
     {% endif %}
     <a class="dropdown-item" href="{% url 'portal_accounts:manage_profile' %}">
-      <i class="fas fa-user-circle nav-icon"></i> My Account
+      <i class="icon icon-user nav-icon"></i> My Account
     </a>
     <a class="dropdown-item" href="{% url 'portal_accounts:logout' %}">
-      <i class="fas fa-sign-out-alt nav-icon"></i> Log Out
+      <i class="icon icon-exit nav-icon"></i> Log Out
     </a>
   </nav>
 </li>
 {% else %}
 <li class="nav-item">
   <a class="nav-link" href="{% url 'portal_auth:agave_oauth' %}">
-    <i class="fas fa-sign-in-alt nav-icon"></i> Log in
+    <i class="icon icon-user-reverse nav-icon"></i> Log in
   </a>
 </li>
 {% endif %}


### PR DESCRIPTION
## Overview: ##

- Update Portal nav markup to use Cortal icons.
    - _Update Font Awesome icon load to reference correct ticket to remove it._

## Related Jira tickets: ##

* [FP-526](https://jira.tacc.utexas.edu/browse/FP-526)

Further header, portal nav, icon UI improvements come in https://github.com/TACC/Core-CMS/pull/222.

## Summary of Changes: ##

- __New__: Change `fa` icons to `icon` icons.
- _Minor_: Update related ticket reference in `base.html`.

## Testing Steps: ##
1. Login to Portal.
2. Open dropdown.
3. All dropdown links must have an icon.
4. All dropdown link icons must be from [Cortal icon set](https://confluence.tacc.utexas.edu/display/UP/UI+-+Components+-+Icon?preview=%2F129171529%2F175865880%2FCortal+Icons+v1.2.pdf) (direct PDF link).

## UI Photos:

<img width="1200" alt="Logged In - CMS" src="https://user-images.githubusercontent.com/62723358/121274653-95436580-c890-11eb-84b4-339d3a03cf8c.png">
<img width="1200" alt="Logged In - Portal" src="https://user-images.githubusercontent.com/62723358/121274655-97a5bf80-c890-11eb-8e30-00a7b1a42c79.png">
<img width="1200" alt="Logged Out" src="https://user-images.githubusercontent.com/62723358/121274838-f703cf80-c890-11eb-8602-0787cf481c14.png">

## Known Issues: ##

### Does Not Match Any Design

The [design where header uses a Cortal icon](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/38e3fb7c-0b56-4b76-9648-162d2fa71a97/) does **not** show Portal Nav dropdown, yet.

_P.S. The header redesign comes in https://github.com/TACC/Core-CMS/pull/222._

### Log Out Icon is Weird

Yeah, it is. That's what we'll use until Design creates a log out icon. [Design approved this placeholder.](https://tacc-team.slack.com/archives/CQUA4D5KJ/p1622041786049800?thread_ts=1619472854.048100&cid=CQUA4D5KJ)