### PR TITLE
Task/FP-1118: Support no datafiles systems [A2CPS].

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -169,7 +169,7 @@ export const AppSchemaForm = ({ app }) => {
     );
     const { defaultHost, configuration } = state.systems.storage;
     const hasCorral =
-      defaultHost &&
+      configuration.length &&
       ['cloud.corral.tacc.utexas.edu', 'data.tacc.utexas.edu'].some(s =>
         defaultHost.endsWith(s)
       );

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -261,6 +261,8 @@ export const AppSchemaForm = ({ app }) => {
 
   return (
     <div id="appForm-wrapper">
+      {/* The !! is needed because the second value of this shorthand 
+          is interpreted as a literal 0 if not. */}
       {!!(!systemHasKeys && hasStorageSystems) && (
         <div className="appDetail-error">
           <SectionMessage type="warning">

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -203,6 +203,35 @@ describe('AppSchemaForm', () => {
     });
   });
 
+  it('displays an error if no storage systems are enabled', async () => {
+    const store = mockStore({
+      ...initialMockState,
+      systems: {
+        storage: {
+          configuration: [],
+          error: false,
+          errorMessage: null,
+          loading: false,
+          defaultHost: ''
+        },
+        definitions: {
+          list: [],
+          error: false,
+          errorMessage: null,
+          loading: false
+        },
+      }
+    });
+
+    const { getByText } = renderAppSchemaFormComponent(store, {
+      ...namdAppFixture
+    });
+
+    await wait(() => {
+      expect(getByText(/No storage systems enabled for this portal./)).toBeDefined();
+    });
+  });
+
   it('renders validation error for using normal queue for SERIAL apps', async () => {
     const store = mockStore({
       ...initialMockState

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -27,7 +27,7 @@ import DataFilesModals from './DataFilesModals/DataFilesModals';
 import DataFilesProjectsList from './DataFilesProjectsList/DataFilesProjectsList';
 import DataFilesProjectFileListing from './DataFilesProjectFileListing/DataFilesProjectFileListing';
 
-const PrivateDataRedirect = () => {
+const DefaultSystemRedirect = () => {
   const systems = useSelector(
     state => state.systems.storage.configuration,
     shallowEqual
@@ -35,7 +35,12 @@ const PrivateDataRedirect = () => {
   const history = useHistory();
   useEffect(() => {
     if (systems.length === 0) return;
-    history.push(`/workbench/data/tapis/private/${systems[0].system}/`);
+    const defaultSystem = systems[0];
+    history.push(
+      `/workbench/data/${defaultSystem.api}/${defaultSystem.scheme}/${
+        defaultSystem.scheme === 'projects' ? '' : defaultSystem.system
+      }/`
+    );
   }, [systems]);
   return <></>;
 };
@@ -94,7 +99,7 @@ const DataFilesSwitch = React.memo(() => {
         <DataFilesProjectsList />
       </Route>
       <Route path={`${path}`}>
-        <PrivateDataRedirect />
+        <DefaultSystemRedirect />
       </Route>
     </Switch>
   );

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -107,6 +107,7 @@ const DataFiles = () => {
   );
   const loading = useSelector(state => state.systems.storage.loading);
   const error = useSelector(state => state.systems.storage.error);
+  const systems = useSelector(state => state.systems.storage.configuration);
 
   const readOnly =
     listingParams.scheme === 'projects' &&
@@ -124,6 +125,16 @@ const DataFiles = () => {
 
   if (loading) {
     return <LoadingSpinner />;
+  }
+
+  if (!systems.length) {
+    return (
+      <div styleName="error">
+        <SectionMessage type="warning">
+          No storage systems enabled for this portal
+        </SectionMessage>
+      </div>
+    );
   }
 
   return (

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -38,8 +38,8 @@ const DefaultSystemRedirect = () => {
     const defaultSystem = systems[0];
     history.push(
       `/workbench/data/${defaultSystem.api}/${defaultSystem.scheme}/${
-        defaultSystem.scheme === 'projects' ? '' : defaultSystem.system
-      }/`
+        defaultSystem.scheme === 'projects' ? '' : `${defaultSystem.system}/`
+      }`
     );
   }, [systems]);
   return <></>;

--- a/client/src/components/DataFiles/tests/DataFiles.test.js
+++ b/client/src/components/DataFiles/tests/DataFiles.test.js
@@ -49,4 +49,54 @@ describe('DataFiles', () => {
     expect(getAllByText(/My Data \(Frontera\)/)).toBeDefined();
     expect(getByText(/My Data \(Longhorn\)/)).toBeDefined();
   });
+
+  it('should not render Data Files with no systems', () => {
+    const history = createMemoryHistory();
+    const store = mockStore({
+      workbench: { config: {
+        extract: '',
+        compress: ''
+      }
+      },
+      systems: {
+        storage: {
+          configuration: [],
+          error: false,
+          errorMessage: null,
+          loading: false,
+          defaultHost: ''
+        },
+        definitions: {
+          list: [],
+          error: false,
+          errorMessage: null,
+          loading: false
+        },
+      },
+      files: filesFixture,
+      pushKeys: {
+        modals: {
+          pushKeys: false
+        },
+        modalProps: {
+          pushKeys: {}
+        }
+      },
+      projects: projectsFixture,
+      authenticatedUser: {
+        user: {
+          username: "username",
+          first_name: "User",
+          last_name: "Name",
+          email: "user@name.com"
+        }
+      }
+    });
+    const { getByText, getAllByText } = renderComponent(
+      <DataFiles />,
+      store,
+      history
+    )
+    expect(getAllByText(/No storage systems enabled for this portal/)).toBeDefined();
+  });
 });

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -51,7 +51,8 @@ class SystemListingView(BaseApiView):
                     )
                 default_system = user_systems[settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT]
                 response['default_host'] = default_system['host']
-        response['system_list'] += portal_systems
+        if portal_systems:
+            response['system_list'] += portal_systems
         return JsonResponse(response)
 
 

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -37,19 +37,20 @@ class SystemListingView(BaseApiView):
         # compare available storage systems to the systems a user can access
         response = {'system_list': []}
         if request.user.is_authenticated:
-            user_systems = get_user_storage_systems(request.user.username, local_systems)
-            for system_name, details in user_systems.items():
-                response['system_list'].append(
-                    {
-                        'name': details['name'],
-                        'system':  UserSystemsManager(request.user, system_name=system_name).get_system_id(),
-                        'scheme': 'private',
-                        'api': 'tapis',
-                        'icon': details['icon']
-                    }
-                )
-            default_system = user_systems[settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT]
-            response['default_host'] = default_system['host']
+            if local_systems:
+                user_systems = get_user_storage_systems(request.user.username, local_systems)
+                for system_name, details in user_systems.items():
+                    response['system_list'].append(
+                        {
+                            'name': details['name'],
+                            'system':  UserSystemsManager(request.user, system_name=system_name).get_system_id(),
+                            'scheme': 'private',
+                            'api': 'tapis',
+                            'icon': details['icon']
+                        }
+                    )
+                default_system = user_systems[settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT]
+                response['default_host'] = default_system['host']
         response['system_list'] += portal_systems
         return JsonResponse(response)
 

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -89,16 +89,17 @@ class AppsView(BaseApiView):
         if app_id:
             METRICS.debug("user:{} is requesting app id:{}".format(request.user.username, app_id))
             data = _get_app(app_id, request.user)
-            
-            # check if default system needs keys pushed
-            default_sys = UserSystemsManager(
-                request.user,
-                settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT
-            )
-            storage_sys = StorageSystem(agave, default_sys.get_system_id())
-            success, result = storage_sys.test()
-            data['systemHasKeys'] = success
-            data['pushKeysSystem'] = storage_sys.to_dict()
+
+            if settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS:
+                # check if default system needs keys pushed
+                default_sys = UserSystemsManager(
+                    request.user,
+                    settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT
+                )
+                storage_sys = StorageSystem(agave, default_sys.get_system_id())
+                success, result = storage_sys.test()
+                data['systemHasKeys'] = success
+                data['pushKeysSystem'] = storage_sys.to_dict()
         else:
             METRICS.debug("user:{} is requesting all public apps".format(request.user.username))
             public_only = request.GET.get('publicOnly')


### PR DESCRIPTION
## Overview: ##
Supports the following configurations: 
`_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = []`
`_PORTAL_DATAFILES_STORAGE_SYSTEMS = []`  
`_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT = ''`

## Related Jira tickets: ##

* [FP-1118](https://jira.tacc.utexas.edu/browse/FP-1118)

## Summary of Changes: ##
Handles messaging in `AppForm` and `DataFiles` when configured with empty storage systems.

## Testing Steps: ##
1. Try out variations of the above configurations and ensure that there aren't uncaught errors.

## UI Photos:
![1-1](https://user-images.githubusercontent.com/9425579/127036022-7be3aa5d-14c9-453a-9d77-c7abb96f69b1.png)
![1-2](https://user-images.githubusercontent.com/9425579/127036035-6f508f9a-5564-47ef-96c9-848b431951ed.png)


## Notes: ##
When the local storage system is empty, the default storage system should also be an empty string.
