### PR TITLE
Bug/FP-1030: Fix breadcrumbs for application page

### DIFF
--- a/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
@@ -307,7 +307,7 @@ const namdFixture = {
     lastModified: '2020-07-02T13:44:46-05:00'
   },
   license: { type: null },
-  appListing: {}
+  appListing: []
 };
 
 export default namdFixture;

--- a/client/src/components/Applications/AppLayout/AppLayout.js
+++ b/client/src/components/Applications/AppLayout/AppLayout.js
@@ -32,11 +32,12 @@ const AppsLayout = () => {
   );
 };
 
-const AppsHeader = appDict => {
+const AppsHeader = categoryDict => {
   const { params } = useRouteMatch();
-  const appMeta = appDict[params.appId];
-  const path = appMeta ? ` / ${appMeta.value.definition.label}` : '';
-
+  const appMeta = Object.values(categoryDict.categoryDict)
+    .flatMap(e => e)
+    .find(car => car.appId === params.appId);
+  const path = appMeta ? ` / ${appMeta.label}` : '';
   return `Applications ${path}`;
 };
 
@@ -44,6 +45,10 @@ const AppsRoutes = () => {
   const { path } = useRouteMatch();
   const dispatch = useDispatch();
   const appDict = useSelector(state => state.apps.appDict, shallowEqual);
+  const categoryDict = useSelector(
+    state => state.apps.categoryDict,
+    shallowEqual
+  );
 
   return (
     <Section
@@ -51,7 +56,7 @@ const AppsRoutes = () => {
       welcomeMessageName="APPLICATIONS"
       header={
         <Route path={`${path}/:appId?`}>
-          <AppsHeader appDict={appDict} />
+          <AppsHeader categoryDict={categoryDict} />
         </Route>
       }
       content={

--- a/client/src/components/Applications/AppLayout/AppLayout.js
+++ b/client/src/components/Applications/AppLayout/AppLayout.js
@@ -36,7 +36,7 @@ const AppsHeader = categoryDict => {
   const { params } = useRouteMatch();
   const appMeta = Object.values(categoryDict.categoryDict)
     .flatMap(e => e)
-    .find(car => car.appId === params.appId);
+    .find(app => app.appId === params.appId);
   const path = appMeta ? ` / ${appMeta.label}` : '';
   return `Applications ${path}`;
 };

--- a/client/src/components/Applications/AppLayout/AppLayout.test.js
+++ b/client/src/components/Applications/AppLayout/AppLayout.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from "redux-mock-store";
+import AppsHeader from "./AppLayout";
+import { MemoryRouter, Route } from 'react-router-dom';
+import systemsFixture from '../../DataFiles/fixtures/DataFiles.systems.fixture';
+import { projectsFixture } from '../../../redux/sagas/fixtures/projects.fixture';
+import filesFixture from '../../DataFiles/fixtures/DataFiles.files.fixture';
+import { appTrayExpectedFixture } from '../../../redux/sagas/fixtures/apptray.fixture';
+import allocationsFixture from '../AppForm/fixtures/AppForm.allocations.fixture';
+import namdFixture from '../AppForm/fixtures/AppForm.app.fixture';
+import { default as jobsFixture } from '../AppForm/fixtures/AppForm.jobs.fixture';
+
+const mockStore = configureStore();
+
+function renderAppsHeader(store, appId) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[`/applications/${appId}`]}>
+        <Route path='/:appId?'>
+          <AppsHeader categoryDict={appTrayExpectedFixture}/>
+        </Route>
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+describe('AppHeader', () => {
+  it('renders breadcrumbs', () => {
+    const store = mockStore({
+      systems: systemsFixture,
+      projects: projectsFixture,
+      jobs: jobsFixture,
+      files: filesFixture,
+      apps: appTrayExpectedFixture,
+      allocations: allocationsFixture,
+      app: {
+        error: {
+          isError: false
+        },
+        ...namdFixture,
+        
+      },
+      pushKeys: {
+        modals: filesFixture.modals,
+        modalProps: filesFixture.modalProps
+      }
+    });
+
+    let {getByText} = renderAppsHeader(store, 'arraytest-0.1');
+    expect(getByText(/Applications \/ Array Test/)).toBeDefined();
+  });
+});

--- a/client/src/components/DataFiles/fixtures/DataFiles.files.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.files.fixture.js
@@ -134,7 +134,8 @@ const filesFixture = {
     rename: {},
     pushKeys: {},
     showpath: {},
-    makePublic: {}
+    makePublic: {},
+    select: {}
   },
   preview: {
     href: '',


### PR DESCRIPTION
## Overview: ##
Made the breadcrumbs for the applications page to properly render.

## Related Jira tickets: ##

* [FP-1030](https://jira.tacc.utexas.edu/browse/FP-123)

## Summary of Changes: ##
Changed `AppLayout.js` to use the correct data to display breadcrumbs. 

## Testing Steps: ##
1. Ensure that the application breadcrumbs show.

## UI Photos:
![20210628143723](https://user-images.githubusercontent.com/9425579/123694173-9710a100-d81e-11eb-9c09-19a36189836e.png)
![20210628143713](https://user-images.githubusercontent.com/9425579/123694179-9972fb00-d81e-11eb-9a48-4af1217c9e30.png)
![20210628143702](https://user-images.githubusercontent.com/9425579/123694181-9aa42800-d81e-11eb-9bdf-52d1f7c4cae2.png)


## Notes: ##
There is a bug with routing to html-type apps (i.e. the vis-portal) when testing locally.
