### PR TITLE
task/FP-952: Replace Django Messages with Client Side Messages

### DIFF
--- a/client/src/components/ManageAccount/ManageAccount.js
+++ b/client/src/components/ManageAccount/ManageAccount.js
@@ -32,14 +32,16 @@ const ManageAccountView = () => {
     dispatch({ type: 'GET_PROFILE_DATA' });
   }, [dispatch, isLoading]);
   return (
-
-      !isLoading && integrations[0].error_message && (
-               <Alert color="danger">{integrations[0].error_message}</Alert>
-            )
     <Section
       bodyClassName="has-loaded-account"
       welcomeMessageName="ACCOUNT"
       header="Manage Account"
+      messages={
+        !isLoading &&
+        integrations[0].error_message && (
+          <Alert color="danger">{integrations[0].error_message}</Alert>
+        )
+      }
       headerActions={
         <Link to="/workbench/dashboard" className="wb-link">
           Back to Dashboard
@@ -52,9 +54,6 @@ const ManageAccountView = () => {
           <>
             {errors.data && (
               <Alert color="danger">Unable to get your profile data</Alert>
-            )}
-            {integrations[0].error_message && (
-              <Alert color="danger">{integrations[0].error_message}</Alert>
             )}
             {errors.fields && (
               <Alert color="danger">Unable to get form fields</Alert>

--- a/client/src/components/ManageAccount/ManageAccount.js
+++ b/client/src/components/ManageAccount/ManageAccount.js
@@ -32,6 +32,10 @@ const ManageAccountView = () => {
     dispatch({ type: 'GET_PROFILE_DATA' });
   }, [dispatch, isLoading]);
   return (
+
+      !isLoading && integrations[0].error_message && (
+               <Alert color="danger">{integrations[0].error_message}</Alert>
+            )
     <Section
       bodyClassName="has-loaded-account"
       welcomeMessageName="ACCOUNT"
@@ -48,6 +52,9 @@ const ManageAccountView = () => {
           <>
             {errors.data && (
               <Alert color="danger">Unable to get your profile data</Alert>
+            )}
+            {integrations[0].error_message && (
+              <Alert color="danger">{integrations[0].error_message}</Alert>
             )}
             {errors.fields && (
               <Alert color="danger">Unable to get form fields</Alert>

--- a/client/src/components/ManageAccount/ManageAccount.js
+++ b/client/src/components/ManageAccount/ManageAccount.js
@@ -20,6 +20,7 @@ import {
 import './ManageAccount.scss';
 import './ManageAccount.global.css';
 import './ManageAccount.module.css';
+import { GOOGLE_DRIVE_SETUP_ERROR } from '../../constants/messages';
 
 const ManageAccountView = () => {
   const {
@@ -38,8 +39,8 @@ const ManageAccountView = () => {
       header="Manage Account"
       messages={
         !isLoading &&
-        integrations[0].error_message && (
-          <Alert color="danger">{integrations[0].error_message}</Alert>
+        integrations[0].error === 'SETUP_ERROR' && (
+          <Alert color="danger">{GOOGLE_DRIVE_SETUP_ERROR}</Alert>
         )
       }
       headerActions={

--- a/client/src/components/ManageAccount/ManageAccount.js
+++ b/client/src/components/ManageAccount/ManageAccount.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert } from 'reactstrap';
 import { isEmpty } from 'lodash';
-import { LoadingSpinner, Section } from '_common';
+import { LoadingSpinner, Section, SectionMessage } from '_common';
 import {
   RequiredInformation,
   ChangePassword,
@@ -40,7 +40,9 @@ const ManageAccountView = () => {
       messages={
         !isLoading &&
         integrations[0].error === 'SETUP_ERROR' && (
-          <Alert color="danger">{GOOGLE_DRIVE_SETUP_ERROR}</Alert>
+          <SectionMessage type="warning" canDismiss>
+            {GOOGLE_DRIVE_SETUP_ERROR}
+          </SectionMessage>
         )
       }
       headerActions={

--- a/client/src/components/Workbench/Workbench.test.js
+++ b/client/src/components/Workbench/Workbench.test.js
@@ -17,7 +17,7 @@ import { initialState as systemMonitor } from '../../redux/reducers/systemMonito
 import { initialWelcomeMessages as welcomeMessages } from '../../redux/reducers/welcome.reducers';
 import { initialSystemState as systems } from '../../redux/reducers/datafiles.reducers';
 
-import * as welcomeMessageText from '../../constants/welcomeMessages';
+import * as welcomeMessageText from '../../constants/messages';
 
 /* state required to render workbench/dashboard */
 const state = {

--- a/client/src/components/_common/Section/SectionMessages.js
+++ b/client/src/components/_common/Section/SectionMessages.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { WelcomeMessage, isKnownWelcomeMessage } from '_common';
-import * as MESSAGES from '../../../constants/welcomeMessages';
+import * as MESSAGES from '../../../constants/messages';
 
 import './SectionMessages.module.css';
 import './SectionMessages.css';

--- a/client/src/components/_common/Section/SectionMessages.test.js
+++ b/client/src/components/_common/Section/SectionMessages.test.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { Alert } from 'reactstrap';
 
 import SectionMessages from './SectionMessages';
-import * as MESSAGES from '../../../constants/welcomeMessages';
+import * as MESSAGES from '../../../constants/messages';
 
 const mockStore = configureStore();
 const store = mockStore({});

--- a/client/src/constants/messages.js
+++ b/client/src/constants/messages.js
@@ -1,3 +1,4 @@
+import React from 'react';
 /**
  * Standard welcome message texts
  *
@@ -20,3 +21,9 @@ export const TICKETS =
   'This page allows you to submit a help request via an RT Ticket.';
 export const UI =
   'This hidden page allows developers to review UI components in isolation.';
+export const GOOGLE_DRIVE_SETUP_ERROR = (
+  <span>
+    An error occurred setting up Google Drive. For help,{' '}
+    <a href="/workbench/dashboard/tickets/create">submit a ticket</a>.
+  </span>
+);

--- a/server/portal/apps/accounts/integrations.py
+++ b/server/portal/apps/accounts/integrations.py
@@ -6,13 +6,13 @@ logger = logging.getLogger(__name__)
 INTEGRATION_APPS = ['portal.apps.googledrive_integration']
 
 
-def get_integrations(user):
+def get_integrations(request):
     app_integrations = []
 
     for app in INTEGRATION_APPS:
         try:
             mod = import_module('{}.integrations'.format(app))
-            app_integrations += mod.provide_integrations(user)
+            app_integrations += mod.provide_integrations(request)
 
         except Exception as exc:
             logger.warning('Call to module.provide_integrations fail for module: {app_name}. {exc}'

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -118,7 +118,7 @@ def manage_licenses(request):
 
 @login_required
 def manage_integrations(request):
-    return integrations.get_integrations(request.user)
+    return integrations.get_integrations(request)
 
 
 @login_required

--- a/server/portal/apps/googledrive_integration/integrations.py
+++ b/server/portal/apps/googledrive_integration/integrations.py
@@ -2,18 +2,24 @@ from django.conf import settings
 from portal.apps.googledrive_integration.models import GoogleDriveUserToken
 
 
-def provide_integrations(user):
+def provide_integrations(request):
     activated = False
+    error = False
+    error_message = 'Hello error message'
+
     try:
-        user.googledrive_user_token
+        request.user.googledrive_user_token
         activated = True
     except GoogleDriveUserToken.DoesNotExist:
+        if 'googledrive_error' in request.session:
+            error_message = request.session.pop('googledrive_error')
         pass
 
     integration = {
         'label': 'Google Drive',
         'description': 'Access files from your Google Drive account in {}.'.format(settings.PORTAL_NAMESPACE),
-        'activated': activated
+        'activated': activated,
+        'error_message': error_message
     },
 
     return integration

--- a/server/portal/apps/googledrive_integration/integrations.py
+++ b/server/portal/apps/googledrive_integration/integrations.py
@@ -1,18 +1,18 @@
 from django.conf import settings
 from portal.apps.googledrive_integration.models import GoogleDriveUserToken
-
+from django.core.cache import cache
 
 def provide_integrations(request):
     activated = False
     error = False
-    error_message = 'Hello error message'
+    error_message = ''
 
     try:
         request.user.googledrive_user_token
         activated = True
     except GoogleDriveUserToken.DoesNotExist:
-        if 'googledrive_error' in request.session:
-            error_message = request.session.pop('googledrive_error')
+        if cache.get('{0}_googledrive_error'.format(request.session.session_key), False):
+            error_message = cache.get('{0}_googledrive_error'.format(request.session.session_key))
         pass
 
     integration = {

--- a/server/portal/apps/googledrive_integration/integrations.py
+++ b/server/portal/apps/googledrive_integration/integrations.py
@@ -4,22 +4,21 @@ from django.core.cache import cache
 
 def provide_integrations(request):
     activated = False
-    error = False
-    error_message = ''
+    error = ''
 
     try:
         request.user.googledrive_user_token
         activated = True
     except GoogleDriveUserToken.DoesNotExist:
         if cache.get('{0}_googledrive_error'.format(request.session.session_key), False):
-            error_message = cache.get('{0}_googledrive_error'.format(request.session.session_key))
+            error = cache.get('{0}_googledrive_error'.format(request.session.session_key))
         pass
 
     integration = {
         'label': 'Google Drive',
         'description': 'Access files from your Google Drive account in {}.'.format(settings.PORTAL_NAMESPACE),
         'activated': activated,
-        'error_message': error_message
+        'error': error
     },
 
     return integration

--- a/server/portal/apps/googledrive_integration/views.py
+++ b/server/portal/apps/googledrive_integration/views.py
@@ -8,6 +8,7 @@ from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import TemplateView
 from portal.apps.googledrive_integration.models import GoogleDriveUserToken
+from django.core.cache import cache
 
 import logging
 logger = logging.getLogger(__name__)
@@ -57,21 +58,19 @@ def initialize_token(request):
 @csrf_exempt
 @login_required
 def oauth2_callback(request):
+    error_message = 'An unexpected error occurred during Google Drive setup.'
+    error_timeout = 5
     state = request.GET.get('state')
-    if 'googledrivers' in request.session:
-        googledrive = request.session['googledriveer']
+    if 'googledrive' in request.session:
+        googledrive = request.session['googledrive']
     else:
-        logger.error("Error getting googledrive state")
-        request.session['googledrive_error'] = \
-                    'Oh no! An unexpected error occurred while trying to set up the Google Drive application. Please try again.'
-        # messages.error(request, 'Oh no! An unexpected error occurred while trying to set '
-        #                         'up the Google Drive application. Please try again.')
+        logger.error('Could not retrieve googledrive from session')
+        cache.set('{0}_googledrive_error'.format(request.session.session_key), error_message, error_timeout)
         return HttpResponseRedirect('/accounts/profile')
 
     if not (state == googledrive['state']):
-        logger.info("(state == googledrive['state']):  **********************************************")
-        request.session['googledrive_error'] = \
-                    'Oh no! An unexpected error occurred while trying to set up the Google Drive application. Please try again.'
+        logger.error('Could not retrieve state from googledrive stored var')
+        cache.set('{0}_googledrive_error'.format(request.session.session_key), error_message, error_timeout)
         return HttpResponseRedirect('/accounts/profile')
 
     try:
@@ -92,7 +91,7 @@ def oauth2_callback(request):
             # Auth flow completed previously, and no refresh_token granted. Need to disconnect to get
             # another refresh_token.
 
-            logger.debug('GoogleDriveUserToken refresh_token cannot be null, revoking previous access and restart flow.')
+            logger.error('GoogleDriveUserToken refresh_token cannot be null, revoking previous access and restart flow.')
             requests.post('https://accounts.google.com/o/oauth2/revoke',
                           params={'token': credentials.token},
                           headers={'content-type': 'application/x-www-form-urlencoded'})
@@ -106,11 +105,9 @@ def oauth2_callback(request):
 
     except Exception as e:
         logger.exception('Unable to complete Google Drive integration setup: %s' % e)
-        request.session['googledrive_error'] = \
-                    'Oh no! An unexpected error occurred while trying to set up the Google Drive application. Please try again.'
+        cache.set('{0}_googledrive_error'.format(request.session.session_key), error_message, error_timeout)
 
     return HttpResponseRedirect('/accounts/profile')
-
 
 @login_required
 def disconnect(request):

--- a/server/portal/apps/googledrive_integration/views.py
+++ b/server/portal/apps/googledrive_integration/views.py
@@ -58,19 +58,19 @@ def initialize_token(request):
 @csrf_exempt
 @login_required
 def oauth2_callback(request):
-    error_message = 'An unexpected error occurred during Google Drive setup.'
+    error = 'SETUP_ERROR'
     error_timeout = 5
     state = request.GET.get('state')
     if 'googledrive' in request.session:
         googledrive = request.session['googledrive']
     else:
         logger.error('Could not retrieve googledrive from session')
-        cache.set('{0}_googledrive_error'.format(request.session.session_key), error_message, error_timeout)
+        cache.set('{0}_googledrive_error'.format(request.session.session_key), error, error_timeout)
         return HttpResponseRedirect('/accounts/profile')
 
     if not (state == googledrive['state']):
         logger.error('Could not retrieve state from googledrive stored var')
-        cache.set('{0}_googledrive_error'.format(request.session.session_key), error_message, error_timeout)
+        cache.set('{0}_googledrive_error'.format(request.session.session_key), error, error_timeout)
         return HttpResponseRedirect('/accounts/profile')
 
     try:
@@ -105,7 +105,7 @@ def oauth2_callback(request):
 
     except Exception as e:
         logger.exception('Unable to complete Google Drive integration setup: %s' % e)
-        cache.set('{0}_googledrive_error'.format(request.session.session_key), error_message, error_timeout)
+        cache.set('{0}_googledrive_error'.format(request.session.session_key), error, error_timeout)
 
     return HttpResponseRedirect('/accounts/profile')
 

--- a/server/portal/apps/googledrive_integration/views.py
+++ b/server/portal/apps/googledrive_integration/views.py
@@ -58,16 +58,20 @@ def initialize_token(request):
 @login_required
 def oauth2_callback(request):
     state = request.GET.get('state')
-    if 'googledrive' in request.session:
-        googledrive = request.session['googledrive']
+    if 'googledrivers' in request.session:
+        googledrive = request.session['googledriveer']
     else:
-        messages.error(request, 'Oh no! An unexpected error occurred while trying to set '
-                                'up the Google Drive application. Please try again.')
+        logger.error("Error getting googledrive state")
+        request.session['googledrive_error'] = \
+                    'Oh no! An unexpected error occurred while trying to set up the Google Drive application. Please try again.'
+        # messages.error(request, 'Oh no! An unexpected error occurred while trying to set '
+        #                         'up the Google Drive application. Please try again.')
         return HttpResponseRedirect('/accounts/profile')
 
     if not (state == googledrive['state']):
-        messages.error(request, 'Oh no! An unexpected error occurred while trying to set '
-                                'up the Google Drive application. Please try again.')
+        logger.info("(state == googledrive['state']):  **********************************************")
+        request.session['googledrive_error'] = \
+                    'Oh no! An unexpected error occurred while trying to set up the Google Drive application. Please try again.'
         return HttpResponseRedirect('/accounts/profile')
 
     try:
@@ -102,8 +106,8 @@ def oauth2_callback(request):
 
     except Exception as e:
         logger.exception('Unable to complete Google Drive integration setup: %s' % e)
-        messages.error(request, 'Oh no! An unexpected error occurred while trying to set '
-                                'up the Google Drive application. Please try again.')
+        request.session['googledrive_error'] = \
+                    'Oh no! An unexpected error occurred while trying to set up the Google Drive application. Please try again.'
 
     return HttpResponseRedirect('/accounts/profile')
 


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [FP-952](https://jira.tacc.utexas.edu/browse/FP-952)

## Summary of Changes: ##

Update "add google drive" workflow to use react error messages instead of django's template-based messages

## Testing Steps: ##
1. Modify line 64 of server/portal/apps/googledrive_integration/views.py to make `if 'googledrive' in request.session:` validate to False
2. Go to https://cep.dev/workbench/account/ 
3. Click on, connect to Google Drive
4. Follow the steps to connect TACC google account
5. Verify error message appears below nav bar



## UI Photos:
Example of what will cause an error:
<img width="498" alt="Screen Shot 2021-07-07 at 4 58 01 PM" src="https://user-images.githubusercontent.com/4061215/124834102-ca50df80-df44-11eb-9129-79254f6fbbd0.png">

Error Location:
<img width="620" alt="Screen Shot 2021-07-07 at 4 58 40 PM" src="https://user-images.githubusercontent.com/4061215/124834143-db99ec00-df44-11eb-843f-a8da330b81f2.png">



## Notes: ##
