### PR TITLE
Task/FP-939: Display shared workspace description whitespace.

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
@@ -20,12 +20,13 @@
   padding-top: 0.5em;
   margin-bottom: 1em; /* padding would only be effectual within scrollarea */
   color: #707070;
+  white-space: pre-wrap;
 
   /* FAQ: `14px` is part of normalization of "table" font sizes */
   font-size: 0.875rem; /* 14px (assumed deviation from design) */
 
-  max-height: 10%;
-  overflow-y: scroll;
+  // max-height: 10%;
+  // overflow-y: scroll;
 
   border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
 }

--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
@@ -25,8 +25,8 @@
   /* FAQ: `14px` is part of normalization of "table" font sizes */
   font-size: 0.875rem; /* 14px (assumed deviation from design) */
 
-  // max-height: 10%;
-  // overflow-y: scroll;
+  max-height: 10%;
+  overflow-y: scroll;
 
   border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
 }


### PR DESCRIPTION
## Overview: ##
Made shared workspace descriptions properly render whitespace.

## Related Jira tickets: ##

* [FP-939](https://jira.tacc.utexas.edu/browse/FP-939)

## Summary of Changes: ##
Added style to descriptions to properly render whitespace in shared workspace description.



## Testing Steps: ##
1. Ensure whitespace is properly displayed in shared workspace description.

## UI Photos:
![20210628144635](https://user-images.githubusercontent.com/9425579/123695532-4732d980-d820-11eb-9b9f-fffdc46d06e5.png)

## Notes: ##
