### PR TITLE
Task/FP-1134: Toggle Manage Team and Edit Description [A2CPS]

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
@@ -22,6 +22,14 @@ const DataFilesProjectFileListing = ({ system, path }) => {
 
   const metadata = useSelector(state => state.projects.metadata);
 
+  const userIsOwner = useSelector(state =>
+    metadata.members.some(
+      member =>
+        member.access === 'owner' &&
+        member.user.username === state.authenticatedUser.user.username
+    )
+  );
+
   const onEdit = () => {
     dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',
@@ -62,15 +70,17 @@ const DataFilesProjectFileListing = ({ system, path }) => {
       styleName="root"
       header={<div styleName="title">{metadata.title}</div>}
       headerActions={
-        <div styleName="controls">
-          <Button color="link" styleName="edit" onClick={onEdit}>
-            Edit Descriptions
-          </Button>
-          <span styleName="separator">|</span>
-          <Button color="link" styleName="edit" onClick={onManage}>
-            Manage Team
-          </Button>
-        </div>
+        userIsOwner && (
+          <div styleName="controls">
+            <Button color="link" styleName="edit" onClick={onEdit}>
+              Edit Descriptions
+            </Button>
+            <span styleName="separator">|</span>
+            <Button color="link" styleName="edit" onClick={onManage}>
+              Manage Team
+            </Button>
+          </div>
+        )
       }
       manualContent
     >
@@ -81,7 +91,7 @@ const DataFilesProjectFileListing = ({ system, path }) => {
                - (D) __both__ (A) or (B) __and__ (C)
       */}
       <div styleName="description">
-        <ReadMore>{metadata.description}</ReadMore>
+        {metadata.description && <ReadMore>{metadata.description}</ReadMore>}
       </div>
       <DataFilesListing
         api="tapis"

--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
@@ -22,13 +22,23 @@ const DataFilesProjectFileListing = ({ system, path }) => {
 
   const metadata = useSelector(state => state.projects.metadata);
 
-  const userIsOwner = useSelector(state =>
-    metadata.members.some(
-      member =>
-        member.access === 'owner' &&
-        member.user.username === state.authenticatedUser.user.username
-    )
-  );
+  const editable = useSelector(state => {
+    const projectSystem = state.systems.storage.configuration.find(
+      s => s.scheme === 'projects'
+    );
+
+    const privilegeRequired = projectSystem && projectSystem.privilegeRequired;
+
+    return (
+      !privilegeRequired ||
+      metadata.members.some(member => {
+        return (
+          member.access === 'owner' &&
+          member.user.username === state.authenticatedUser.user.username
+        );
+      })
+    );
+  });
 
   const onEdit = () => {
     dispatch({
@@ -70,7 +80,7 @@ const DataFilesProjectFileListing = ({ system, path }) => {
       styleName="root"
       header={<div styleName="title">{metadata.title}</div>}
       headerActions={
-        userIsOwner && (
+        editable && (
           <div styleName="controls">
             <Button color="link" styleName="edit" onClick={onEdit}>
               Edit Descriptions

--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.test.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.test.js
@@ -3,7 +3,7 @@ import configureStore from 'redux-mock-store';
 import renderComponent from 'utils/testing';
 import systemsFixture from '../../DataFiles/fixtures/DataFiles.systems.fixture'
 import filesFixture from '../fixtures/DataFiles.files.fixture';
-import {projectsFixture} from '../../../redux/sagas/fixtures/projects.fixture';
+import { projectsFixture, projectMetadataFixture } from '../../../redux/sagas/fixtures/projects.fixture';
 import DataFilesProjectFileListing from './DataFilesProjectFileListing';
 
 // Mock ResizeObserver
@@ -40,23 +40,86 @@ jest.mock('react-resize-detector', () => ({
 
 const mockStore = configureStore();
 const initialMockState = {
-  projects: projectsFixture,
+  projects: {
+    ...projectsFixture,
+    metadata: projectMetadataFixture
+  },
   files: filesFixture,
   systems: systemsFixture,
   pushKeys: {
     modals: filesFixture.modals,
     modalProps: filesFixture.modalProps
+  },
+  authenticatedUser: {
+    user: {
+      email: 'user@username.com',
+      first_name: 'Firstname',
+      last_name: 'Lastname',
+      username: 'username'
+    }
   }
 };
 
 describe('DataFilesProjectFileListing', () => {
-  it('', () => {
+  it('shows uses the Read More component for long descriptions', () => {
     const store = mockStore(initialMockState);
-    const {getByText} = renderComponent(
+    const { getByText } = renderComponent(
       <DataFilesProjectFileListing system="test.site.project.PROJECT-3" path="/" />,
       store
     );
 
     expect(getByText(/Read More/)).toBeDefined();
+  });
+
+  it('hides Edit Descriptions and Manage Team when privilege is needed and user is not owner', () => {
+    initialMockState.authenticatedUser.user.username = 'member';
+    initialMockState.systems.storage.configuration[5].privilegeRequired = true;
+    const store = mockStore(initialMockState);
+    const { queryByText } = renderComponent(
+      <DataFilesProjectFileListing system="test.site.project.PROJECT-3" path="/" />,
+      store
+    )
+
+    expect(queryByText(/Edit Descriptions/)).toBeNull();
+    expect(queryByText(/Manage Team/)).toBeNull();
+  });
+
+  it('shows Edit Descriptions and Manage Team when privilege is needed and user is owner', () => {
+    initialMockState.authenticatedUser.user.username = 'username';
+    initialMockState.systems.storage.configuration[5].privilegeRequired = true;
+    const store = mockStore(initialMockState);
+    const { getByText } = renderComponent(
+      <DataFilesProjectFileListing system="test.site.project.PROJECT-3" path="/" />,
+      store
+    )
+
+    expect(getByText(/Edit Descriptions/)).toBeDefined();
+    expect(getByText(/Manage Team/)).toBeDefined();
+  });
+
+  it('shows Edit Descriptions and Manage Team when privilege is not needed and user not owner', () => {
+    initialMockState.authenticatedUser.user.username = 'member';
+    initialMockState.systems.storage.configuration[5].privilegeRequired = false;
+    const store = mockStore(initialMockState);
+    const { getByText } = renderComponent(
+      <DataFilesProjectFileListing system="test.site.project.PROJECT-3" path="/" />,
+      store
+    )
+
+    expect(getByText(/Edit Descriptions/)).toBeDefined();
+    expect(getByText(/Manage Team/)).toBeDefined();
+  });
+
+  it('shows Edit Descriptions and Manage Team when privilege is not needed and user is not owner', () => {
+    initialMockState.authenticatedUser.user.username = 'member';
+    initialMockState.systems.storage.configuration[5].privilegeRequired = false;
+    const store = mockStore(initialMockState);
+    const { getByText } = renderComponent(
+      <DataFilesProjectFileListing system="test.site.project.PROJECT-3" path="/" />,
+      store
+    )
+
+    expect(getByText(/Edit Descriptions/)).toBeDefined();
+    expect(getByText(/Manage Team/)).toBeDefined();
   });
 });

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -88,7 +88,7 @@ const DataFilesSidebar = ({ readOnly }) => {
                   <i className="icon-folder" /> Folder
                 </span>
               </DropdownItem>
-              {sharedWorkspaces && !sharedWorkspaces.read_only && (
+              {sharedWorkspaces && !sharedWorkspaces.readOnly && (
                 <DropdownItem onClick={toggleAddProjectModal}>
                   <i className="icon-folder" /> Shared Workspace
                 </DropdownItem>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
@@ -64,7 +64,7 @@ describe('DataFilesSidebar', () => {
     const history = createMemoryHistory();
     history.push('/workbench/data/tapis/projects/');
 
-    systemsFixture.storage.configuration[5].read_only = true;
+    systemsFixture.storage.configuration[5].readOnly = true;
 
     const store = mockStore({
       ...initialMockState,

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -118,7 +118,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'api': 'tapis',
         'icon': None,
         'privilegeRequired': False
-        'read_only': False
+        'readOnly': False
     },
     {
         'name': 'Google Drive',

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -116,7 +116,8 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'name': 'Shared Workspaces',
         'scheme': 'projects',
         'api': 'tapis',
-        'icon': None
+        'icon': None,
+        'privilegeRequired': False
     },
     {
         'name': 'Google Drive',

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -117,7 +117,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'scheme': 'projects',
         'api': 'tapis',
         'icon': None,
-        'privilegeRequired': False
+        'privilegeRequired': False,
         'readOnly': False
     },
     {

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -118,7 +118,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'api': 'tapis',
         'icon': None,
         'privilegeRequired': False
-        'read_only': False
+        'readOnly': False
     },
     {
         'name': 'Google Drive',

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -116,7 +116,8 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'name': 'Shared Workspaces',
         'scheme': 'projects',
         'api': 'tapis',
-        'icon': None
+        'icon': None,
+        'privilegeRequired': False
     },
     {
         'name': 'Google Drive',

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -117,7 +117,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'scheme': 'projects',
         'api': 'tapis',
         'icon': None,
-        'privilegeRequired': False
+        'privilegeRequired': False,
         'readOnly': False
     },
     {


### PR DESCRIPTION
## Overview: ##
Allows a settings value to determine if privilege is needed for editing project data.

## Related Jira tickets: ##

* [FP-1134](https://jira.tacc.utexas.edu/browse/FP-1134)

## Summary of Changes: ##
Added a setting, `privilegeRequired`, in the project api setting.
When `True`, it will only display to an owner of the project.

## Testing Steps: ##
1. Toggle the setting values and check that the buttons enable only to an `owner` when `True`.

## UI Photos:
![screentshot](https://user-images.githubusercontent.com/9425579/127374333-05c468c8-eb9b-4bba-8f04-400617091ebb.png)

## Notes: ##
