### PR TITLE
Adjust colors of links in Manage Account to match the website's theme.

### DIFF
--- a/client/src/components/ManageAccount/ManageAccountTables.js
+++ b/client/src/components/ManageAccount/ManageAccountTables.js
@@ -224,7 +224,10 @@ export const GoogleDriveIntegrationCell = ({ activated }) => {
     >
       {activated ? (
         <div>
-          <a className="wb-link" href="/accounts/applications/googledrive/disconnect/">
+          <a
+            className="wb-link"
+            href="/accounts/applications/googledrive/disconnect/"
+          >
             Disconnect
           </a>
         </div>
@@ -327,7 +330,12 @@ WebsiteCell.propTypes = {
 };
 WebsiteCell.defaultProps = { cell: { value: '' } };
 const OrcidCell = ({ cell: { value } }) => (
-  <a className="wb-link" href={`https://orchid.org/${value}`} target="_blank" rel="noreferrer">
+  <a
+    className="wb-link"
+    href={`https://orchid.org/${value}`}
+    target="_blank"
+    rel="noreferrer"
+  >
     {value}
   </a>
 );

--- a/client/src/components/ManageAccount/ManageAccountTables.js
+++ b/client/src/components/ManageAccount/ManageAccountTables.js
@@ -224,7 +224,7 @@ export const GoogleDriveIntegrationCell = ({ activated }) => {
     >
       {activated ? (
         <div>
-          <a href="/accounts/applications/googledrive/disconnect/">
+          <a className="wb-link" href="/accounts/applications/googledrive/disconnect/">
             Disconnect
           </a>
         </div>
@@ -315,7 +315,7 @@ const WebsiteCell = ({ cell: { value } }) => {
       ? `https://${website}`
       : website;
     return (
-      <a href={url} target="_blank" rel="noreferrer">
+      <a className="wb-link" href={url} target="_blank" rel="noreferrer">
         {url}
       </a>
     );
@@ -327,7 +327,7 @@ WebsiteCell.propTypes = {
 };
 WebsiteCell.defaultProps = { cell: { value: '' } };
 const OrcidCell = ({ cell: { value } }) => (
-  <a href={`https://orchid.org/${value}`} target="_blank" rel="noreferrer">
+  <a className="wb-link" href={`https://orchid.org/${value}`} target="_blank" rel="noreferrer">
     {value}
   </a>
 );


### PR DESCRIPTION
## Overview: ##
Made links in Manage Account to match the website's theme.

## Related Jira tickets: ##

* [FP-1095](https://jira.tacc.utexas.edu/browse/FP-1095)

## Summary of Changes: ##
Added `wb-link` class to links in `ManageAccountsTable`.

## Testing Steps: ##
1. Check if link colors in Manage Account are the right color.

## UI Photos:
![1](https://user-images.githubusercontent.com/9425579/122444918-a4987200-cf66-11eb-97af-cd55d0c2d677.png)
![2](https://user-images.githubusercontent.com/9425579/122444922-a6623580-cf66-11eb-8321-d41ac44a060a.png)

## Notes: ##
