### PR TITLE
fixed styling differences in disabled dropdown options between Commun…

### DIFF
--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -117,7 +117,7 @@ const DataFiles = () => {
   const readOnly =
     listingParams.scheme === 'projects' &&
     (listingParams.system === '' || !listingParams.system);
-    
+
   if (error) {
     return (
       <div styleName="error">

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -113,11 +113,9 @@ const DataFiles = () => {
   const loading = useSelector(state => state.systems.storage.loading);
   const error = useSelector(state => state.systems.storage.error);
   const systems = useSelector(state => state.systems.storage.configuration);
-
   const readOnly =
     listingParams.scheme === 'projects' &&
     (listingParams.system === '' || !listingParams.system);
-
   if (error) {
     return (
       <div styleName="error">

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -113,9 +113,11 @@ const DataFiles = () => {
   const loading = useSelector(state => state.systems.storage.loading);
   const error = useSelector(state => state.systems.storage.error);
   const systems = useSelector(state => state.systems.storage.configuration);
+
   const readOnly =
     listingParams.scheme === 'projects' &&
     (listingParams.system === '' || !listingParams.system);
+    
   if (error) {
     return (
       <div styleName="error">

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -60,8 +60,6 @@ const DataFilesSidebar = ({ readOnly }) => {
     });
   };
 
-  const writeItemStyle = readOnly ? 'read-only' : '';
-
   const match = useRouteMatch();
 
   const disabled =
@@ -69,6 +67,8 @@ const DataFilesSidebar = ({ readOnly }) => {
     err !== false ||
     api !== 'tapis' ||
     (scheme !== 'private' && scheme !== 'projects');
+
+  const writeItemStyle = disabled ? 'read-only' : '';
 
   return (
     <div styleName="root">


### PR DESCRIPTION
…ity Data and Shared Workspaces

## Overview: ##

## Related Jira tickets: ##

* [FP-1008](https://jira.tacc.utexas.edu/browse/FP-1008)

## Summary of Changes: ##
Changed boolean that checks for a disabled dropdown item from `readOnly` to `disabled`.

## Testing Steps: ##
1. Navigate to Data Files
2. Open Community Data
3. 'Folder' and 'Upload' options text should both be light grey, matching that of Shared Workspaces.

## UI Photos:
![image](https://user-images.githubusercontent.com/43251554/132924781-2463aabf-5561-48ed-b922-5c7e68e15739.png)

## Notes: ##
