### PR TITLE
Move setting out of secret

### DIFF
--- a/server/portal/settings/settings_secret.example.py
+++ b/server/portal/settings/settings_secret.example.py
@@ -64,8 +64,6 @@ _ES_HOSTS = 'core_portal_elasticsearch:9200'
 _ES_AUTH = 'username:password'
 _ES_INDEX_PREFIX = 'cep-dev-{}'
 
-_COMMUNITY_INDEX_SCHEDULE = {}
-
 ########################
 # CELERY SETTINGS
 ########################
@@ -77,6 +75,7 @@ _RESULT_BACKEND_DB = '0'
 #######################
 # PROJECTS SETTINGS
 #######################
+
 _PORTAL_PROJECTS_PRIVATE_KEY = ''
 _PORTAL_PROJECTS_PUBLIC_KEY = ''
 


### PR DESCRIPTION
The COMMUNITY_INDEX_SCHEDULE setting is configured in the settings_custom.py file.

## Overview: ##

## Related Jira tickets: ##

* [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)

## Summary of Changes: ##

## Testing Steps: ##
1.

## UI Photos:

## Notes: ##
