### PR TITLE
bug/FP-1201: [A2CPS] Handle missing pi in project metadata

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
@@ -34,6 +34,7 @@ const DataFilesProjectFileListing = ({ system, path }) => {
       metadata.members.some(member => {
         return (
           member.access === 'owner' &&
+          member.user &&
           member.user.username === state.authenticatedUser.user.username
         );
       })

--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.test.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.test.js
@@ -25,7 +25,7 @@ afterEach(() => {
 
 // Mock Resize Detector
 jest.mock('react-resize-detector', () => ({
-  useResizeDetector: () => 
+  useResizeDetector: () =>
   {
     return {
       height: 10,
@@ -74,7 +74,17 @@ describe('DataFilesProjectFileListing', () => {
   it('hides Edit Descriptions and Manage Team when privilege is needed and user is not owner', () => {
     initialMockState.authenticatedUser.user.username = 'member';
     initialMockState.systems.storage.configuration[5].privilegeRequired = true;
-    const store = mockStore(initialMockState);
+    const initialMockStateUnknownUser = {
+      ...initialMockState,
+      projects: {
+        ...initialMockState.projects,
+        metadata: {
+          ...initialMockState.projects.metadata,
+          members: [{ access: 'owner', user: null }]
+        }
+      }
+    };
+    const store = mockStore(initialMockStateUnknownUser);
     const { queryByText } = renderComponent(
       <DataFilesProjectFileListing system="test.site.project.PROJECT-3" path="/" />,
       store

--- a/client/src/redux/reducers/projects.reducers.js
+++ b/client/src/redux/reducers/projects.reducers.js
@@ -30,7 +30,7 @@ const removeProjectMember = (members, removedMember) => {
 
 const transformMetadata = project => {
   const members = [];
-  members.push({ user: project.pi, access: 'owner' });
+  if (project.pi) members.push({ user: project.pi, access: 'owner' });
   project.coPis.forEach(coPi => {
     members.push({ user: coPi, access: 'edit' });
   });


### PR DESCRIPTION
## Overview: ##
Project listings crash the frontend if there is no pi defined, or if any member is missing a user model. This handles those cases.

## Related Jira tickets: ##

* [FP-1201](https://jira.tacc.utexas.edu/browse/FP-1201)

## Testing Steps: ##
IF YOU ARE FRANK:
1. Use a2cps settings
2. Go here and make sure it works: https://cep.dev/workbench/data/tapis/projects/a2cps.project.WMA-TEST-1

ANYONE ELSE: 
1. Change your `_PORTAL_PROJECTS_SYSTEM_PREFIX` to `cep.project` and `_PORTAL_PROJECTS_ID_PREFIX` to `CEP`
2. Create a project in cep.tacc.utexas.edu with a test account
3. Add your normal user as a member
4. In https://cep.dev, confirm you can view the project normally

