### PR TITLE
(quick fix) Task/FP-1171: Toggle Data Files.

### DIFF
--- a/client/src/components/ManageAccount/ManageAccount.js
+++ b/client/src/components/ManageAccount/ManageAccount.js
@@ -28,6 +28,9 @@ const ManageAccountView = () => {
     errors,
     data: { licenses, integrations }
   } = useSelector(state => state.profile);
+
+  const { hideDataFiles } = useSelector(state => state.workbench.config);
+
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch({ type: 'GET_PROFILE_DATA' });
@@ -66,8 +69,8 @@ const ManageAccountView = () => {
             <ChangePasswordModal />
             <EditOptionalInformationModal />
             <EditRequiredInformationModal />
-            {!isEmpty(licenses) && <Licenses />}
-            {!isEmpty(integrations) && <Integrations />}
+            {!hideDataFiles && !isEmpty(licenses) && <Licenses />}
+            {!hideDataFiles && !isEmpty(integrations) && <Integrations />}
             <ChangePassword />
           </>
         )

--- a/client/src/components/ManageAccount/ManageAccountTables.js
+++ b/client/src/components/ManageAccount/ManageAccountTables.js
@@ -172,7 +172,6 @@ LicenseCell.propTypes = {
 /* eslint-enable react/no-danger */
 export const Licenses = () => {
   const { licenses } = useSelector(state => state.profile.data);
-  const { hideDataFiles } = useSelector(state => state.workbench.config);
 
   const columns = useMemo(
     () =>
@@ -187,14 +186,12 @@ export const Licenses = () => {
   );
   const data = useMemo(() => licenses, [licenses]);
   return (
-    !hideDataFiles && (
-      <SectionTableWrapper
-        manualHeader={<SectionHeader isForList>Licenses</SectionHeader>}
-        manualContent
-      >
-        <TableTemplate attributes={{ columns, data }} />
-      </SectionTableWrapper>
-    )
+    <SectionTableWrapper
+      manualHeader={<SectionHeader isForList>Licenses</SectionHeader>}
+      manualContent
+    >
+      <TableTemplate attributes={{ columns, data }} />
+    </SectionTableWrapper>
   );
 };
 
@@ -257,7 +254,6 @@ GoogleDriveIntegrationCell.propTypes = {
 
 export const Integrations = () => {
   const { integrations } = useSelector(state => state.profile.data);
-  const { hideDataFiles } = useSelector(state => state.workbench.config);
   const columns = useMemo(
     () =>
       integrations.map(app => ({
@@ -269,14 +265,12 @@ export const Integrations = () => {
   );
   const data = useMemo(() => integrations, [integrations]);
   return (
-    !hideDataFiles && (
-      <SectionTableWrapper
-        manualHeader={<SectionHeader isForList>3rd Party Apps</SectionHeader>}
-        manualContent
-      >
-        <TableTemplate attributes={{ columns, data }} />
-      </SectionTableWrapper>
-    )
+    <SectionTableWrapper
+      manualHeader={<SectionHeader isForList>3rd Party Apps</SectionHeader>}
+      manualContent
+    >
+      <TableTemplate attributes={{ columns, data }} />
+    </SectionTableWrapper>
   );
 };
 export const ChangePassword = () => {

--- a/client/src/components/ManageAccount/ManageAccountTables.js
+++ b/client/src/components/ManageAccount/ManageAccountTables.js
@@ -172,6 +172,8 @@ LicenseCell.propTypes = {
 /* eslint-enable react/no-danger */
 export const Licenses = () => {
   const { licenses } = useSelector(state => state.profile.data);
+  const { hideDataFiles } = useSelector(state => state.workbench.config);
+
   const columns = useMemo(
     () =>
       licenses.map(license => {
@@ -185,12 +187,14 @@ export const Licenses = () => {
   );
   const data = useMemo(() => licenses, [licenses]);
   return (
-    <SectionTableWrapper
-      manualHeader={<SectionHeader isForList>Licenses</SectionHeader>}
-      manualContent
-    >
-      <TableTemplate attributes={{ columns, data }} />
-    </SectionTableWrapper>
+    !hideDataFiles && (
+      <SectionTableWrapper
+        manualHeader={<SectionHeader isForList>Licenses</SectionHeader>}
+        manualContent
+      >
+        <TableTemplate attributes={{ columns, data }} />
+      </SectionTableWrapper>
+    )
   );
 };
 
@@ -253,6 +257,7 @@ GoogleDriveIntegrationCell.propTypes = {
 
 export const Integrations = () => {
   const { integrations } = useSelector(state => state.profile.data);
+  const { hideDataFiles } = useSelector(state => state.workbench.config);
   const columns = useMemo(
     () =>
       integrations.map(app => ({
@@ -264,12 +269,14 @@ export const Integrations = () => {
   );
   const data = useMemo(() => integrations, [integrations]);
   return (
-    <SectionTableWrapper
-      manualHeader={<SectionHeader isForList>3rd Party Apps</SectionHeader>}
-      manualContent
-    >
-      <TableTemplate attributes={{ columns, data }} />
-    </SectionTableWrapper>
+    !hideDataFiles && (
+      <SectionTableWrapper
+        manualHeader={<SectionHeader isForList>3rd Party Apps</SectionHeader>}
+        manualContent
+      >
+        <TableTemplate attributes={{ columns, data }} />
+      </SectionTableWrapper>
+    )
   );
 };
 export const ChangePassword = () => {

--- a/client/src/components/ManageAccount/tests/ManageAccount.test.js
+++ b/client/src/components/ManageAccount/tests/ManageAccount.test.js
@@ -18,7 +18,9 @@ describe('Manage Account Page', () => {
     const { getByText, getAllByText, getByRole } = render(
       <Provider store={mockStore({
         profile,
-        workbench,
+        workbench: {
+          ...workbench, config: {hideDataFiles: false}
+        },
         notifications,
         welcomeMessages,
         ticketCreate

--- a/client/src/components/ManageAccount/tests/ManageAccountTables.test.js
+++ b/client/src/components/ManageAccount/tests/ManageAccountTables.test.js
@@ -62,10 +62,7 @@ const mockStore = configureStore({});
 describe('Required Information Component', () => {
   let getByText;
   const testStore = mockStore({
-    profile: dummyState,
-    workbench: {
-      ...workbench, config: {hideDataFiles: false}
-    }
+    profile: dummyState
   });
   beforeEach(() => {
     const utils = render(
@@ -107,10 +104,7 @@ describe('Required Information Component', () => {
 describe('Change Password Component', () => {
   let getByText, getAllByText;
   const testStore = mockStore({
-    profile: dummyState,
-    workbench: {
-      ...workbench, config: {hideDataFiles: false}
-    }
+    profile: dummyState
   });
   beforeEach(() => {
     const utils = render(
@@ -144,10 +138,7 @@ describe('Third Party Apps', () => {
 
   it('Shows connect link when not connected', () => {
     const testStore = mockStore({
-      profile: dummyState,
-      workbench: {
-        ...workbench, config: {hideDataFiles: false}
-      }
+      profile: dummyState
     });
     const { getByText } = render(
       <Provider store={testStore}>
@@ -160,9 +151,6 @@ describe('Third Party Apps', () => {
   });
   it('Shows disconnect link when  connected', () => {
     const testStore = mockStore({
-      workbench: {
-        ...workbench, config: {hideDataFiles: false}
-      },
       profile: {
         ...dummyState,
         data: {
@@ -191,10 +179,7 @@ describe('Third Party Apps', () => {
 describe('Optional Information Component', () => {
   let getByText;
   const testStore = mockStore({
-    profile: dummyState,
-    workbench: {
-      ...workbench, config: {hideDataFiles: false}
-    }
+    profile: dummyState
   });
   beforeEach(() => {
     const utils = render(
@@ -230,10 +215,7 @@ describe('Optional Information Component', () => {
 describe('License Cell', () => {
   let getByText, getByRole;
   const testStore = mockStore({
-    profile: dummyState,
-    workbench: {
-      ...workbench, config: {hideDataFiles: false}
-    }
+    profile: dummyState
   });
   beforeEach(() => {
     const utils = render(

--- a/client/src/components/ManageAccount/tests/ManageAccountTables.test.js
+++ b/client/src/components/ManageAccount/tests/ManageAccountTables.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, wait, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { initialState as workbench } from '../../../redux/reducers/workbench.reducers';
 import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import {
@@ -61,7 +62,10 @@ const mockStore = configureStore({});
 describe('Required Information Component', () => {
   let getByText;
   const testStore = mockStore({
-    profile: dummyState
+    profile: dummyState,
+    workbench: {
+      ...workbench, config: {hideDataFiles: false}
+    }
   });
   beforeEach(() => {
     const utils = render(
@@ -103,7 +107,10 @@ describe('Required Information Component', () => {
 describe('Change Password Component', () => {
   let getByText, getAllByText;
   const testStore = mockStore({
-    profile: dummyState
+    profile: dummyState,
+    workbench: {
+      ...workbench, config: {hideDataFiles: false}
+    }
   });
   beforeEach(() => {
     const utils = render(
@@ -137,7 +144,10 @@ describe('Third Party Apps', () => {
 
   it('Shows connect link when not connected', () => {
     const testStore = mockStore({
-      profile: dummyState
+      profile: dummyState,
+      workbench: {
+        ...workbench, config: {hideDataFiles: false}
+      }
     });
     const { getByText } = render(
       <Provider store={testStore}>
@@ -150,6 +160,9 @@ describe('Third Party Apps', () => {
   });
   it('Shows disconnect link when  connected', () => {
     const testStore = mockStore({
+      workbench: {
+        ...workbench, config: {hideDataFiles: false}
+      },
       profile: {
         ...dummyState,
         data: {
@@ -178,7 +191,10 @@ describe('Third Party Apps', () => {
 describe('Optional Information Component', () => {
   let getByText;
   const testStore = mockStore({
-    profile: dummyState
+    profile: dummyState,
+    workbench: {
+      ...workbench, config: {hideDataFiles: false}
+    }
   });
   beforeEach(() => {
     const utils = render(
@@ -214,7 +230,10 @@ describe('Optional Information Component', () => {
 describe('License Cell', () => {
   let getByText, getByRole;
   const testStore = mockStore({
-    profile: dummyState
+    profile: dummyState,
+    workbench: {
+      ...workbench, config: {hideDataFiles: false}
+    }
   });
   beforeEach(() => {
     const utils = render(


### PR DESCRIPTION
## Overview: ##
Additional PR to #471 

## Related Jira tickets: ##

* [FP-1171](https://jira.tacc.utexas.edu/browse/FP-1171)

## Summary of Changes: ##
Hides 3rd Party Apps and Licenses in Manage Account component when `hideDataFiles` is `True`.

## Testing Steps: ##
1. Set `hideDataFiles` in `settings_custom.py` to `True`.
2. Ensure that 3rd Party Apps and License are hidden in `/workbench/account/`.

## UI Photos:
N/A

## Notes: ##
