### PR TITLE
Bug/FP-1007: Remove inactive toolbar buttons for public/community/google drive

### DIFF
--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -39,16 +39,16 @@ const DataFilesToolbar = ({ scheme, api }) => {
     )
   );
 
-  const userData =
-    api !== 'googledrive' && scheme !== 'public' && scheme !== 'community';
+  const modifiableUserData =
+    api === 'tapis' && scheme !== 'public' && scheme !== 'community';
 
-  const showMove = userData;
+  const showMove = modifiableUserData;
 
-  const showRename = userData;
+  const showRename = modifiableUserData;
 
-  const showTrash = userData;
+  const showTrash = modifiableUserData;
 
-  const showDownload = api !== 'googledrive';
+  const showDownload = api === 'tapis';
 
   const showMakeLink = useSelector(
     state =>
@@ -59,11 +59,11 @@ const DataFilesToolbar = ({ scheme, api }) => {
   );
 
   const showCompress = !!useSelector(
-    state => state.workbench.config.extractApp && userData
+    state => state.workbench.config.extractApp && modifiableUserData
   );
 
   const showExtract = !!useSelector(
-    state => state.workbench.config.compressApp && userData
+    state => state.workbench.config.compressApp && modifiableUserData
   );
 
   const showMakePublic = useSelector(
@@ -71,7 +71,7 @@ const DataFilesToolbar = ({ scheme, api }) => {
       state.workbench &&
       state.workbench.config.makePublic &&
       api === 'tapis' &&
-      userData
+      modifiableUserData
   );
 
   const toggleRenameModal = () =>

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -39,17 +39,14 @@ const DataFilesToolbar = ({ scheme, api }) => {
     )
   );
 
-  const showMove = useSelector(
-    () => api !== 'googledrive' && scheme !== 'public' && scheme !== 'community'
-  );
+  const publicData =
+    api !== 'googledrive' && scheme !== 'public' && scheme !== 'community';
 
-  const showRename = useSelector(
-    () => api !== 'googledrive' && scheme !== 'public' && scheme !== 'community'
-  );
+  const showMove = useSelector(() => publicData);
 
-  const showTrash = useSelector(
-    () => api !== 'googledrive' && scheme !== 'public' && scheme !== 'community'
-  );
+  const showRename = useSelector(() => publicData);
+
+  const showTrash = useSelector(() => publicData);
 
   const showDownload = useSelector(() => api !== 'googledrive');
 
@@ -62,19 +59,11 @@ const DataFilesToolbar = ({ scheme, api }) => {
   );
 
   const showCompress = !!useSelector(
-    state =>
-      state.workbench.config.extractApp &&
-      api !== 'googledrive' &&
-      scheme !== 'public' &&
-      scheme !== 'community'
+    state => state.workbench.config.extractApp && publicData
   );
 
   const showExtract = !!useSelector(
-    state =>
-      state.workbench.config.compressApp &&
-      api !== 'googledrive' &&
-      scheme !== 'public' &&
-      scheme !== 'community'
+    state => state.workbench.config.compressApp && publicData
   );
 
   const showMakePublic = useSelector(
@@ -82,8 +71,7 @@ const DataFilesToolbar = ({ scheme, api }) => {
       state.workbench &&
       state.workbench.config.makePublic &&
       api === 'tapis' &&
-      scheme !== 'public' &&
-      scheme !== 'community'
+      publicData
   );
 
   const toggleRenameModal = () =>

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -39,6 +39,20 @@ const DataFilesToolbar = ({ scheme, api }) => {
     )
   );
 
+  const showMove = useSelector(
+    () => api !== 'googledrive' && scheme !== 'public' && scheme !== 'community'
+  );
+
+  const showRename = useSelector(
+    () => api !== 'googledrive' && scheme !== 'public' && scheme !== 'community'
+  );
+
+  const showTrash = useSelector(
+    () => api !== 'googledrive' && scheme !== 'public' && scheme !== 'community'
+  );
+
+  const showDownload = useSelector(() => api !== 'googledrive');
+
   const showMakeLink = useSelector(
     state =>
       state.workbench &&
@@ -48,15 +62,28 @@ const DataFilesToolbar = ({ scheme, api }) => {
   );
 
   const showCompress = !!useSelector(
-    state => state.workbench.config.extractApp
+    state =>
+      state.workbench.config.extractApp &&
+      api !== 'googledrive' &&
+      scheme !== 'public' &&
+      scheme !== 'community'
   );
 
   const showExtract = !!useSelector(
-    state => state.workbench.config.compressApp
+    state =>
+      state.workbench.config.compressApp &&
+      api !== 'googledrive' &&
+      scheme !== 'public' &&
+      scheme !== 'community'
   );
+
   const showMakePublic = useSelector(
     state =>
-      state.workbench && state.workbench.config.makePublic && api === 'tapis'
+      state.workbench &&
+      state.workbench.config.makePublic &&
+      api === 'tapis' &&
+      scheme !== 'public' &&
+      scheme !== 'community'
   );
 
   const toggleRenameModal = () =>
@@ -182,30 +209,36 @@ const DataFilesToolbar = ({ scheme, api }) => {
             disabled={!canCompress}
           />
         )}
-        <ToolbarButton
-          text="Rename"
-          onClick={toggleRenameModal}
-          iconName="rename"
-          disabled={!canRename}
-        />
-        <ToolbarButton
-          text="Move"
-          onClick={toggleMoveModal}
-          iconName="move"
-          disabled={!canMove}
-        />
+        {showRename && (
+          <ToolbarButton
+            text="Rename"
+            onClick={toggleRenameModal}
+            iconName="rename"
+            disabled={!canRename}
+          />
+        )}
+        {showMove && (
+          <ToolbarButton
+            text="Move"
+            onClick={toggleMoveModal}
+            iconName="move"
+            disabled={!canMove}
+          />
+        )}
         <ToolbarButton
           text="Copy"
           onClick={toggleCopyModal}
           iconName="copy"
           disabled={!canCopy}
         />
-        <ToolbarButton
-          text="Download"
-          iconName="download"
-          onClick={download}
-          disabled={!canDownload && !isFolderSelected}
-        />
+        {showDownload && (
+          <ToolbarButton
+            text="Download"
+            iconName="download"
+            onClick={download}
+            disabled={!canDownload && !isFolderSelected}
+          />
+        )}
         {showMakeLink && (
           <ToolbarButton
             text="Link"
@@ -222,12 +255,14 @@ const DataFilesToolbar = ({ scheme, api }) => {
             disabled={!canMakePublic}
           />
         )}
-        <ToolbarButton
-          text="Trash"
-          iconName="trash"
-          onClick={trash}
-          disabled={!canTrash}
-        />
+        {showTrash && (
+          <ToolbarButton
+            text="Trash"
+            iconName="trash"
+            onClick={trash}
+            disabled={!canTrash}
+          />
+        )}
       </div>
     </>
   );

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -39,16 +39,16 @@ const DataFilesToolbar = ({ scheme, api }) => {
     )
   );
 
