### PR TITLE
Reduce initial load time by circumventing the global Elasticsearch client.

### DIFF
--- a/server/portal/libs/elasticsearch/docs/base.py
+++ b/server/portal/libs/elasticsearch/docs/base.py
@@ -5,6 +5,7 @@
 import logging
 import datetime
 from django.conf import settings
+from elasticsearch import Elasticsearch
 from elasticsearch_dsl import (Document, Date, Object, Text, Long, Boolean,
                                Keyword)
 from portal.libs.elasticsearch.analyzers import path_analyzer, file_analyzer, file_pattern_analyzer, reverse_file_analyzer
@@ -192,8 +193,11 @@ class IndexedAllocation(Document):
         ------
         elasticsearch.exceptions.NotFoundError
         """
+        es_client = Elasticsearch([{'host': settings.ES_HOSTS,
+                                    'http_auth': settings.ES_AUTH}],
+                                  timeout=10)
         uuid = get_sha256_hash(username)
-        return cls.get(uuid)
+        return cls.get(uuid, using=es_client)
 
     class Index:
         name = settings.ES_INDEX_PREFIX.format('allocations')

--- a/server/portal/libs/elasticsearch/docs/unit_test.py
+++ b/server/portal/libs/elasticsearch/docs/unit_test.py
@@ -63,11 +63,13 @@ class TestIndexedFile(TestCase):
 
 
 class TestIndexedAllocation(TestCase):
-
     @patch('portal.libs.elasticsearch.docs.base.IndexedAllocation.get')
-    def test_from_username(self, mock_get):
+    @patch('portal.libs.elasticsearch.docs.base.Elasticsearch')
+    def test_from_username(self, mock_es, mock_get):
+        mock_es_client = MagicMock()
+        mock_es.return_value = mock_es_client
         IndexedAllocation.from_username('testuser')
-        mock_get.assert_called_once_with('ae5deb822e0d71992900471a7199d0d95b8e7c9d05c40a8245a281fd2c1d6684')
+        mock_get.assert_called_once_with('ae5deb822e0d71992900471a7199d0d95b8e7c9d05c40a8245a281fd2c1d6684', using=mock_es_client)
 
 
 class TestIndexedProject(TestCase):


### PR DESCRIPTION
## Overview: ##
The global ES client consistently times out on the initial load, resulting in 10+ seconds of the UI hanging. Instantiating a new client inside the method fixes this.

## Summary of Changes: ##
- Create a fresh ES client inside of `IndexedAllocation.from_username`
- Update tests

## Testing Steps: ##
1. Update `_ES_HOSTS` and `_ES_AUTH` in settings_secret to point to a staging or production environment
2. Log into the portal and check the network requests in your browser's devtools to make sure that allocations were retrieved.
