### PR TITLE
[A2CPS] FP-1128: Accommodate non-portal created Projects

### DIFF
--- a/server/portal/apps/projects/models/base.py
+++ b/server/portal/apps/projects/models/base.py
@@ -113,7 +113,6 @@ class Project(object):
         if not self._storage.last_modified:
             logger.debug(self._storage.to_dict())
             raise Exception("Invalid storage system")
-        logger.debug(self.storage.roles.to_dict())
         if metadata is None:
             self._metadata = self._get_metadata()
         else:

--- a/server/portal/apps/projects/models/base.py
+++ b/server/portal/apps/projects/models/base.py
@@ -175,6 +175,8 @@ class Project(object):
                     # Get first role tuple, first item in tuple which is username
                     admin = get_user_model().objects.get(username=admins[0][0])
                     meta.pi = admin
+                    meta.full_clean()
+                    meta.save()
                 except ObjectDoesNotExist:
                     # User does not exist, skip PI assignment
                     pass

--- a/server/portal/apps/projects/models/base.py
+++ b/server/portal/apps/projects/models/base.py
@@ -159,7 +159,11 @@ class Project(object):
         try:
             meta = ProjectMetadata.objects.get(project_id=self.project_id)
         except ObjectDoesNotExist:
-            meta = self._create_metadata(self.title, self.project_id)
+            try:
+                user = get_user_model().objects.get(username=self.storage.owner)
+                meta = self._create_metadata(self.title, self.project_id, user)
+            except ObjectDoesNotExist:
+                meta = self._create_metadata(self.title, self.project_id)
 
         return meta
 

--- a/server/portal/apps/projects/models/unit_test.py
+++ b/server/portal/apps/projects/models/unit_test.py
@@ -8,7 +8,6 @@ from portal.apps.projects.models.metadata import ProjectMetadata
 from portal.apps.projects.models.base import Project
 from portal.libs.agave.models.systems.storage import StorageSystem
 import pytest
-from mock import MagicMock
 
 
 @pytest.fixture()
@@ -73,7 +72,7 @@ def test_project_create_storage_failure(mock_owner, portal_project, agave_client
     assert ProjectMetadata.objects.all().count() == 0
 
 
-def test_metadata_create_on_project_load(agave_client, mock_owner, mock_signal):
+def test_metadata_create_on_project_load(agave_client, mock_owner, mock_project_save_signal):
     agave_client.systems.listRoles.return_value = [{'username': 'username', 'role': 'ADMIN'}]
     sys = StorageSystem(agave_client, 'cep.test.PRJ-123')
     sys.last_modified = '1234'

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -115,12 +115,9 @@ class ProjectsApiView(BaseApiView):
         project_id = prj.project_id
         for member in members:
             try:
-                user = get_user_model().objects.get(username=member['username'])
                 if member['access'] == 'owner':
-                    prj.add_pi(user)
                     access = 'pi'
                 elif member['access'] == 'edit':
-                    prj.add_co_pi(user)
                     access = 'co_pi'
                 else:
                     raise ApiException("Unsupported access level")

--- a/server/portal/apps/projects/views_unit_test.py
+++ b/server/portal/apps/projects/views_unit_test.py
@@ -64,7 +64,6 @@ def test_projects_post(authenticated_user, client, mock_project_mgr):
     )
 
     mock_project_mgr.create.assert_called_with('Test Title')
-    mock_project.add_pi.assert_called_with(authenticated_user)
     mock_project_mgr.add_member.assert_called_with('PRJ-123', 'pi', 'username')
     assert response.status_code == 200
     assert response.json() == {


### PR DESCRIPTION
## Overview: ##
A2CPS admins will be creating project systems and sharing them with users manually via tapis. This means the portal will have no notion of users or owners associated with the project.

This PR will add tapis system owners to the ProjectMetadata record, if the owner has previously logged into the portal.

## Related Jira tickets: ##

* [FP-1128](https://jira.tacc.utexas.edu/browse/FP-1128)

## Testing Steps: ##
1. Create a project in cep.tacc.utexas.edu. This will take you to the project page, e.g. `https://cep.tacc.utexas.edu/workbench/data/tapis/projects/${systemId}`
2. In cep.dev, insert the resulting project system id in the local url, e.g. `https://cep.dev/workbench/data/tapis/projects/${systemID}`
3. In the "Manage Team" modal, ensure that you see yourself as the owner

## UI Photos:
<img width="1652" alt="Screen Shot 2021-08-09 at 2 20 55 PM" src="https://user-images.githubusercontent.com/20326896/128762163-57686381-cb24-4be9-8054-528d6dcae5bb.png">
<img width="817" alt="Screen Shot 2021-08-09 at 2 20 28 PM" src="https://user-images.githubusercontent.com/20326896/128762166-f7beb205-fd45-450e-9886-d83e5ad237c7.png">

