### PR TITLE
Bug/FP-1151: Shared workspace privilege bypass

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
@@ -14,7 +14,7 @@ const DataFilesAddProjectModal = () => {
   const match = useRouteMatch();
   const dispatch = useDispatch();
   const isOpen = useSelector(state => state.files.modals.addproject);
-  const { members } = useSelector(state => state.projects.metadata);
+  const { formMembers } = useSelector(state => state.projects.metadata);
   const isCreating = useSelector(state => {
     return (
       state.projects.operation &&
@@ -48,7 +48,7 @@ const DataFilesAddProjectModal = () => {
       type: 'PROJECTS_CREATE',
       payload: {
         title,
-        members: members.map(member => ({
+        members: formMembers.map(member => ({
           username: member.user.username,
           access: member.access
         })),
@@ -60,7 +60,7 @@ const DataFilesAddProjectModal = () => {
   const onAdd = useCallback(
     newUser => {
       dispatch({
-        type: 'PROJECTS_MEMBER_LIST_ADD',
+        type: 'PROJECTS_FORM_MEMBER_LIST_ADD',
         payload: newUser
       });
     },
@@ -70,7 +70,7 @@ const DataFilesAddProjectModal = () => {
   const onRemove = useCallback(
     removedUser => {
       dispatch({
-        type: 'PROJECTS_MEMBER_LIST_REMOVE',
+        type: 'PROJECTS_FORM_MEMBER_LIST_REMOVE',
         payload: removedUser
       });
     },
@@ -113,7 +113,7 @@ const DataFilesAddProjectModal = () => {
                 }
               />
               <DataFilesProjectMembers
-                members={members}
+                members={formMembers}
                 onAdd={onAdd}
                 onRemove={onRemove}
               />

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import * as Yup from 'yup';
 import { Formik, Form } from 'formik';
@@ -13,8 +13,9 @@ const DataFilesAddProjectModal = () => {
   const history = useHistory();
   const match = useRouteMatch();
   const dispatch = useDispatch();
+  const { user } = useSelector(state => state.authenticatedUser);
+  const [members, setMembers] = useState([{ user, access: 'owner' }]);
   const isOpen = useSelector(state => state.files.modals.addproject);
-  const { formMembers } = useSelector(state => state.projects.metadata);
   const isCreating = useSelector(state => {
     return (
       state.projects.operation &&
@@ -48,7 +49,7 @@ const DataFilesAddProjectModal = () => {
       type: 'PROJECTS_CREATE',
       payload: {
         title,
-        members: formMembers.map(member => ({
+        members: members.map(member => ({
           username: member.user.username,
           access: member.access
         })),
@@ -57,25 +58,15 @@ const DataFilesAddProjectModal = () => {
     });
   };
 
-  const onAdd = useCallback(
-    newUser => {
-      dispatch({
-        type: 'PROJECTS_FORM_MEMBER_LIST_ADD',
-        payload: newUser
-      });
-    },
-    [dispatch]
-  );
+  const onAdd = newUser => {
+    setMembers([...members, newUser]);
+  };
 
-  const onRemove = useCallback(
-    removedUser => {
-      dispatch({
-        type: 'PROJECTS_FORM_MEMBER_LIST_REMOVE',
-        payload: removedUser
-      });
-    },
-    [dispatch]
-  );
+  const onRemove = removedUser => {
+    setMembers(
+      members.filter(m => m.user.username !== removedUser.user.username)
+    );
+  };
 
   const validationSchema = Yup.object().shape({
     title: Yup.string()
@@ -113,7 +104,7 @@ const DataFilesAddProjectModal = () => {
                 }
               />
               <DataFilesProjectMembers
-                members={formMembers}
+                members={members}
                 onAdd={onAdd}
                 onRemove={onRemove}
               />

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
@@ -27,9 +27,7 @@ const initialMockState = {
       loading: false,
       error: null
     },
-    metadata: {
-      ...projectMetadataFixture,
-    }
+    metadata: projectMetadataFixture,
   },
   authenticatedUser: {
     user: {

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
@@ -27,7 +27,20 @@ const initialMockState = {
       loading: false,
       error: null
     },
-    metadata: projectMetadataFixture
+    metadata: {
+      ...projectMetadataFixture,
+      formMembers: [
+        {
+          user: {
+            username: 'username',
+            first_name: 'User',
+            last_name: 'Name',
+            email: 'user@username.com'
+          },
+          access: 'owner'
+        }
+      ]
+    }
   },
   authenticatedUser: {
     user: {

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
@@ -29,17 +29,6 @@ const initialMockState = {
     },
     metadata: {
       ...projectMetadataFixture,
-      formMembers: [
-        {
-          user: {
-            username: 'username',
-            first_name: 'User',
-            last_name: 'Name',
-            email: 'user@username.com'
-          },
-          access: 'owner'
-        }
-      ]
     }
   },
   authenticatedUser: {

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -51,7 +51,7 @@ const DataFilesSidebar = ({ readOnly }) => {
       type: 'PROJECTS_CLEAR_OPERATION'
     });
     dispatch({
-      type: 'PROJECTS_MEMBER_LIST_SET',
+      type: 'PROJECTS_FORM_MEMBER_LIST_SET',
       payload: [{ user, access: 'owner' }]
     });
     dispatch({

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -32,7 +32,6 @@ const DataFilesSidebar = ({ readOnly }) => {
     state => state.systems.storage.configuration,
     shallowEqual
   );
-  const { user } = useSelector(state => state.authenticatedUser);
 
   const sharedWorkspaces = systems.find(e => e.scheme === 'projects');
 
@@ -49,10 +48,6 @@ const DataFilesSidebar = ({ readOnly }) => {
     });
     dispatch({
       type: 'PROJECTS_CLEAR_OPERATION'
-    });
-    dispatch({
-      type: 'PROJECTS_FORM_MEMBER_LIST_SET',
-      payload: [{ user, access: 'owner' }]
     });
     dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',

--- a/client/src/redux/reducers/projects.reducers.js
+++ b/client/src/redux/reducers/projects.reducers.js
@@ -112,14 +112,6 @@ export default function projects(state = initialState, action) {
           members: [...action.payload]
         }
       };
-    case 'PROJECTS_FORM_MEMBER_LIST_SET':
-      return {
-        ...state,
-        metadata: {
-          ...state.metadata,
-          formMembers: [...action.payload]
-        }
-      };
     case 'PROJECTS_MEMBER_LIST_ADD':
       return {
         ...state,
@@ -128,34 +120,12 @@ export default function projects(state = initialState, action) {
           members: addProjectMember(state.metadata.members, action.payload)
         }
       };
-    case 'PROJECTS_FORM_MEMBER_LIST_ADD':
-      return {
-        ...state,
-        metadata: {
-          ...state.metadata,
-          formMembers: addProjectMember(
-            state.metadata.formMembers,
-            action.payload
-          )
-        }
-      };
     case 'PROJECTS_MEMBER_LIST_REMOVE':
       return {
         ...state,
         metadata: {
           ...state.metadata,
           members: removeProjectMember(state.metadata.members, action.payload)
-        }
-      };
-    case 'PROJECTS_FORM_MEMBER_LIST_REMOVE':
-      return {
-        ...state,
-        metadata: {
-          ...state.metadata,
-          formMembers: removeProjectMember(
-            state.metadata.formMembers,
-            action.payload
-          )
         }
       };
     case 'PROJECTS_GET_METADATA_STARTED':

--- a/client/src/redux/reducers/projects.reducers.js
+++ b/client/src/redux/reducers/projects.reducers.js
@@ -104,14 +104,6 @@ export default function projects(state = initialState, action) {
           result: null
         }
       };
-    case 'PROJECTS_MEMBER_LIST_SET':
-      return {
-        ...state,
-        metadata: {
-          ...state.metadata,
-          members: [...action.payload]
-        }
-      };
     case 'PROJECTS_MEMBER_LIST_ADD':
       return {
         ...state,

--- a/client/src/redux/reducers/projects.reducers.js
+++ b/client/src/redux/reducers/projects.reducers.js
@@ -112,6 +112,14 @@ export default function projects(state = initialState, action) {
           members: [...action.payload]
         }
       };
+    case 'PROJECTS_FORM_MEMBER_LIST_SET':
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          formMembers: [...action.payload]
+        }
+      };
     case 'PROJECTS_MEMBER_LIST_ADD':
       return {
         ...state,
@@ -120,12 +128,34 @@ export default function projects(state = initialState, action) {
           members: addProjectMember(state.metadata.members, action.payload)
         }
       };
+    case 'PROJECTS_FORM_MEMBER_LIST_ADD':
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          formMembers: addProjectMember(
+            state.metadata.formMembers,
+            action.payload
+          )
+        }
+      };
     case 'PROJECTS_MEMBER_LIST_REMOVE':
       return {
         ...state,
         metadata: {
           ...state.metadata,
           members: removeProjectMember(state.metadata.members, action.payload)
+        }
+      };
+    case 'PROJECTS_FORM_MEMBER_LIST_REMOVE':
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          formMembers: removeProjectMember(
+            state.metadata.formMembers,
+            action.payload
+          )
         }
       };
     case 'PROJECTS_GET_METADATA_STARTED':


### PR DESCRIPTION
## Overview: ##
This PR fixes the bug where a user with `edit` access can bypass the `owner` check when `privilegeRequired` settings is set to `True`.

The reason behind this was that the `member` list in the project `metadata` was shared and modified (`PROJECTS_MEMBER_LIST_SET` in `DataFilesSidebar.js`) on opening the
project create modal (**+ Add -> Shared  Workspace**).

While working on this, I also noticed that the member listing when clicking on **Manage Team** also changed if one opens the project create modal (**+ Add -> Shared  Workspace**) (reverting to only showing the currently authenticated user).

This PR mitigates both bugs.

## Related Jira tickets: ##

* [FP-1151](https://jira.tacc.utexas.edu/browse/FP-1151)

## Summary of Changes: ##
Added a new state for local member list (`formMembers`) in the project metadata only used by `DataFilesSidebar` and `DataFilesAddProjectModal`.
I've also made separate actions to remove/add/set this state.

## Testing Steps: ##
1. In `server/portal/settings/settings_custom.py`, set `privilegeRequired` to `True`.
2. Go to a Shared Workspace that **is not** owned by you (you would have `edit` access).
3. Ensure that you do not see **Edit Descriptions | Manage Teams**.
4. Open the create project modal with **+ Add -> Shared  Workspace**.
5. Close the modal.
6. Ensure that you still do not see **Edit Descriptions | Manage Teams**.
7. Go to a Shared Workspace that **is** owned by you.
8. Add another member using **Manage Team**.
9. Open the create project modal with **+ Add -> Shared  Workspace**.
10. Close the modal.
11. Open **Manage Team** again and ensure that you see the member you added.

## UI Photos:

## Notes: ##