### PR TITLE
Add Docker RAM req. to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,21 @@ Finally, create a home page in the CMS.
 
 ### Setting up search index:
 
-At least one page in CMS is needed (see above), then rebuild the cms search index
+Requirements:
+- At least one page in CMS (see above).
+- At least 4GB of RAM allocated to Docker (see Docker Desktop > Preferences > Resources > Advanced).
+
+First, rebuild the cms search index:
 ```
     docker exec -it core_portal_cms /bin/bash
     python3 manage.py rebuild_index
 ```
-Then use the django shell in the `core_portal_django` container:
+Then, use the django shell in the `core_portal_django` container—
 ```
     docker exec -it core_portal_django /bin/bash
     python3 manage.py shell
 ```
-to run the following code to set up the search index
+—to run the following code to set up the search index:
 ```
 from portal.libs.elasticsearch.indexes import setup_files_index, setup_projects_index, setup_allocations_index
 setup_files_index(force=True)


### PR DESCRIPTION
## Overview: ##

- __Add requirement for ES setup.__
- Group requirements for ES setup.
- Improve(?) punctuation for ES setup.

## Related Jira tickets: ##

N/A

## Summary of Changes: ##

- __New__: Add requirement bullet to ES section of Readme.
- _Minor_: Tweak formatting of ES section of Readme.

## Testing Steps: ##

N/A

[Wes & Sal figured this out, again.](https://tacc-team.slack.com/archives/GQW4Q8HLG/p1623255556098500?thread_ts=1623252581.092900&cid=GQW4Q8HLG)

## UI Photos:

N/A

## Notes: ##

- Allocations retrieval (among other things) fails if ElasticSearch is unable to process.
- ElasticSearch requires lots of memory.
- Docker Desktop—by default—limits memory to 2GB.