### PR TITLE
Upate `README.md`: Clarify cert install for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ NOTE: This may require a computer restart to take effect.
 #### OSX
 
 1. Open mac's Keychain Access
-2. File > Import Items
+2. With Default Keychains > login selected, choose File > Import Items... from the menu.
 3. Navigate to `./server/conf/nginx/certificates`
 4. Select `ca.pem`
 5. Search for CEP and double click on the certificate


### PR DESCRIPTION
## Overview: ##

Update `README.md` to prevent error importing certificate on macOS.

## Related Jira tickets: ##

N/A

## Summary of Changes: ##

- Update `README.md`

## Testing Steps: ##

N/A

## UI Photos:

<details>
<summary>Problem</summary>

<img width="589" alt="Local Dev Portal Cert Install Error" src="https://user-images.githubusercontent.com/62723358/121271597-a472e500-c889-11eb-8388-a4387ab4c99c.png">

</details>