### PR TITLE
Task/FP-1067 - Prevent certain table columns from squishing content

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalSelectedTable.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalSelectedTable.js
@@ -60,6 +60,7 @@ const DataFilesSelectedTable = ({ data, operation }) => {
       {
         id: 'status',
         width: 0.15,
+        minWidth: 80,
         Cell: ({ row }) => DataFilesSelectedStatusCell({ row, operation })
       }
     ],

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.scss
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.scss
@@ -31,6 +31,7 @@
 .td {
   padding-left: 15px;
   padding-right: 15px;
+  flex-grow: 1;
 }
 
 /* NOTE: Mimicked on: DataFiles, DataFilesProjectsList, DataFilesProjectFileListing */

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
@@ -36,6 +36,22 @@
   }
 
   tbody {
+    tr {
+      button {
+        white-space: normal;
+      }
+      link {
+        white-space: normal;
+      }
+      .-status {
+        box-sizing: border-box;
+      }
+      .-status td {
+        padding-top: 0.5em;
+        padding-bottom: 0.5em;
+        text-align: center;
+      }
+    }
     tr:not(.-status) td {
       border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     }
@@ -53,16 +69,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-
-    tr.-status {
-      box-sizing: border-box;
-    }
-    tr.-status td {
-      padding-top: 0.5em;
-      padding-bottom: 0.5em;
-
-      text-align: center;
     }
   }
   /* Allow cell width to propogate to common child elements */


### PR DESCRIPTION
## Overview: ##
The Allocations table crushes the "View Team" button when the page width is compressed enough. File listing tables for file upload and file copy had issues where the loading spinner was cut off or squished while the success button could also be cropped as well.

## Related Jira tickets: ##

* [FP-1067](https://jira.tacc.utexas.edu/browse/FP-1067)

## Summary of Changes: ##
I've attached some reference images below to show these changes.
- To fix the issues with the Allocations table button being cut off, I've just made the text wrap to a new line only for button/link elements within the InfiniteScrollTable's body
1. Fixing the issues with the file listings tables within the upload and copy areas, I've set a min-width for the status column
2. I noticed some excess spacing at the end of the columns (I'm not sure if this was intentional) I've set the flex content to grow to the full width of the tr element to avoid having empty spaces at the end

## UI Photos:
1. File Upload Listing and File Copy Listing before:
<img width="398" alt="no-min-width-success" src="https://user-images.githubusercontent.com/29575979/121436484-4a842500-c946-11eb-8661-bbed9a791d48.png">
<img width="425" alt="no-min-width-loading" src="https://user-images.githubusercontent.com/29575979/121436485-4b1cbb80-c946-11eb-9754-46c79b23ecba.png">

1. File Upload Listing and File Copy Listing after:
<img width="398" alt="min-width-loading" src="https://user-images.githubusercontent.com/29575979/121436498-51129c80-c946-11eb-8eb8-c3fde9517cb3.png">
<img width="400" alt="min-width-success" src="https://user-images.githubusercontent.com/29575979/121436502-51129c80-c946-11eb-895d-0f34704e88ca.png">

2. Table row spacing issue before:
<img width="568" alt="no-flex-grow" src="https://user-images.githubusercontent.com/29575979/121436557-6687c680-c946-11eb-9163-8f8577bdd4fa.png">

2. Table row spacing issue after:
<img width="568" alt="flex-grow" src="https://user-images.githubusercontent.com/29575979/121436564-6b4c7a80-c946-11eb-8d9f-986af23b7b3f.png">