### PR TITLE
task/FP-1143: Convert underscore to hyphen in system ids

### DIFF
--- a/server/conftest.py
+++ b/server/conftest.py
@@ -66,6 +66,29 @@ def regular_user2(django_user_model, django_db_reset_sequences, mock_agave_clien
 
 
 @pytest.fixture
+def regular_user_with_underscore(django_user_model, django_db_reset_sequences, mock_agave_client):
+    django_user_model.objects.create_user(username="user_name",
+                                          password="password",
+                                          first_name="Firstname3",
+                                          last_name="Lastname3",
+                                          email="user_name@user.com")
+    user = django_user_model.objects.get(username="user_name")
+    token = AgaveOAuthToken.objects.create(
+        user=user,
+        token_type="bearer",
+        scope="default",
+        access_token="1234fsf",
+        refresh_token="123123123",
+        expires_in=14400,
+        created=1523633447)
+    token.save()
+    profile = PortalProfile.objects.create(user=user)
+    profile.save()
+    user.save()
+    yield user
+
+
+@pytest.fixture
 def authenticated_user(client, regular_user):
     client.force_login(regular_user)
     yield regular_user

--- a/server/portal/apps/accounts/managers/user_systems.py
+++ b/server/portal/apps/accounts/managers/user_systems.py
@@ -87,7 +87,7 @@ class UserSystemsManager():
         :returns: unique id for a user's home system. ex: [system].home.[username]
         :rtype: str
         """
-        return self.system['systemId'].format(username=self.user.username)
+        return self.system['systemId'].format(username=self.user.username.replace('_', '-'))
 
     def get_sys_tas_user_dir(self):
         """Gets path to user's home directory for given system

--- a/server/portal/apps/accounts/managers/user_systems_unit_test.py
+++ b/server/portal/apps/accounts/managers/user_systems_unit_test.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def tas_mock(mocker):
-    with open(os.path.join(settings.BASE_DIR, 'fixtures/tas/tas_user.json')) as f:
+    with open(os.path.join(settings.BASE_DIR, 'fixtures/tas/tas_user_with_underscore.json')) as f:
         tas_user = json.load(f)
     mock_get_user_data = mocker.patch('portal.apps.accounts.managers.user_systems.get_user_data')
     mock_get_user_data.return_value = tas_user
@@ -22,8 +22,8 @@ def tas_mock(mocker):
 
 
 @pytest.fixture
-def test_manager(tas_mock, regular_user):
-    yield UserSystemsManager(regular_user)
+def test_manager(tas_mock, regular_user_with_underscore):
+    yield UserSystemsManager(regular_user_with_underscore)
 
 
 @pytest.fixture
@@ -45,22 +45,22 @@ def mock_404(monkeypatch):
     yield mock_error
 
 
-def test_init(tas_mock, test_manager, regular_user):
+def test_init(tas_mock, test_manager, regular_user_with_underscore):
     # Assert that the default system will be loaded
     assert test_manager.system == settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS['frontera']
-    assert test_manager.tas_user['username'] == regular_user.username
+    assert test_manager.tas_user['username'] == regular_user_with_underscore.username
 
     # Assert that it loads a system by name
-    mgr = UserSystemsManager(regular_user, system_name='longhorn')
+    mgr = UserSystemsManager(regular_user_with_underscore, system_name='longhorn')
     assert mgr.system == settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS['longhorn']
 
 
 def test_lookup_methods(test_manager):
     assert test_manager.get_name() == 'My Data (Frontera)'
     assert test_manager.get_host() == 'frontera.tacc.utexas.edu'
-    assert test_manager.get_system_id() == 'frontera.home.username'
-    assert test_manager.get_sys_tas_user_dir() == '/home1/01234/username'
-    assert test_manager.get_private_directory() == '01234/username'
+    assert test_manager.get_system_id() == 'frontera.home.user-name'
+    assert test_manager.get_sys_tas_user_dir() == '/home1/01234/user_name'
+    assert test_manager.get_private_directory() == '01234/user_name'
 
 
 def test_setup_private_system_exists(test_manager, mock_service_account):
@@ -70,7 +70,7 @@ def test_setup_private_system_exists(test_manager, mock_service_account):
         assert test_manager.setup_private_system().id == system['id']
 
 
-def test_setup_private_system(test_manager, mock_service_account, regular_user, mock_404, monkeypatch):
+def test_setup_private_system(test_manager, mock_service_account, regular_user_with_underscore, mock_404, monkeypatch):
     with open(os.path.join(settings.BASE_DIR, 'fixtures/agave/systems/storage.json')) as f:
         system = json.load(f)
     # Mock all the service functions
@@ -83,10 +83,10 @@ def test_setup_private_system(test_manager, mock_service_account, regular_user, 
     assert test_manager.setup_private_system().id == system_definition.id
 
     mock_service_account.systems.updateRole.assert_called_with(
-        body={'role': "OWNER", 'username': regular_user.username},
+        body={'role': "OWNER", 'username': regular_user_with_underscore.username},
         systemId=system_definition.id)
     system_key = SSHKeys.objects.all()[0]
-    assert system_key.user == regular_user
+    assert system_key.user == regular_user_with_underscore
     host_key = HostKeys.objects.all()[0]
     assert host_key.hostname == system['storage']['host']
     key_object = Keys.objects.get(ssh_keys=system_key)
@@ -96,8 +96,8 @@ def test_setup_private_system(test_manager, mock_service_account, regular_user, 
 def test_get_system_definition(test_manager, mock_service_account, mock_404):
     mock_service_account.systems.get.side_effect = mock_404
     system = test_manager.get_system_definition("public_key", "private_key")
-    assert system.name == "frontera.home.username"
+    assert system.name == "frontera.home.user-name"
     assert system.storage.host == "frontera.tacc.utexas.edu"
-    assert system.storage.root_dir == "/home1/01234/username"
+    assert system.storage.root_dir == "/home1/01234/user_name"
     assert system.storage.auth.public_key == "public_key"
     assert system.storage.auth.private_key == "private_key"

--- a/server/portal/apps/search/tasks.py
+++ b/server/portal/apps/search/tasks.py
@@ -91,22 +91,22 @@ def project_indexer(self, listing):
 
 
 # Indexing task for My Data.
-@shared_task(bind=True, queue='indexing')
-def index_my_data(self, reindex=False):
-    users = User.objects.all()
-    for user in users:
-        uname = user.username
-        default_sys = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT
-        default_system_prefix = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS[default_sys]['prefix']
-        systemId = default_system_prefix.format(uname)
+# @shared_task(bind=True, queue='indexing')
+# def index_my_data(self, reindex=False):
+#     users = User.objects.all()
+#     for user in users:
+#         uname = user.username
+#         default_sys = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT
+#         default_system_prefix = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS[default_sys]['prefix']
+#         systemId = default_system_prefix.format(uname)
 
-        # s = IndexedFile.search()
-        # s = s.query("match", **{"system._exact": systemId})
-        # resp = s.delete()
-        agave_indexer.apply_async(
-            args=[systemId],
-            kwargs={'filePath': '/', 'reindex': reindex}
-        )
+#         # s = IndexedFile.search()
+#         # s = s.query("match", **{"system._exact": systemId})
+#         # resp = s.delete()
+#         agave_indexer.apply_async(
+#             args=[systemId],
+#             kwargs={'filePath': '/', 'reindex': reindex}
+#         )
 
 
 # @shared_task(bind=True, queue='indexing')

--- a/server/portal/apps/system_creation/utils.py
+++ b/server/portal/apps/system_creation/utils.py
@@ -80,7 +80,7 @@ def _get_tas_dir(user):
 def _create_substitutions(user):
     substitutions = {}
     substitutions["tasdir"] = _get_tas_dir(user)
-    substitutions["username"] = user.username
+    substitutions["username"] = user.username.replace('_', '-')
     substitutions["portal"] = settings.PORTAL_DOMAIN
     return substitutions
 

--- a/server/portal/apps/system_creation/utils_unit_test.py
+++ b/server/portal/apps/system_creation/utils_unit_test.py
@@ -61,15 +61,11 @@ def test_create_substitutions(regular_user, mocker):
     assert subs == expected
 
 
-def test_substitute_user_variables(regular_user, mocker):
-    mock_substitutions = mocker.patch('portal.apps.system_creation.utils._create_substitutions')
-    mock_substitutions.return_value = {
-        "tasdir": "12345/MOCK_WORK",
-        "username": "username",
-        "portal": "test.portal"
-    }
+def test_substitute_user_variables(regular_user_with_underscore, mocker):
+    mock_substitutions = mocker.patch('portal.apps.system_creation.utils._get_tas_dir')
+    mock_substitutions.return_value = "12345/MOCK_WORK"
     systemId, variables = substitute_user_variables(
-        regular_user,
+        regular_user_with_underscore,
         "data-tacc-work-{username}",
         {
             "description": "Home system for {portal}",
@@ -83,8 +79,8 @@ def test_substitute_user_variables(regular_user, mocker):
         "rootDir": "/work/12345/MOCK_WORK",
         "description": "Home system for test.portal",
         "site": "test.portal",
-        "id": "data-tacc-work-username",
-        "name": "data-tacc-work-username"
+        "id": "data-tacc-work-user-name",
+        "name": "data-tacc-work-user-name"
     }
-    assert systemId == "data-tacc-work-username"
+    assert systemId == "data-tacc-work-user-name"
     assert variables == expected_variables

--- a/server/portal/apps/users/views.py
+++ b/server/portal/apps/users/views.py
@@ -47,7 +47,7 @@ class UsageView(BaseApiView):
         if not system_id:
             # get default system prefix
             default_sys = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT
-            default_system_prefix = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS[default_sys]['prefix']
+            default_system_prefix = settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS[default_sys]['systemId']
             system_id = default_system_prefix.format(username)
 
         search = IndexedFile.search()

--- a/server/portal/fixtures/tas/tas_user_with_underscore.json
+++ b/server/portal/fixtures/tas/tas_user_with_underscore.json
@@ -1,0 +1,23 @@
+{
+    "id": 123456,
+    "username": "user_name",
+    "email": "user_name@username.com",
+    "firstName": "Firstname2",
+    "lastName": "Lastname2",
+    "institution": "University of Texas at Austin",
+    "institutionId": 1,
+    "department": "Texas Advanced Computing Center",
+    "departmentId": 127,
+    "country": "United States",
+    "countryId": 230,
+    "citizenship": "United States",
+    "citizenshipId": 230,
+    "piEligibility": "Eligible",
+    "source": "Standard",
+    "phone": "5125125125",
+    "title": "Center Non-Researcher Staff",
+    "uid": 123456,
+    "homeDirectory": "01234/user_name",
+    "gid": 456789,
+    "emailConfirmations": []
+}


### PR DESCRIPTION
## Overview: ##
Tapis doesn't support system ids with underscores, and we use a user's `username` in the system id for uniqueness, which causes an issue for users with underscores. This has been brought up with CIC, and [they are looking into allowing underscores in usernames](https://jira.tacc.utexas.edu/browse/CIC-4520), but in the meantime we have [active tickets](https://consult.tacc.utexas.edu/Ticket/Display.html?id=72795) with users who can't access the portal because of this bug.

Note: We can make this swap, because [TUP does not allow hyphens in usernames](https://portal.tacc.utexas.edu/), so the swap should still result in a unique string.

## Related Jira tickets: ##

* [FP-1143](https://jira.tacc.utexas.edu/browse/FP-1143)
* [CIC-4520](https://jira.tacc.utexas.edu/browse/CIC-4520)

## Summary of Changes: ##
- Convert `_` to `-` in usernames in system ids
- Add unit tests to cover changes

## Testing Steps: ##
1. Create a test user with an underscore in TUP, and get the account approved
2. Login to https://cep.dev/ and ensure that you get past onboarding

## UI Photos:
- N/A

## Notes: ##
