### PR TITLE
task/FP-1129: Toggle Apps and History Sections

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -11,7 +11,7 @@ import './Dashboard.global.css';
 import './Dashboard.module.css';
 
 function Dashboard() {
-  const showApps = useSelector(state => state.workbench.config.showApps);
+  const hideApps = useSelector(state => state.workbench.config.hideApps);
   return (
     <Section
       bodyClassName="has-loaded-dashboard"
@@ -28,7 +28,7 @@ function Dashboard() {
       contentShouldScroll
       content={
         <>
-          {showApps && <DashboardJobs />}
+          {!hideApps && <DashboardJobs />}
           <DashboardTickets />
           <DashboardSysmon />
           <DashboardRoutes />

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Link, Route, Switch } from 'react-router-dom';
 
 import { BrowserChecker, Section, SectionTableWrapper } from '_common';
@@ -11,6 +11,7 @@ import './Dashboard.global.css';
 import './Dashboard.module.css';
 
 function Dashboard() {
+  const showApps = useSelector(state => state.workbench.config.showApps);
   return (
     <Section
       bodyClassName="has-loaded-dashboard"
@@ -27,7 +28,7 @@ function Dashboard() {
       contentShouldScroll
       content={
         <>
-          <DashboardJobs />
+          {showApps && <DashboardJobs />}
           <DashboardTickets />
           <DashboardSysmon />
           <DashboardRoutes />

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -53,7 +53,7 @@ const Sidebar = ({ disabled, showUIPatterns }) => {
   if (path.includes('accounts')) path = ROUTES.WORKBENCH;
 
   const unread = useSelector(state => state.notifications.list.unread);
-  const showApps = useSelector(state => state.workbench.config.showApps);
+  const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   return (
     <Nav styleName="root" vertical>
@@ -69,7 +69,7 @@ const Sidebar = ({ disabled, showUIPatterns }) => {
         iconName="folder"
         disabled={disabled}
       />
-      {showApps && (
+      {!hideApps && (
         <SidebarItem
           to={`${path}${ROUTES.APPLICATIONS}`}
           label="Applications"
@@ -83,7 +83,7 @@ const Sidebar = ({ disabled, showUIPatterns }) => {
         iconName="allocations"
         disabled={disabled}
       />
-      {showApps && (
+      {!hideApps && (
         <SidebarItem
           to={`${path}${ROUTES.HISTORY}`}
           label="History"

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -56,9 +56,9 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   return (
-    <>
+    <Nav styleName="root" vertical>
       {!loading && (
-        <Nav styleName="root" vertical>
+        <>
           <SidebarItem
             to={`${path}${ROUTES.DASHBOARD}`}
             label="Dashboard"

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -48,7 +48,7 @@ SidebarItem.defaultProps = {
 };
 
 /** A navigation list for the application */
-const Sidebar = ({ disabled, showUIPatterns }) => {
+const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   let { path } = useRouteMatch();
   if (path.includes('accounts')) path = ROUTES.WORKBENCH;
 
@@ -56,66 +56,72 @@ const Sidebar = ({ disabled, showUIPatterns }) => {
   const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   return (
-    <Nav styleName="root" vertical>
-      <SidebarItem
-        to={`${path}${ROUTES.DASHBOARD}`}
-        label="Dashboard"
-        iconName="dashboard"
-        disabled={disabled}
-      />
-      <SidebarItem
-        to={`${path}${ROUTES.DATA}`}
-        label="Data Files"
-        iconName="folder"
-        disabled={disabled}
-      />
-      {!hideApps && (
-        <SidebarItem
-          to={`${path}${ROUTES.APPLICATIONS}`}
-          label="Applications"
-          iconName="applications"
-          disabled={disabled}
-        />
+    <>
+      {!loading && (
+        <Nav styleName="root" vertical>
+          <SidebarItem
+            to={`${path}${ROUTES.DASHBOARD}`}
+            label="Dashboard"
+            iconName="dashboard"
+            disabled={disabled}
+          />
+          <SidebarItem
+            to={`${path}${ROUTES.DATA}`}
+            label="Data Files"
+            iconName="folder"
+            disabled={disabled}
+          />
+          {!hideApps && (
+            <SidebarItem
+              to={`${path}${ROUTES.APPLICATIONS}`}
+              label="Applications"
+              iconName="applications"
+              disabled={disabled}
+            />
+          )}
+          <SidebarItem
+            to={`${path}${ROUTES.ALLOCATIONS}`}
+            label="Allocations"
+            iconName="allocations"
+            disabled={disabled}
+          />
+          {!hideApps && (
+            <SidebarItem
+              to={`${path}${ROUTES.HISTORY}`}
+              label="History"
+              iconName="history"
+              disabled={disabled}
+            >
+              <HistoryBadge unread={unread} disabled={disabled} />
+            </SidebarItem>
+          )}
+          {showUIPatterns && (
+            <SidebarItem
+              to={`${path}${ROUTES.UI}`}
+              label="UI Patterns"
+              iconName="copy"
+              disabled={disabled}
+            />
+          )}
+          <NavItem styleName="feedback-nav-item">
+            <FeedbackButton />
+          </NavItem>
+        </Nav>
       )}
-      <SidebarItem
-        to={`${path}${ROUTES.ALLOCATIONS}`}
-        label="Allocations"
-        iconName="allocations"
-        disabled={disabled}
-      />
-      {!hideApps && (
-        <SidebarItem
-          to={`${path}${ROUTES.HISTORY}`}
-          label="History"
-          iconName="history"
-          disabled={disabled}
-        >
-          <HistoryBadge unread={unread} disabled={disabled} />
-        </SidebarItem>
-      )}
-      {showUIPatterns && (
-        <SidebarItem
-          to={`${path}${ROUTES.UI}`}
-          label="UI Patterns"
-          iconName="copy"
-          disabled={disabled}
-        />
-      )}
-      <NavItem styleName="feedback-nav-item">
-        <FeedbackButton />
-      </NavItem>
-    </Nav>
+    </>
   );
 };
 
 Sidebar.propTypes = {
   disabled: PropTypes.bool,
-  showUIPatterns: PropTypes.bool
+  showUIPatterns: PropTypes.bool,
+  loading: PropTypes.bool
 };
 
 Sidebar.defaultProps = {
   disabled: false,
-  showUIPatterns: false
+  showUIPatterns: false,
+  loading: true
 };
 
 export default Sidebar;

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -103,12 +103,12 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
               disabled={disabled}
             />
           )}
-          <NavItem styleName="feedback-nav-item">
-            <FeedbackButton />
-          </NavItem>
-        </Nav>
+        </>
       )}
-    </>
+      <NavItem styleName="feedback-nav-item">
+        <FeedbackButton />
+      </NavItem>
+    </Nav>
   );
 };
 

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -53,6 +53,7 @@ const Sidebar = ({ disabled, showUIPatterns }) => {
   if (path.includes('accounts')) path = ROUTES.WORKBENCH;
 
   const unread = useSelector(state => state.notifications.list.unread);
+  const showApps = useSelector(state => state.workbench.config.showApps);
 
   return (
     <Nav styleName="root" vertical>
@@ -68,26 +69,30 @@ const Sidebar = ({ disabled, showUIPatterns }) => {
         iconName="folder"
         disabled={disabled}
       />
-      <SidebarItem
-        to={`${path}${ROUTES.APPLICATIONS}`}
-        label="Applications"
-        iconName="applications"
-        disabled={disabled}
-      />
+      {showApps && (
+        <SidebarItem
+          to={`${path}${ROUTES.APPLICATIONS}`}
+          label="Applications"
+          iconName="applications"
+          disabled={disabled}
+        />
+      )}
       <SidebarItem
         to={`${path}${ROUTES.ALLOCATIONS}`}
         label="Allocations"
         iconName="allocations"
         disabled={disabled}
       />
-      <SidebarItem
-        to={`${path}${ROUTES.HISTORY}`}
-        label="History"
-        iconName="history"
-        disabled={disabled}
-      >
-        <HistoryBadge unread={unread} disabled={disabled} />
-      </SidebarItem>
+      {showApps && (
+        <SidebarItem
+          to={`${path}${ROUTES.HISTORY}`}
+          label="History"
+          iconName="history"
+          disabled={disabled}
+        >
+          <HistoryBadge unread={unread} disabled={disabled} />
+        </SidebarItem>
+      )}
       {showUIPatterns && (
         <SidebarItem
           to={`${path}${ROUTES.UI}`}

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -16,6 +16,7 @@ const PUBLIC_PAGES = [
   'Allocations',
   'History'
 ];
+const APP_PAGES = ['Applications', 'History'];
 const DEBUG_PAGES = ['UI Patterns'];
 
 function getPath(page) {
@@ -59,6 +60,20 @@ describe('workbench sidebar', () => {
       'href',
       `/workbench/${path}`
     );
+    expect(queryByRole('status')).toBeNull();
+  });
+
+  it.each(APP_PAGES)('should not have a link to the %s page', page => {
+    const { queryByText, queryByRole } = renderSideBar(
+      mockStore({
+        workbench: { ...workbench, config: { hideApps: true } },
+        notifications,
+        ticketCreate
+      }),
+      false
+    );
+    const path = getPath(page);
+    expect(queryByText(page)).not.toBeInTheDocument();
     expect(queryByRole('status')).toBeNull();
   });
 

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -47,10 +47,9 @@ describe('workbench sidebar', () => {
   it.each(PUBLIC_PAGES)('should have a link to the %s page', page => {
     const { getByText, queryByRole } = renderSideBar(
       mockStore({
-        workbench,
+        workbench: { ...workbench, config: { showApps: true } },
         notifications,
-        ticketCreate,
-        workbench: { config: { showApps: true } }
+        ticketCreate
       }),
       false
     );
@@ -66,10 +65,9 @@ describe('workbench sidebar', () => {
   it('should have a notification badge', () => {
     const { getByRole } = renderSideBar(
       mockStore({
-        workbench,
+        workbench: { ...workbench, config: { showApps: true } },
         notifications: { list: { unread: 1 } },
-        ticketCreate,
-        workbench: { config: { showApps: true } }
+        ticketCreate
       }),
       false
     );
@@ -93,7 +91,7 @@ describe('workbench sidebar', () => {
   it.each(DEBUG_PAGES)('is available in debug mode', page => {
     const { getByText } = renderSideBar(
       mockStore({
-        workbench: { status: { debug: true },config: { showApps: true } },
+        workbench: { status: { debug: true }, config: { showApps: true } },
         notifications,
         ticketCreate
       }),

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -36,7 +36,7 @@ function renderSideBar(store, showUIPatterns) {
     <Provider store={store}>
       <MemoryRouter initialEntries={['/workbench']}>
         <Route path="/workbench">
-          <Sidebar showUIPatterns={showUIPatterns} />
+          <Sidebar showUIPatterns={showUIPatterns} loading={false} />
         </Route>
       </MemoryRouter>
     </Provider>

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -47,7 +47,7 @@ describe('workbench sidebar', () => {
   it.each(PUBLIC_PAGES)('should have a link to the %s page', page => {
     const { getByText, queryByRole } = renderSideBar(
       mockStore({
-        workbench: { ...workbench, config: { showApps: true } },
+        workbench: { ...workbench, config: { hideApps: false } },
         notifications,
         ticketCreate
       }),
@@ -65,7 +65,7 @@ describe('workbench sidebar', () => {
   it('should have a notification badge', () => {
     const { getByRole } = renderSideBar(
       mockStore({
-        workbench: { ...workbench, config: { showApps: true } },
+        workbench: { ...workbench, config: { hideApps: false } },
         notifications: { list: { unread: 1 } },
         ticketCreate
       }),
@@ -91,7 +91,7 @@ describe('workbench sidebar', () => {
   it.each(DEBUG_PAGES)('is available in debug mode', page => {
     const { getByText } = renderSideBar(
       mockStore({
-        workbench: { status: { debug: true }, config: { showApps: true } },
+        workbench: { status: { debug: true }, config: { hideApps: false } },
         notifications,
         ticketCreate
       }),

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -16,6 +16,7 @@ const PUBLIC_PAGES = [
   'Allocations',
   'History'
 ];
+const APP_PAGES = ['Applications', 'History'];
 const DEBUG_PAGES = ['UI Patterns'];
 
 function getPath(page) {
@@ -34,8 +35,8 @@ function renderSideBar(store, showUIPatterns) {
   return render(
     <Provider store={store}>
       <MemoryRouter initialEntries={['/workbench']}>
-        <Route path='/workbench'>
-          <Sidebar showUIPatterns={showUIPatterns}/>
+        <Route path="/workbench">
+          <Sidebar showUIPatterns={showUIPatterns} />
         </Route>
       </MemoryRouter>
     </Provider>
@@ -49,7 +50,8 @@ describe('workbench sidebar', () => {
       mockStore({
         workbench,
         notifications,
-        ticketCreate
+        ticketCreate,
+        workbench: { config: { showApps: true } }
       }),
       false
     );
@@ -67,7 +69,8 @@ describe('workbench sidebar', () => {
       mockStore({
         workbench,
         notifications: { list: { unread: 1 } },
-        ticketCreate
+        ticketCreate,
+        workbench: { config: { showApps: true } }
       }),
       false
     );
@@ -93,7 +96,8 @@ describe('workbench sidebar', () => {
       mockStore({
         workbench: { status: { debug: true } },
         notifications,
-        ticketCreate
+        ticketCreate,
+        workbench: { config: { showApps: true } }
       }),
       true
     );

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -93,7 +93,7 @@ describe('workbench sidebar', () => {
   it.each(DEBUG_PAGES)('is available in debug mode', page => {
     const { getByText } = renderSideBar(
       mockStore({
-        workbench: { status: { debug: true } },
+        workbench: { status: { debug: true },config: { showApps: true } },
         notifications,
         ticketCreate,
         workbench: { config: { showApps: true } }

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -16,7 +16,6 @@ const PUBLIC_PAGES = [
   'Allocations',
   'History'
 ];
-const APP_PAGES = ['Applications', 'History'];
 const DEBUG_PAGES = ['UI Patterns'];
 
 function getPath(page) {

--- a/client/src/components/Sidebar/Sidebar.test.js
+++ b/client/src/components/Sidebar/Sidebar.test.js
@@ -95,8 +95,7 @@ describe('workbench sidebar', () => {
       mockStore({
         workbench: { status: { debug: true },config: { showApps: true } },
         notifications,
-        ticketCreate,
-        workbench: { config: { showApps: true } }
+        ticketCreate
       }),
       true
     );

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -33,7 +33,7 @@ function Workbench() {
     shallowEqual
   );
 
-  const showApps = useSelector(state => state.workbench.config.showApps);
+  const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   // Get systems and any other initial data we need from the backend
   useEffect(() => {
@@ -78,7 +78,7 @@ function Workbench() {
                 <Route path={`${path}${ROUTES.DATA}`}>
                   <DataFiles />
                 </Route>
-                {showApps && (
+                {!hideApps && (
                   <Route
                     path={`${path}${ROUTES.APPLICATIONS}`}
                     component={Applications}
@@ -88,7 +88,7 @@ function Workbench() {
                   path={`${path}${ROUTES.ALLOCATIONS}`}
                   component={Allocations}
                 />
-                {showApps && (
+                {!hideApps && (
                   <Route
                     path={`${path}${ROUTES.HISTORY}`}
                     component={History}

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -59,7 +59,11 @@ function Workbench() {
   return (
     <div className="workbench-wrapper">
       <NotificationToast />
-      <Sidebar disabled={!setupComplete} showUIPatterns={showUIPatterns} />
+      <Sidebar
+        disabled={!setupComplete}
+        showUIPatterns={showUIPatterns}
+        loading={loading}
+      />
       <div className="workbench-content">
         {loading ? (
           <LoadingSpinner />

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -20,6 +20,7 @@ import './Workbench.scss';
 function Workbench() {
   const { path } = useRouteMatch();
   const dispatch = useDispatch();
+  const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   // showUIPatterns: Show some entries only in local development
   const { loading, setupComplete, showUIPatterns, isStaff } = useSelector(
@@ -32,8 +33,6 @@ function Workbench() {
     }),
     shallowEqual
   );
-
-  const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   // Get systems and any other initial data we need from the backend
   useEffect(() => {

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -20,16 +20,22 @@ import './Workbench.scss';
 function Workbench() {
   const { path } = useRouteMatch();
   const dispatch = useDispatch();
-  const hideApps = useSelector(state => state.workbench.config.hideApps);
 
   // showUIPatterns: Show some entries only in local development
-  const { loading, setupComplete, showUIPatterns, isStaff } = useSelector(
+  const {
+    loading,
+    setupComplete,
+    showUIPatterns,
+    isStaff,
+    hideApps
+  } = useSelector(
     state => ({
       loading: state.workbench.loading || state.systems.storage.loading,
       setupComplete: state.workbench.setupComplete,
       showUIPatterns: state.workbench.config.debug,
       isStaff:
-        state.authenticatedUser.user && state.authenticatedUser.user.isStaff
+        state.authenticatedUser.user && state.authenticatedUser.user.isStaff,
+      hideApps: state.workbench.config.hideApps
     }),
     shallowEqual
   );

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -33,6 +33,8 @@ function Workbench() {
     shallowEqual
   );
 
+  const showApps = useSelector(state => state.workbench.config.showApps);
+
   // Get systems and any other initial data we need from the backend
   useEffect(() => {
     dispatch({ type: 'FETCH_WORKBENCH' });
@@ -76,15 +78,32 @@ function Workbench() {
                 <Route path={`${path}${ROUTES.DATA}`}>
                   <DataFiles />
                 </Route>
-                <Route
-                  path={`${path}${ROUTES.APPLICATIONS}`}
-                  component={Applications}
-                />
+                {showApps ? (
+                  <Route
+                    path={`${path}${ROUTES.APPLICATIONS}`}
+                    component={Applications}
+                  />
+                ) : (
+                  <Redirect
+                    from={`${path}${ROUTES.APPLICATIONS}`}
+                    to={`${path}${ROUTES.DASHBOARD}`}
+                  />
+                )}
                 <Route
                   path={`${path}${ROUTES.ALLOCATIONS}`}
                   component={Allocations}
                 />
-                <Route path={`${path}${ROUTES.HISTORY}`} component={History} />
+                {showApps ? (
+                  <Route
+                    path={`${path}${ROUTES.HISTORY}`}
+                    component={History}
+                  />
+                ) : (
+                  <Redirect
+                    from={`${path}${ROUTES.HISTORY}`}
+                    to={`${path}${ROUTES.DASHBOARD}`}
+                  />
+                )}
                 <Route
                   path={`${path}${ROUTES.ONBOARDING}`}
                   component={Onboarding}

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -93,15 +93,10 @@ function Workbench() {
                   path={`${path}${ROUTES.ALLOCATIONS}`}
                   component={Allocations}
                 />
-                {showApps ? (
+                {showApps && (
                   <Route
                     path={`${path}${ROUTES.HISTORY}`}
                     component={History}
-                  />
-                ) : (
-                  <Redirect
-                    from={`${path}${ROUTES.HISTORY}`}
-                    to={`${path}${ROUTES.DASHBOARD}`}
                   />
                 )}
                 <Route

--- a/client/src/components/Workbench/Workbench.js
+++ b/client/src/components/Workbench/Workbench.js
@@ -78,15 +78,10 @@ function Workbench() {
                 <Route path={`${path}${ROUTES.DATA}`}>
                   <DataFiles />
                 </Route>
-                {showApps ? (
+                {showApps && (
                   <Route
                     path={`${path}${ROUTES.APPLICATIONS}`}
                     component={Applications}
-                  />
-                ) : (
-                  <Redirect
-                    from={`${path}${ROUTES.APPLICATIONS}`}
-                    to={`${path}${ROUTES.DASHBOARD}`}
                   />
                 )}
                 <Route

--- a/client/src/components/Workbench/Workbench.test.js
+++ b/client/src/components/Workbench/Workbench.test.js
@@ -42,7 +42,8 @@ describe('workbench', () => {
       ...state,
       workbench: {
         ...workbench,
-        setupComplete: false
+        setupComplete: false,
+        loading: false
       }
     });
     const { getByText } = renderComponent(<Workbench />, store, history);
@@ -58,7 +59,8 @@ describe('workbench', () => {
       ...state,
       workbench: {
         ...workbench,
-        setupComplete: true
+        setupComplete: true,
+        loading: false
       }
     });
 

--- a/client/src/redux/reducers/workbench.reducers.js
+++ b/client/src/redux/reducers/workbench.reducers.js
@@ -1,5 +1,5 @@
 export const initialState = {
-  loading: false,
+  loading: true,
   config: {},
   portalName: '',
   setupComplete: window.__INITIAL_SETUP_COMPLETE__

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -233,5 +233,5 @@ _WORKBENCH_SETTINGS = {
     "compressApp": 'zippy',
     "extractApp": 'extract',
     "makePublic": False,
-    "showApps": False
+    "showApps": True
 }

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -233,5 +233,5 @@ _WORKBENCH_SETTINGS = {
     "compressApp": 'zippy',
     "extractApp": 'extract',
     "makePublic": False,
-    "showApps": True
+    "hideApps": False
 }

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -232,5 +232,6 @@ _WORKBENCH_SETTINGS = {
     "viewPath": True,
     "compressApp": 'zippy',
     "extractApp": 'extract',
-    "makePublic": False
+    "makePublic": False,
+    "showApps": False
 }

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -232,5 +232,6 @@ _WORKBENCH_SETTINGS = {
     "viewPath": True,
     "compressApp": 'zippy',
     "extractApp": 'extract',
-    "makePublic": True
+    "makePublic": True,
+    "showApps": True
 }

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -233,5 +233,5 @@ _WORKBENCH_SETTINGS = {
     "compressApp": 'zippy',
     "extractApp": 'extract',
     "makePublic": True,
-    "showApps": True
+    "hideApps": False
 }


### PR DESCRIPTION
## Overview: ##
A2CPS does not want the Applications space to be enabled for the time being.

## Related Jira tickets: ##

* [FP-1129](https://jira.tacc.utexas.edu/browse/FP-1129)

## Summary of Changes: ##
Custom setting added to enable/disable Applications and History sections and Dashboard Recent Jobs secction.

## Testing Steps: ##
1. Modify **_WORKBENCH_SETTINGS = {"hideApps": True}** property to enable/disable Apps sections

## UI Photos:

<img width="1067" alt="Screen Shot 2021-07-22 at 2 44 33 PM" src="https://user-images.githubusercontent.com/62672123/126700277-fe44244f-db6c-4ec6-80b1-43061e5d51d6.png">
<img width="1067" alt="Screen Shot 2021-07-22 at 2 44 57 PM" src="https://user-images.githubusercontent.com/62672123/126700278-65de80fa-5452-4a7a-920b-f648138d649f.png">


## Notes: ##
**workbench/applications** and **workbench/history/jobs** routes should redirect to **workbench/dashboard**.