-  const publicData =
+  const userData =
     api !== 'googledrive' && scheme !== 'public' && scheme !== 'community';
 
-  const showMove = useSelector(() => publicData);
+  const showMove = userData;
 
-  const showRename = useSelector(() => publicData);
+  const showRename = userData;
 
-  const showTrash = useSelector(() => publicData);
+  const showTrash = userData;
 
-  const showDownload = useSelector(() => api !== 'googledrive');
+  const showDownload = api !== 'googledrive';
 
   const showMakeLink = useSelector(
     state =>
@@ -59,11 +59,11 @@ const DataFilesToolbar = ({ scheme, api }) => {
   );
 
   const showCompress = !!useSelector(
-    state => state.workbench.config.extractApp && publicData
+    state => state.workbench.config.extractApp && userData
   );
 
   const showExtract = !!useSelector(
-    state => state.workbench.config.compressApp && publicData
+    state => state.workbench.config.compressApp && userData
   );
 
   const showMakePublic = useSelector(
@@ -71,7 +71,7 @@ const DataFilesToolbar = ({ scheme, api }) => {
       state.workbench &&
       state.workbench.config.makePublic &&
       api === 'tapis' &&
-      publicData
+      userData
   );
 
   const toggleRenameModal = () =>

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.js
@@ -46,10 +46,8 @@ describe('DataFilesToolbar', () => {
     expect(getByText(/Trash/)).toBeDefined();
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
-});
 
-describe('DataFilesToolbar', () => {
-  it('do not render unnecessary buttons in Community Data', () => {
+  it('does not render unnecessary buttons in Community Data', () => {
     const {getByText, queryByText} = renderComponent(
       <DataFilesToolbar scheme="community" api="tapis" />,
       mockStore({
@@ -71,10 +69,7 @@ describe('DataFilesToolbar', () => {
     expect(queryByText(/Trash/)).toBeFalsy();
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
-});
 
-
-describe('DataFilesToolbar', () => {
   it('do not render unnecessary buttons in Public Data', () => {
     const {getByText, queryByText} = renderComponent(
       <DataFilesToolbar scheme="public" api="tapis" />,
@@ -97,9 +92,7 @@ describe('DataFilesToolbar', () => {
     expect(queryByText(/Trash/)).toBeFalsy();
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
-});
 
-describe('DataFilesToolbar', () => {
   it('do not render unnecessary buttons in Google Drive', () => {
     const {getByText, queryByText} = renderComponent(
       <DataFilesToolbar scheme="private" api="googledrive" />,
@@ -122,10 +115,7 @@ describe('DataFilesToolbar', () => {
     expect(queryByText(/Trash/)).toBeFalsy();
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
-});
 
-
-describe('DataFilesToolbar', () => {
   it('render Make Public button', () => {
     const { getByText } = renderComponent(
       <DataFilesToolbar scheme="private" api="tapis" />,

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.js
@@ -10,7 +10,7 @@ const mockStore = configureStore();
 expect.extend({ toHaveClass });
 describe('ToolbarButton', () => {
   const store = mockStore({});
-  it('render button with correct text', () => {
+  it('renders button with correct text', () => {
     const { getByText, getByRole, getByTestId } = renderComponent(
       <ToolbarButton text="Rename" iconName="rename" onClick={() => {}} />,
       store,
@@ -24,7 +24,7 @@ describe('ToolbarButton', () => {
 });
 
 describe('DataFilesToolbar', () => {
-  it('render necessary buttons', () => {
+  it('renders necessary buttons', () => {
     const { getByText, queryByText } = renderComponent(
       <DataFilesToolbar scheme="private" api="tapis" />,
       mockStore({
@@ -70,7 +70,7 @@ describe('DataFilesToolbar', () => {
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
 
-  it('do not render unnecessary buttons in Public Data', () => {
+  it('does not render unnecessary buttons in Public Data', () => {
     const {getByText, queryByText} = renderComponent(
       <DataFilesToolbar scheme="public" api="tapis" />,
       mockStore({
@@ -93,7 +93,7 @@ describe('DataFilesToolbar', () => {
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
 
-  it('do not render unnecessary buttons in Google Drive', () => {
+  it('does not render unnecessary buttons in Google Drive', () => {
     const {getByText, queryByText} = renderComponent(
       <DataFilesToolbar scheme="private" api="googledrive" />,
       mockStore({
@@ -116,7 +116,7 @@ describe('DataFilesToolbar', () => {
     expect(queryByText(/Make Public/)).toBeFalsy();
   });
 
-  it('render Make Public button', () => {
+  it('renders Make Public button', () => {
     const { getByText } = renderComponent(
       <DataFilesToolbar scheme="private" api="tapis" />,
       mockStore({

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.js
@@ -49,6 +49,83 @@ describe('DataFilesToolbar', () => {
 });
 
 describe('DataFilesToolbar', () => {
+  it('do not render unnecessary buttons in Community Data', () => {
+    const {getByText, queryByText} = renderComponent(
+      <DataFilesToolbar scheme="community" api="tapis" />,
+      mockStore({
+        workbench: { config: {
+          extract: '',
+          compress: ''
+        } },
+        files: { selected: { FilesListing: [] } },
+        listing: { selected: { FilesListing: [] } },
+        systems: systemsFixture
+      }),
+      createMemoryHistory()
+    );
+
+    expect(queryByText(/Rename/)).toBeFalsy();
+    expect(queryByText(/Move/)).toBeFalsy();
+    expect(getByText(/Copy/)).toBeDefined();
+    expect(getByText(/Download/)).toBeDefined();
+    expect(queryByText(/Trash/)).toBeFalsy();
+    expect(queryByText(/Make Public/)).toBeFalsy();
+  });
+});
+
+
+describe('DataFilesToolbar', () => {
+  it('do not render unnecessary buttons in Public Data', () => {
+    const {getByText, queryByText} = renderComponent(
+      <DataFilesToolbar scheme="public" api="tapis" />,
+      mockStore({
+        workbench: { config: {
+          extract: '',
+          compress: ''
+        } },
+        files: { selected: { FilesListing: [] } },
+        listing: { selected: { FilesListing: [] } },
+        systems: systemsFixture
+      }),
+      createMemoryHistory()
+    );
+
+    expect(queryByText(/Rename/)).toBeFalsy();
+    expect(queryByText(/Move/)).toBeFalsy();
+    expect(getByText(/Copy/)).toBeDefined();
+    expect(getByText(/Download/)).toBeDefined();
+    expect(queryByText(/Trash/)).toBeFalsy();
+    expect(queryByText(/Make Public/)).toBeFalsy();
+  });
+});
+
+describe('DataFilesToolbar', () => {
+  it('do not render unnecessary buttons in Google Drive', () => {
+    const {getByText, queryByText} = renderComponent(
+      <DataFilesToolbar scheme="private" api="googledrive" />,
+      mockStore({
+        workbench: { config: {
+          extract: '',
+          compress: ''
+        } },
+        files: { selected: { FilesListing: [] } },
+        listing: { selected: { FilesListing: [] } },
+        systems: systemsFixture
+      }),
+      createMemoryHistory()
+    );
+
+    expect(queryByText(/Rename/)).toBeFalsy();
+    expect(queryByText(/Move/)).toBeFalsy();
+    expect(getByText(/Copy/)).toBeDefined();
+    expect(queryByText(/Download/)).toBeFalsy();
+    expect(queryByText(/Trash/)).toBeFalsy();
+    expect(queryByText(/Make Public/)).toBeFalsy();
+  });
+});
+
+
+describe('DataFilesToolbar', () => {
   it('render Make Public button', () => {
     const { getByText } = renderComponent(
       <DataFilesToolbar scheme="private" api="tapis" />,


### PR DESCRIPTION
## Overview: ##
Removes unused/disabled buttons in Public/Community/Google Drive.

## Related Jira tickets: ##

* [FP-1007](https://jira.tacc.utexas.edu/browse/FP-1007)

## Summary of Changes: ##
Added additional `show*` conditions for each toolbar button component.

## Testing Steps: ##
1. Route to Community Data, Google Drive, and Public Data to ensure that the unused toolbar buttons are disabled.

## UI Photos:
![20210628161405](https://user-images.githubusercontent.com/9425579/123705068-0e006680-d82c-11eb-822b-96e137db2608.png)
![20210628161411](https://user-images.githubusercontent.com/9425579/123705073-0fca2a00-d82c-11eb-8257-825a22b9edfa.png)
![20210628161419](https://user-images.githubusercontent.com/9425579/123705079-10fb5700-d82c-11eb-8971-2d1211f37a29.png)

## Notes: ##
