### PR TITLE
Quick: Update docs image tag in docker compose

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -125,7 +125,7 @@ services:
     container_name: core_portal_workers
 
   docs:
-    image: taccwma/frontera-docs:d4b36ba
+    image: taccwma/frontera-docs:0bafe19
     volumes:
       - ../../docs:/docs/site
     command: ["mkdocs", "build"]


### PR DESCRIPTION
## Overview: ##

Update docs image tag commit to latest commit on `dev`.

Alternatively, wait until merge of [dev to master PR](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/18/deploy-changes-from-dev), so we can use post-merge main commit.

## Related Jira tickets: ##

* [FP-1015: Clone Portal Nav](https://jira.tacc.utexas.edu/browse/FP-1015)
* [FP-1047: Set Menu Resize Triggers After AJAX Nav Load](https://jira.tacc.utexas.edu/browse/FP-1047)
* [FP-1092: Show Cortal Icons in Docs Header](https://jira.tacc.utexas.edu/browse/FP-1092)

## Summary of Changes: ##

See [Docs PR #18](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/18/).

## Testing Steps: ##

See https://dev.fronteraweb.tacc.utexas.edu/ (as of 2021-06-15).

## UI Photos:

See "Changes" links in [Docs PR #18](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/18/).

## Notes: ##
