### PR TITLE
task/FP-1111: Dashboard Job History "Job Status" column overflow

### DIFF
--- a/client/src/components/Jobs/Jobs.js
+++ b/client/src/components/Jobs/Jobs.js
@@ -93,7 +93,6 @@ function JobsView({ showDetails, showFancyStatus, rowProps }) {
       Header: 'Job Status',
       headerStyle: { textAlign: 'left' },
       accessor: 'status',
-      className: 'job__status',
       Cell: el => (
         <JobsStatus
           status={el.value}

--- a/client/src/components/Jobs/Jobs.scss
+++ b/client/src/components/Jobs/Jobs.scss
@@ -89,8 +89,3 @@
     /* date */    tr > *:nth-child(6) { width: 14%; }
   }
 }
-
-/* Always */
-.job__status {
-  position: relative;
-}


### PR DESCRIPTION
## Overview: ##
The "Job Status" column of the Job History listing on the dashboard appears to overflow slightly onto the header row when scrolling.

## Related Jira tickets: ##

* [FP-1111](https://jira.tacc.utexas.edu/browse/FP-1111)

## Summary of Changes: ##
* Removed 
> `.job__status {
>   position: relative;
> }`
from jobs.scss

## Testing Steps: ##
1.  If necessary, run enough jobs to require scrolling to see all jobs in History / Jobs view of portal.
2. Test by scrolling job history table up.  "Job Status" column should no longer scroll up into the table header.

## UI Photos:
"Job Status" Column Scrolling into Header
![Job History screen with Job Status scrolling into header](https://user-images.githubusercontent.com/77903391/134060451-913f5cac-5638-4b0c-ba0a-7e5f348176c5.png)

"Job Status" Column No Longer Scrolling into Header
![Job History screen with Job Status no longer scrolling into header](https://user-images.githubusercontent.com/77903391/134060660-f89a06c0-b550-483c-9f1d-404f1cfaefb4.png)

## Notes: ##
