### PR TITLE
task/FP-1194: Support CMS login

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -12,6 +12,8 @@ services:
       - ../../cms/media:/code/media
     command: python manage.py runserver 0.0.0.0:8000
     container_name: core_portal_cms
+    depends_on:
+      - postgrescms
 
   redis:
     image: redis:5.0
@@ -80,6 +82,9 @@ services:
       - 80:80
       - 443:443
     container_name: core_portal_nginx
+    depends_on:
+      - cms
+      - django
 
   websockets:
     image: taccwma/core-portal:local

--- a/server/portal/apps/accounts/urls.py
+++ b/server/portal/apps/accounts/urls.py
@@ -3,7 +3,8 @@
    :synopsis: Accounts URLs
 """
 from django.conf.urls import url
-from portal.apps.accounts.views import LogoutView, accounts
+from django.contrib.auth.views import LogoutView
+from portal.apps.accounts.views import accounts
 from portal.apps.accounts import views
 
 

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -27,14 +27,14 @@ def accounts(request):
     return response
 
 
-class LogoutView(View):
-    """Logout view
-    """
-
-    def get(self, request):
-        """GET"""
-        logout(request)
-        return HttpResponseRedirect('/')
+# class LogoutView(View):
+#     """Logout view
+#     """
+#
+#     def get(self, request):
+#         """GET"""
+#         logout(request)
+#         return HttpResponseRedirect('/')
 
 
 @login_required

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -5,8 +5,6 @@ import logging
 import json
 import requests
 from django.forms.models import model_to_dict
-from django.contrib.auth import logout
-from django.views.generic.base import View
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponse, JsonResponse
 from django.contrib.auth.decorators import login_required
@@ -25,16 +23,6 @@ logger = logging.getLogger(__name__)
 def accounts(request):
     response = redirect('/workbench/account/')
     return response
-
-
-# class LogoutView(View):
-#     """Logout view
-#     """
-#
-#     def get(self, request):
-#         """GET"""
-#         logout(request)
-#         return HttpResponseRedirect('/')
 
 
 @login_required

--- a/server/portal/apps/auth/views.py
+++ b/server/portal/apps/auth/views.py
@@ -140,12 +140,13 @@ def agave_oauth_callback(request):
 
         return HttpResponseRedirect(reverse('portal_accounts:logout'))
 
+    redirect = getattr(settings, 'LOGIN_REDIRECT_URL', '/')
+    next = ''
     if 'next' in request.session:
-        next_uri = request.session.pop('next')
-        return HttpResponseRedirect(next_uri)
-    else:
-        login_url = getattr(settings, 'LOGIN_REDIRECT_URL')
-        return HttpResponseRedirect(login_url)
+        next = '?next=' + request.session.pop('next')
+
+    response = HttpResponseRedirect(redirect + next)
+    return response
 
 
 def agave_session_error(request):

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -34,6 +34,9 @@ FIXTURE_DIRS = [
     os.path.join(BASE_DIR, 'fixtures'),
 ]
 
+# this can be set to just '/' if we're not using core portal to create cms sessions
+LOGOUT_REDIRECT_URL='/cms/logout/'
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = settings_secret._SECRET_KEY
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -34,9 +34,6 @@ FIXTURE_DIRS = [
     os.path.join(BASE_DIR, 'fixtures'),
 ]
 
-# this can be set to just '/' if we're not using core portal to create cms sessions
-LOGOUT_REDIRECT_URL='/cms/logout/'
-
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = settings_secret._SECRET_KEY
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -185,6 +182,8 @@ IMPERSONATE = {
     'REQUIRE_SUPERUSER': True
 }
 
+# this can be set to just '/' if we're not using core portal to create cms sessions
+LOGOUT_REDIRECT_URL = getattr(settings_custom, '_LOGOUT_REDIRECT_URL', '/')
 LOGIN_REDIRECT_URL = getattr(settings_custom, '_LOGIN_REDIRECT_URL', '/')
 LOGIN_URL = '/auth/agave/'
 

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -238,3 +238,8 @@ _WORKBENCH_SETTINGS = {
     "hideApps": False,
     "hideDataFiles": False
 }
+
+# to authenticate a user with the CMS after Portal login,
+# set the _LOGIN_REDIRECT_URL to the custom cms auth endpoint
+# otherwise just redirect to /workbench
+_LOGIN_REDIRECT_URL='/remote/login/'

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -243,3 +243,5 @@ _WORKBENCH_SETTINGS = {
 # set the _LOGIN_REDIRECT_URL to the custom cms auth endpoint
 # otherwise just redirect to /workbench
 _LOGIN_REDIRECT_URL='/remote/login/'
+
+_LOGOUT_REDIRECT_URL='/cms/logout/'

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -238,3 +238,10 @@ _WORKBENCH_SETTINGS = {
     "hideApps": False,
     "hideDataFiles": False
 }
+
+# to authenticate a user with the CMS after Portal login,
+# set the _LOGIN_REDIRECT_URL to the custom cms auth endpoint
+# otherwise just redirect to /workbench
+_LOGIN_REDIRECT_URL='/remote/login/'
+
+_LOGOUT_REDIRECT_URL='/cms/logout/'


### PR DESCRIPTION
## Overview: ##

Allow the core portal's auth model backend to be used by the core cms

 
## Related Jira tickets: ##

* [FP-1194](https://jira.tacc.utexas.edu/browse/FP-1194)

## Summary of Changes: ##

Changes allows CMS login after Core Portal has authenticated with Agave/Tapis

## Testing Steps: ##
1. Modify the CMS image tag in `docker-compose-dev.all.debug.yml` from `taccwma/core-cms:latest` to `taccwma/core-portal-cms:78753bf` This pre-built CMS image contains the changes to enable cms login. 
2. In `settings_local.py` add entry `LOGIN_REDIRECT_URL = '/remote/login/'` 
3. Start Portal, navigate to cep.dev. Ensure you are logged out of Core Portal and Core CMS.
4. Ensure the CMS account for your primary TACC account is an admin at cep.dev/admin.
5. Using your primary TACC account log in to Core Portal as usual. Once portal login is successful, navigate to CMS home page. Verify you are logged in to Django CMS (CMS Edit Menu should be visible at the top of the page).
6. Verify users are logged out of both core portal and cms. Log out of core portal using the dropdown menu in top nav. Ensure you are logged out of both the portal and CMS.
7. Verify new users are created in CMS. Repeat the same procedure with a valid TACC account that doesn't exist in the CMS (could be a test account that has has been added to the core portal allocation). Next, log out of Core Portal and log back in using admin account. Verify new account was created by checking the CMS admin interface.

## UI Photos:

## Notes: ##





