### PR TITLE
hotfix: Fix missing `.py` extension on import

### DIFF
--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -25,7 +25,7 @@ def gettext(s): return s  # noqa:E731
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-if os.path.isfile(os.path.join(BASE_DIR, 'settings', 'settings_custom')):
+if os.path.isfile(os.path.join(BASE_DIR, 'settings', 'settings_custom.py')):
     from portal.settings import settings_custom
 else:
     from portal.settings import settings_default as settings_custom


### PR DESCRIPTION
## Overview: ##
Typo on a missing extension on a file lookup in `settings.py` was preventing `settings_custom.py` from ever being loaded.

## Testing Steps: ##
1. Copy and paste `settings_default.py` into `settings_custom.py`
2. Change the value of something testable, like making `_SYSTEM_MONITOR_DISPLAY_LIST` blank `[]`
3. Confirm the setting change propagates on reload
4. Make sure to delete `settings_custom.py` when done testing
