### PR TITLE
FP-1010: Fix Erroneous Font-Weight 500's

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsContactCard/AllocationsContactCard.module.scss
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsContactCard/AllocationsContactCard.module.scss
@@ -13,3 +13,6 @@
 .details {
   padding: 0.25rem 0;
 }
+.details dt {
+  font-weight: normal;
+}

--- a/client/src/components/FeedbackForm/FeedbackButton.module.scss
+++ b/client/src/components/FeedbackForm/FeedbackButton.module.scss
@@ -1,6 +1,6 @@
 .container {
   font-size: 0.75em;
-  font-weight: 500;
+  font-weight: bold;
 
   &:hover {
     color: #9d85ef;

--- a/client/src/components/History/HistoryViews/JobHistoryModal.module.scss
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.module.scss
@@ -37,6 +37,9 @@
 
   padding: var(--padding);
 }
+.panel-content dd dt {
+  font-weight: normal;
+}
 /* Any preformatted values (like system output) should use a `pre` tag */
 .panel-content pre {
   white-space: pre-wrap;

--- a/client/src/components/Jobs/JobsStatus/JobsStatus.module.scss
+++ b/client/src/components/Jobs/JobsStatus/JobsStatus.module.scss
@@ -1,5 +1,3 @@
-$font-weight: 500;
-
 .root {
   :first-child {
     font-size: 100%;
@@ -8,14 +6,13 @@ $font-weight: 500;
 
 .open-icon {
   margin-right: 0.25rem;
-  font-weight: $font-weight;
 }
 .open-button {
   margin-left: 0.5rem;
   min-height: 1.25rem;
   background-color: #f4f4f4;
   border: 1px solid #afafaf;
-  font-weight: $font-weight;
+  font-weight: 500;
   color: #707070;
   position: absolute;
   margin-top: -2px;

--- a/client/src/components/Jobs/JobsStatus/JobsStatus.module.scss
+++ b/client/src/components/Jobs/JobsStatus/JobsStatus.module.scss
@@ -1,4 +1,5 @@
 .root {
+  /* Fix size of `.badge` and `.icon` */
   :first-child {
     font-size: 100%;
   }

--- a/client/src/components/Onboarding/OnboardingActions.module.scss
+++ b/client/src/components/Onboarding/OnboardingActions.module.scss
@@ -6,5 +6,5 @@
 .action {
   padding-bottom: 0;
   padding-top: 0;
-  font-weight: 500;
+  font-weight: bold;
 }

--- a/client/src/components/SystemMonitor/SystemMonitorCells.js
+++ b/client/src/components/SystemMonitor/SystemMonitorCells.js
@@ -9,7 +9,7 @@ const CELL_PROPTYPES = {
 };
 
 export const Display = ({ cell: { value } }) => (
-  <span className="wb-text-primary wb-bold">{value}</span>
+  <strong className="wb-text-primary">{value}</strong>
 );
 Display.propTypes = CELL_PROPTYPES;
 

--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -37,10 +37,6 @@
     color: #707070;
 }
 
-.workbench-content .wb-bold {
-  font-weight: 500;
-}
-
 .spin-sun {
     display: flex;
     justify-content: center;

--- a/client/src/components/_common/DescriptionList/DescriptionList.module.scss
+++ b/client/src/components/_common/DescriptionList/DescriptionList.module.scss
@@ -12,7 +12,6 @@
 .key {
   @include truncate-with-ellipsis;
 
-  font-weight: 500;
   text-overflow: ':';
 }
 .key::after {


### PR DESCRIPTION
## Overview:

Where font weight is erroneously `500`, set font weight to normal or `700` (bold).

_I did this **instead of** fix "Dasboard" "headers", because [I found **zero** such discrepancies](https://jira.tacc.utexas.edu/browse/FP-1010?focusedCommentId=22386&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22386)._




## Related Jira tickets: ##

* [FP-1010](https://jira.tacc.utexas.edu/browse/FP-1010)




## Summary of Changes & UI Photos & Testing:

### Dashboard System Monitor Name

- Change: 500 → 700 (match design)
- Code: `Dashboard`
- Design: [Core Portal > Dashbaord](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/)
- Image: <img width="1080" alt="Dashboard System Monitor Name" src="https://user-images.githubusercontent.com/62723358/121411648-79d86900-c929-11eb-9f26-a99e55ddc0f0.png">

### Jobs Table Open Session Button

- Change:
    - removed ineffectual 500 from icon (_still_ match design)
    - retained 500 for text, but do _not_ use variable (_still_ match design)
- Code: `JobStatus`
- Design: [Core Portal > Dashbaord](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/)
- Image: <img width="1080" alt="Jobs Table Open Session Button" src="https://user-images.githubusercontent.com/62723358/121411669-80ff7700-c929-11eb-8ffa-a5a77928438a.png">


### Jobs History Details Modal

- Change:
    - right panel content nested key: 500 → normal (match design)
    - modal title metadata key: 500 → 700 (match design)
- Code: `JobHistoryModal`
- Design: [Core Portal > View Details of Job](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/7d3e671f-bb61-4a20-89c6-9ca9a78a6f93/specs/)
- Image: 
<img width="1080" alt="Job History Details Modal" src="https://user-images.githubusercontent.com/62723358/121412039-e05d8700-c929-11eb-879f-62e20cf1b60a.png">


### Allocations Member Info

- Change:
    - left panel user name: None (500) (match design)
    - right panel user data key: 500 → normal (match design)
- Code: `AllocationsContactCard.js`
- Design: [Core Portal > View Team](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/5fc0328a-ca4f-45d0-bfa7-a018863ca912/specs/)
- Image: 
<img width="1080" alt="Allocations Member Info" src="https://user-images.githubusercontent.com/62723358/121411793-a0969f80-c929-11eb-99d7-539376d667cc.png">


### UI Patterns

- Change:
    - all instances: 500 → 700 (cascade from `<DescriptionList>`)
- Code: `UIPatternsSection`, `UIPatternsSectionDescriptionList`
- Design: [Core Portal > View Team](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/5fc0328a-ca4f-45d0-bfa7-a018863ca912/specs/)
- Image: 
<img width="1080" alt="UI Patterns" src="https://user-images.githubusercontent.com/62723358/121412427-519d3a00-c92a-11eb-943e-9b3a7fceaaa2.png">


### `<DescriptionList>`

- Change:
    - key: 500 → 700 (browser & bootstrap default) (match some designs)
- Code: `AllocationsContactCard`
- Design: [Core Portal > View Team](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/5fc0328a-ca4f-45d0-bfa7-a018863ca912/specs/)
- Image: 
<img width="1080" alt="DescriptionList" src="https://user-images.githubusercontent.com/62723358/121412264-1f8bd800-c92a-11eb-96d2-8871ecd08c13.png">


### Feedback Button

- Change: 500 → 700 (match design)
- Code: `FeedbackButton`
- Design: [Core Portal > Dashboard](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/specs/)
- Image: 
<img width="1080" alt="Feedback Button" src="https://user-images.githubusercontent.com/62723358/121411764-97a5ce00-c929-11eb-99d2-d3b17da7727a.png">


### Onboarding Actions

- Change: 500 → 700 (match design)
- Code: `OnboardingsAction`
- Design: [Core Portal > Onboarding Failed](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/6a36a675-4bcc-49ca-ab8c-fc4900c76d4d/specs/)
- Image: 
<img width="1080" alt="Onboarding Actions" src="https://user-images.githubusercontent.com/62723358/121411745-9379b080-c929-11eb-8b32-a3499088bb7f.png">




## Notes: ##

All other instances of `font-weight: 500` matched design (except "Possible Issues" 1).

### Possible Issues

1. <details><summary>Tickets Table: Ticket that Requires Reply</summary>

    Unable to find design for this.

    </details>
