### PR TITLE
Bug/FP-1133: Ensure that Frontera-related normal queue validation occurs only on Frontera

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -489,10 +489,12 @@ export const AppSchemaForm = ({ app }) => {
                       .filter(
                         q =>
                           /* normal queue on Frontera does not support 1 (or 2) node jobs and should not be listed */
-                          getSystemName(app.exec_sys.login.host) !==
-                            'Frontera' ||
-                          q !== 'normal' ||
-                          app.definition.parallelism !== 'SERIAL'
+                          !(
+                            getSystemName(app.exec_sys.login.host) ===
+                              'Frontera' &&
+                            q === 'normal' &&
+                            app.definition.parallelism === 'SERIAL'
+                          )
                       )
                       .sort()
                       .map(queue => (

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -348,7 +348,7 @@ export const AppSchemaForm = ({ app }) => {
                 .max(64, 'Must be 64 characters or less')
                 .required('Required'),
               batchQueue: getQueueValidation(queue, app),
-              nodeCount: getNodeCountValidation(queue),
+              nodeCount: getNodeCountValidation(queue, app),
               processorsOnEachNode: getProcessorsOnEachNodeValidation(queue),
               maxRunTime: Yup.string()
                 .matches(
@@ -488,6 +488,9 @@ export const AppSchemaForm = ({ app }) => {
                       .map(q => q.name)
                       .filter(
                         q =>
+                          /* normal queue on Frontera does not support 1 (or 2) node jobs and should not be listed */
+                          getSystemName(app.exec_sys.login.host) !==
+                            'FRONTERA' ||
                           q !== 'normal' ||
                           app.definition.parallelism !== 'SERIAL'
                       )

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -490,7 +490,7 @@ export const AppSchemaForm = ({ app }) => {
                         q =>
                           /* normal queue on Frontera does not support 1 (or 2) node jobs and should not be listed */
                           getSystemName(app.exec_sys.login.host) !==
-                            'FRONTERA' ||
+                            'Frontera' ||
                           q !== 'normal' ||
                           app.definition.parallelism !== 'SERIAL'
                       )

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -148,7 +148,7 @@ describe('AppSchemaForm', () => {
     });
   });
 
-  it('renders validation error for using normal queue but with only 1 node', async () => {
+  it('renders validation error for using normal queue but with only 1 node on Frontera', async () => {
     const store = mockStore({
       ...initialMockState
     });
@@ -203,7 +203,7 @@ describe('AppSchemaForm', () => {
     });
   });
 
-  it('renders validation error for using normal queue for SERIAL apps', async () => {
+  it('renders validation error for using normal queue for SERIAL apps on Frontera', async () => {
     const store = mockStore({
       ...initialMockState
     });

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -108,9 +108,12 @@ export const getQueueValidation = (queue, app) => {
     .test(
       'is-not-serial-job-using-normal-queue',
       'The normal queue does not support serial apps (i.e. Node Count set to 1).',
-      (value, context) =>
-        getSystemName(app.exec_sys.login.host) !== 'Frontera' ||
-        queue.name !== 'normal' ||
-        app.definition.parallelism !== 'SERIAL'
+      (value, context) => {
+        return !(
+          getSystemName(app.exec_sys.login.host) === 'Frontera' &&
+          queue.name === 'normal' &&
+          app.definition.parallelism === 'SERIAL'
+        );
+      }
     );
 };

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -92,6 +92,15 @@ export const getProcessorsOnEachNodeValidation = queue => {
     .max(queue.maxProcessorsPerNode / queue.maxNodes);
 };
 
+/**
+ * Get validator for queues
+ *
+ * 'normal' queue isn't supported on Frontera for SERIAL (i.e. one node) jobs
+ *
+ * @function
+ * @param {Object} queue
+ * @returns {Yup.string()} validation of queue
+ */
 export const getQueueValidation = (queue, app) => {
   return Yup.string()
     .required('Required')

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -61,7 +61,7 @@ export const createMaxRunTimeRegex = maxRunTime => {
 export const getNodeCountValidation = (queue, app) => {
   // all queues have a min node count of 1 except for the normal queue on Frontera which has a min node of 3
   const min =
-    getSystemName(app.exec_sys.login.host) === 'FRONTERA' &&
+    getSystemName(app.exec_sys.login.host) === 'Frontera' &&
     queue.name === 'normal'
       ? 3
       : 1;
@@ -109,7 +109,7 @@ export const getQueueValidation = (queue, app) => {
       'is-not-serial-job-using-normal-queue',
       'The normal queue does not support serial apps (i.e. Node Count set to 1).',
       (value, context) =>
-        getSystemName(app.exec_sys.login.host) !== 'FRONTERA' ||
+        getSystemName(app.exec_sys.login.host) !== 'Frontera' ||
         queue.name !== 'normal' ||
         app.definition.parallelism !== 'SERIAL'
     );

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -1,0 +1,66 @@
+import { cloneDeep } from 'lodash';
+import { namdAppFixture } from './fixtures/AppForm.app.fixture';
+import { getNodeCountValidation, getQueueValidation } from './AppFormUtils';
+
+describe('AppFormUtils', () => {
+  const normalQueue = namdAppFixture.exec_sys.queues.find(
+    q => q.name === 'normal'
+  );
+  const smallQueue = namdAppFixture.exec_sys.queues.find(
+    q => q.name === 'small'
+  );
+
+  const serialFronteraApp = {
+    ...namdAppFixture,
+    definition: {
+      ...namdAppFixture.definition,
+      parallelism: 'SERIAL'
+    }
+  };
+
+  it('handles node count validation on Frontera', () => {
+    expect(
+      getNodeCountValidation(normalQueue, namdAppFixture).isValidSync(1)
+    ).toEqual(false);
+    expect(
+      getNodeCountValidation(normalQueue, namdAppFixture).isValidSync(3)
+    ).toEqual(true);
+    expect(
+      getNodeCountValidation(smallQueue, namdAppFixture).isValidSync(1)
+    ).toEqual(true);
+    expect(
+      getNodeCountValidation(smallQueue, namdAppFixture).isValidSync(3)
+    ).toEqual(false);
+  });
+
+  it('handles node count validation on non-Frontera HPCs', () => {
+    const stampede2App = cloneDeep(namdAppFixture);
+    stampede2App.exec_sys.login.host = 'stampede2.tacc.utexas.edu';
+    expect(
+      getNodeCountValidation(normalQueue, stampede2App).isValidSync(1)
+    ).toEqual(true);
+    expect(
+      getNodeCountValidation(normalQueue, stampede2App).isValidSync(3)
+    ).toEqual(true);
+  });
+
+  it('handles queue validation on Frontera HPCs for SERIAL apps', () => {
+    expect(
+      getQueueValidation(smallQueue, serialFronteraApp).isValidSync('small')
+    ).toEqual(true);
+    expect(
+      getQueueValidation(normalQueue, serialFronteraApp).isValidSync('normal')
+    ).toEqual(false);
+  });
+
+  it('handles queue validation on non-Frontera HPCs for SERIAL apps', () => {
+    const stampede2SerialApp = cloneDeep(namdAppFixture);
+    stampede2SerialApp.exec_sys.login.host = 'stampede2.tacc.utexas.edu';
+    expect(
+      getQueueValidation(smallQueue, stampede2SerialApp).isValidSync('small')
+    ).toEqual(true);
+    expect(
+      getQueueValidation(normalQueue, stampede2SerialApp).isValidSync('normal')
+    ).toEqual(true);
+  });
+});


### PR DESCRIPTION
## Overview: ##

Ensure that Frontera-related normal queue validation occurs only on Frontera

Validation checks for the normal queue were applied in https://github.com/TACC/Core-Portal/pull/426, that should have been limited to the `normal` queue on Frontera only.  This PR fixes that and adds some additional unit tests.

## Related Jira tickets: ##

* [FP-1133](https://jira.tacc.utexas.edu/browse/FP-1133)

## Summary of Changes: ##
* Ensure that Frontera-related normal queue validation occurs only on Frontera
* Add related unit tests

## Testing Steps: ##
1. Ensure you can submit a 1 or 2 node job on the normal queue on Stampede 2.
