### PR TITLE
task/FP-1172 - Extend Django Page model

### DIFF
--- a/server/portal/apps/extended_cms/admin.py
+++ b/server/portal/apps/extended_cms/admin.py
@@ -3,8 +3,7 @@ from cms.extensions import PageExtensionAdmin
 
 from .models import IconExtension
 
-
-class AuthorizationExtensionAdmin(PageExtensionAdmin):
+class AuthenticationExtensionAdmin(PageExtensionAdmin):
     pass
 
-admin.site.register(AuthorizationExtension, AuthorizationExtensionAdmin)
+admin.site.register(AuthenticationExtension, AuthenticationExtensionAdmin)

--- a/server/portal/apps/extended_cms/models.py
+++ b/server/portal/apps/extended_cms/models.py
@@ -3,7 +3,7 @@ from cms.extensions import PageExtension
 from cms.extensions.extension_pool import extension_pool
 
 
-class AuthorizationExtension(PageExtension):
-    pass
+class AuthenticationExtension(PageExtension):
+    authentication = models.BooleanField()
 
-extension_pool.register(AuthorizationExtension)
+extension_pool.register(AuthenticationExtension)


### PR DESCRIPTION
## Overview: ##

A CMS user must be able to mark page as requiring, or not requiring, authentication.

## Related Jira tickets: ##

* [FP-1172](https://jira.tacc.utexas.edu/browse/FP-1172)

## Summary of Changes: ##
Added a boolean field in page model to allow CMS to control whether authenticated users can or can't view the page. There are more changes to come, but they come through the CMS.

## Testing Steps: ##
Make sure that it builds.

## UI Photos:

## Notes: ##
