### PR TITLE
Task/FP-1117: Read only shared workspace setting

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -34,6 +34,10 @@ const DataFilesSidebar = ({ readOnly }) => {
   );
   const { user } = useSelector(state => state.authenticatedUser);
 
+  const disableSharedWorkspaces = systems.find(
+    e => e.name === 'Shared Workspaces'
+  ).read_only;
+
   const toggleMkdirModal = () => {
     dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',
@@ -86,11 +90,12 @@ const DataFilesSidebar = ({ readOnly }) => {
                   <i className="icon-folder" /> Folder
                 </span>
               </DropdownItem>
-              {systems.some(s => s.scheme === 'projects') && (
-                <DropdownItem onClick={toggleAddProjectModal}>
-                  <i className="icon-folder" /> Shared Workspace
-                </DropdownItem>
-              )}
+              {systems.some(s => s.scheme === 'projects') &&
+                !disableSharedWorkspaces && (
+                  <DropdownItem onClick={toggleAddProjectModal}>
+                    <i className="icon-folder" /> Shared Workspace
+                  </DropdownItem>
+                )}
               <DropdownItem
                 className="complex-dropdown-item"
                 onClick={toggleUploadModal}

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -34,9 +34,7 @@ const DataFilesSidebar = ({ readOnly }) => {
   );
   const { user } = useSelector(state => state.authenticatedUser);
 
-  const disableSharedWorkspaces = systems.find(
-    e => e.name === 'Shared Workspaces'
-  ).read_only;
+  const sharedWorkspaces = systems.find(e => e.name === 'Shared Workspaces');
 
   const toggleMkdirModal = () => {
     dispatch({
@@ -91,7 +89,7 @@ const DataFilesSidebar = ({ readOnly }) => {
                 </span>
               </DropdownItem>
               {systems.some(s => s.scheme === 'projects') &&
-                !disableSharedWorkspaces && (
+                !!(sharedWorkspaces && !sharedWorkspaces.read_only) && (
                   <DropdownItem onClick={toggleAddProjectModal}>
                     <i className="icon-folder" /> Shared Workspace
                   </DropdownItem>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -34,7 +34,7 @@ const DataFilesSidebar = ({ readOnly }) => {
   );
   const { user } = useSelector(state => state.authenticatedUser);
 
-  const sharedWorkspaces = systems.find(e => e.name === 'Shared Workspaces');
+  const sharedWorkspaces = systems.find(e => e.scheme === 'projects');
 
   const toggleMkdirModal = () => {
     dispatch({
@@ -88,12 +88,11 @@ const DataFilesSidebar = ({ readOnly }) => {
                   <i className="icon-folder" /> Folder
                 </span>
               </DropdownItem>
-              {systems.some(s => s.scheme === 'projects') &&
-                !!(sharedWorkspaces && !sharedWorkspaces.read_only) && (
-                  <DropdownItem onClick={toggleAddProjectModal}>
-                    <i className="icon-folder" /> Shared Workspace
-                  </DropdownItem>
-                )}
+              {sharedWorkspaces && !sharedWorkspaces.read_only && (
+                <DropdownItem onClick={toggleAddProjectModal}>
+                  <i className="icon-folder" /> Shared Workspace
+                </DropdownItem>
+              )}
               <DropdownItem
                 className="complex-dropdown-item"
                 onClick={toggleUploadModal}

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
@@ -8,7 +8,7 @@ import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 
 const mockStore = configureStore();
 
-const store = mockStore({
+const initialMockState = {
   files: {
     error: {
       FilesListing: false
@@ -26,12 +26,16 @@ const store = mockStore({
       email: 'user@username.com'
     }
   }
-});
+};
 
 describe('DataFilesSidebar', () => {
   it('contains an Add button and a link', () => {
     const history = createMemoryHistory();
     history.push('/workbench/data/');
+
+    const store = mockStore({
+      ...initialMockState
+    });
 
     const { getByText } = renderComponent(
       <Route path="/workbench/data">
@@ -54,5 +58,30 @@ describe('DataFilesSidebar', () => {
         .closest('a')
         .getAttribute('href')
     ).toEqual('/workbench/data/tapis/private/longhorn.home.username/');
+  });
+
+  it('disables creating new shared workspaces in read only shared workspaces', async () => {
+    const history = createMemoryHistory();
+    history.push('/workbench/data/tapis/projects/');
+
+    systemsFixture.storage.configuration[5].read_only = true;
+
+    const store = mockStore({
+      ...initialMockState,
+      systems: systemsFixture,
+    });
+
+    const { container } = renderComponent(
+      <Route path="/workbench/data/tapis/projects/">
+        <DataFilesSidebar />
+      </Route>,
+      store,
+      history
+    );
+
+    expect(Array.from(container.querySelectorAll('.dropdown-item'))
+      .find(el =>
+        el.textContent.includes('Shared Workspace'))
+      ).toBeUndefined();
   });
 });

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -116,7 +116,8 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'name': 'Shared Workspaces',
         'scheme': 'projects',
         'api': 'tapis',
-        'icon': None
+        'icon': None,
+        'read_only': True
     },
     {
         'name': 'Google Drive',

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -117,7 +117,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'scheme': 'projects',
         'api': 'tapis',
         'icon': None,
-        'read_only': True
+        'read_only': False
     },
     {
         'name': 'Google Drive',

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -116,7 +116,8 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'name': 'Shared Workspaces',
         'scheme': 'projects',
         'api': 'tapis',
-        'icon': None
+        'icon': None,
+        'read_only': False
     },
     {
         'name': 'Google Drive',


### PR DESCRIPTION
## Overview: ##
Adds a read only option to shared workspaces settings in `_PORTAL_DATAFILES_STORAGE_SYSTEMS` to disallow creation.

## Related Jira tickets: ##

* [FP-1117](https://jira.tacc.utexas.edu/browse/FP-1117)

## Summary of Changes: ##
Disables shared workspace creation if settings have the `read_only` option enabled.

## Testing Steps: ##
1. Add the read_only option to the Shared Workspaces item in `_PORTAL_DATAFILES_STORAGE_SYSTEMS` in  `settings_custom.py`.
2. Ensure that creating shared workspaces is disabled.

## UI Photos:
![Selection_005](https://user-images.githubusercontent.com/9425579/127066030-57b51223-8e68-4d56-93ff-60f36b979c12.png)

## Notes: ##
Wasn't sure if I should disable `Edit Descriptions` for read only shared workspaces.
Should I make this setting have an effect on [FP-1134](https://jira.tacc.utexas.edu/browse/FP-1134) for hiding it?.
