### PR TITLE
bug/FP-1108: Fix HTML App Loading

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -102,10 +102,10 @@ const AppDetail = () => {
 
   return (
     <>
-      {!app && <AppPlaceholder apps={hasApps} />}
-      {app.appType === 'html' ? (
+      {!app.definition && <AppPlaceholder apps={hasApps} />}
+      {app.definition.appType === 'html' ? (
         <div id="appDetail-wrapper" className="has-external-app">
-          {parse(app.html)}
+          {parse(app.definition.html)}
         </div>
       ) : (
         <div id="appDetail-wrapper" className="has-internal-app">
@@ -403,11 +403,8 @@ export const AppSchemaForm = ({ app }) => {
           ) {
             setSubmitting(false);
             resetForm(initialValues);
-            const formTop = document.getElementById('appForm-wrapper');
-            formTop.scrollTo({
-              top: 0,
-              behavior: 'smooth'
-            });
+            const formTop = document.getElementById('appBrowser-wrapper');
+            formTop.scrollIntoView({ behavior: 'smooth' });
             dispatch({ type: 'TOGGLE_SUBMITTING' });
           }
           const readOnly =

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -574,5 +574,3 @@ export const AppSchemaForm = ({ app }) => {
 AppSchemaForm.propTypes = {
   app: appShape.isRequired
 };
-
-export default AppDetail;

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -66,7 +66,7 @@ AppPlaceholder.propTypes = {
   apps: PropTypes.bool.isRequired
 };
 
-const AppDetail = () => {
+export const AppDetail = () => {
   const { app, allocationsLoading } = useSelector(
     state => ({
       app: state.app,

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -2,11 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { AppSchemaForm } from './AppForm';
+import { AppSchemaForm, AppDetail } from './AppForm';
 import { default as allocationsFixture } from './fixtures/AppForm.allocations.fixture';
 import { default as jobsFixture } from './fixtures/AppForm.jobs.fixture';
 import { default as namdFixture } from './fixtures/AppForm.app.fixture';
+import { appTrayFixture, appTrayExpectedFixture } from '../../../redux/sagas/fixtures/apptray.fixture';
+import { initialAppState } from '../../../redux/reducers/apps.reducers';
 import systemsFixture from '../../DataFiles/fixtures/DataFiles.systems.fixture';
+import renderComponent from 'utils/testing';
 import '@testing-library/jest-dom/extend-expect';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -58,9 +61,9 @@ describe('AppSchemaForm', () => {
     const { getByText } = renderAppSchemaFormComponent(store, {
       ...namdFixture,
       exec_sys: {
-        ...namdFixture.exec_sys, 
+        ...namdFixture.exec_sys,
         login: {
-          ...namdFixture.exec_sys.login, 
+          ...namdFixture.exec_sys.login,
           host: 'login1.frontera.tacc.utexas.edu'
         }
       }
@@ -75,9 +78,9 @@ describe('AppSchemaForm', () => {
     const { getByText } = renderAppSchemaFormComponent(store, {
       ...namdFixture,
       exec_sys: {
-        ...namdFixture.exec_sys, 
+        ...namdFixture.exec_sys,
         login: {
-          ...namdFixture.exec_sys.login, 
+          ...namdFixture.exec_sys.login,
           host: 'invalid_system_frontera.tacc.utexas.edu'
         }
       }
@@ -107,5 +110,17 @@ describe('AppSchemaForm', () => {
       ...namdFixture
     });
     expect(getByText(/There was a problem accessing your default My Data file system/)).toBeDefined();
+  });
+});
+
+describe('AppDetail', () => {
+  it('renders an html app', () => {
+    const store = mockStore({
+      allocations: { loading: false },
+      app: { ...initialAppState, definition: { ...appTrayFixture.definitions['vis-portal'] }},
+      apps: { ...appTrayExpectedFixture }
+    });
+    const { getByText } = renderComponent(<AppDetail />, store);
+    expect(getByText(/The TACC Visualization Portal allows simple access to TACC/)).toBeDefined();
   });
 });

--- a/client/src/components/Applications/AppLayout/AppLayout.js
+++ b/client/src/components/Applications/AppLayout/AppLayout.js
@@ -4,7 +4,7 @@ import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { LoadingSpinner, Section } from '_common';
 import './AppLayout.global.css';
 import AppBrowser from '../AppBrowser/AppBrowser';
-import AppDetail, { AppPlaceholder } from '../AppForm/AppForm';
+import { AppDetail, AppPlaceholder } from '../AppForm/AppForm';
 
 const AppsLayout = () => {
   const { params } = useRouteMatch();

--- a/client/src/components/Applications/AppLayout/AppLayout.js
+++ b/client/src/components/Applications/AppLayout/AppLayout.js
@@ -44,6 +44,10 @@ const AppsRoutes = () => {
   const { path } = useRouteMatch();
   const dispatch = useDispatch();
   const appDict = useSelector(state => state.apps.appDict, shallowEqual);
+  const categoryDict = useSelector(
+    state => state.apps.categoryDict,
+    shallowEqual
+  );
 
   return (
     <Section
@@ -59,7 +63,7 @@ const AppsRoutes = () => {
           <Route path={`${path}/:appId?`}>
             <AppsLayout />
           </Route>
-          {Object.keys(appDict).length ? (
+          {Object.keys(categoryDict).length ? (
             <Route
               exact
               path={`${path}/:appId`}

--- a/client/src/components/Applications/AppLayout/AppLayout.js
+++ b/client/src/components/Applications/AppLayout/AppLayout.js
@@ -68,7 +68,7 @@ const AppsRoutes = () => {
                 if (appDef && 'html' in appDef) {
                   dispatch({
                     type: 'LOAD_APP',
-                    payload: appDict[params.appId]
+                    payload: { definition: appDict[params.appId] }
                   });
                 } else {
                   dispatch({

--- a/client/src/redux/reducers/apps.reducers.js
+++ b/client/src/redux/reducers/apps.reducers.js
@@ -59,19 +59,17 @@ export function apps(state = initialState, action) {
   }
 }
 
-export function app(
-  state = {
-    definition: {},
-    error: { isError: false },
-    loading: false,
-    systemHasKeys: true,
-    pushKeysSystem: {},
-    exec_sys: {},
-    license: {},
-    appListing: []
-  },
-  action
-) {
+export const initialAppState = {
+  definition: {},
+  error: { isError: false },
+  loading: false,
+  systemHasKeys: true,
+  pushKeysSystem: {},
+  exec_sys: {},
+  license: {},
+  appListing: []
+};
+export function app(state = initialAppState, action) {
   switch (action.type) {
     case 'LOAD_APP':
       return {

--- a/client/src/redux/sagas/fixtures/apptray.fixture.js
+++ b/client/src/redux/sagas/fixtures/apptray.fixture.js
@@ -71,6 +71,7 @@ export const appTrayFixture = {
   ],
   definitions: {
     'vis-portal': {
+      appType: 'html',
       html:
         '<div class="jumbotron text-center"> <h2>TACC Visualization Portal</h2> <p> The TACC Visualization Portal allows simple access to TACC\'s vis resources, including remote, interactive web-based access to Stampede2, Frontera, and Wrangler. Launch iPython, Jupyter, and R Studio sessions and more.</p><p><a class="btn btn-lg btn-primary" href="https://vis.tacc.utexas.edu/" target="_blank">Launch</a></p></div>',
       id: 'vis-portal',

--- a/client/src/redux/sagas/fixtures/apptray.fixture.js
+++ b/client/src/redux/sagas/fixtures/apptray.fixture.js
@@ -141,6 +141,7 @@ export const appTrayExpectedFixture = {
   },
   appDict: {
     'vis-portal': {
+      appType: 'html',
       html:
         '<div class="jumbotron text-center"> <h2>TACC Visualization Portal</h2> <p> The TACC Visualization Portal allows simple access to TACC\'s vis resources, including remote, interactive web-based access to Stampede2, Frontera, and Wrangler. Launch iPython, Jupyter, and R Studio sessions and more.</p><p><a class="btn btn-lg btn-primary" href="https://vis.tacc.utexas.edu/" target="_blank">Launch</a></p></div>',
       id: 'vis-portal',


### PR DESCRIPTION
## Overview: ##
In the app definition refactor, we missed a spot in order to load html apps.

Also fixes scrolling to the top of the apps page after job submission.

## Related Jira tickets: ##

* [FP-1108](https://jira.tacc.utexas.edu/browse/FP-1108)

## Testing Steps: ##
1. Make sure you have the Vis Portal app in the Visualization tab, or run `./manage.py import-apps` in the `core_portal_django` container
2. Go to https://cep.tacc.utexas.edu/workbench/applications/vis-portal and make sure you can load it

## Notes:
- [x] TODO: Fix Unit tests