### PR TITLE
task/FP-822 Batch notifications after move/copy/upload

### DIFF
--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -284,6 +284,12 @@ export function* renameFile(action) {
       payload: { status: 'SUCCESS', operation: 'rename' }
     });
     yield call(action.payload.reloadCallback, response.name, response.path);
+    yield put({
+      type: 'ADD_TOAST',
+      payload: {
+        message: `${file.name} renamed to ${action.payload.newName}`
+      }
+    });
   } catch (e) {
     yield put({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
@@ -342,7 +348,9 @@ export function* moveFile(src, dest, index) {
       type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
       payload: { status: 'ERROR', key: index, operation: 'move' }
     });
+    return 'ERR';
   }
+  return 'SUCCESS';
 }
 export function* moveFiles(action) {
   const { dest } = action.payload;
@@ -350,10 +358,18 @@ export function* moveFiles(action) {
     return call(moveFile, file, dest, file.id);
   });
 
-  yield race({
+  const { result } = yield race({
     result: all(moveCalls),
     cancel: take('DATA_FILES_MODAL_CLOSE')
   });
+
+  if (!result.includes('ERR'))
+    yield put({
+      type: 'ADD_TOAST',
+      payload: {
+        message: `Files moved to ${action.payload.dest.name}`
+      }
+    });
 
   yield call(action.payload.reloadCallback);
 }
@@ -442,17 +458,26 @@ export function* copyFile(src, dest, index) {
       type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
       payload: { status: 'ERROR', key: index, operation: 'copy' }
     });
+    return 'ERR';
   }
+  return 'SUCCESS';
 }
 export function* copyFiles(action) {
   const { dest } = action.payload;
   const copyCalls = action.payload.src.map(file => {
     return call(copyFile, file, dest, file.id);
   });
-  yield race({
+  const { result } = yield race({
     result: all(copyCalls),
     cancel: take('DATA_FILES_MODAL_CLOSE')
   });
+  if (!result.includes('ERR'))
+    yield put({
+      type: 'ADD_TOAST',
+      payload: {
+        message: `Files copied to ${action.payload.dest.name}`
+      }
+    });
   yield call(action.payload.reloadCallback);
 }
 
@@ -494,10 +519,18 @@ export function* uploadFiles(action) {
     );
   });
 
-  yield race({
+  const { result } = yield race({
     result: all(uploadCalls),
     cancel: take('DATA_FILES_MODAL_CLOSE')
   });
+
+  if (!result.includes('ERR'))
+    yield put({
+      type: 'ADD_TOAST',
+      payload: {
+        message: `Files were successfully uploaded.`
+      }
+    });
 
   yield call(action.payload.reloadCallback);
 }
@@ -518,7 +551,9 @@ export function* uploadFile(api, scheme, system, path, file, index) {
       type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
       payload: { status: 'ERROR', key: index, operation: 'upload' }
     });
+    return 'ERR';
   }
+  return 'SUCCESS';
 }
 
 export function* watchPreview() {

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -129,8 +129,6 @@ class TapisFilesView(BaseApiView):
                                                             path,
                                                             body))
             response = tapis_put_handler(client, scheme, system, path, operation, body=body)
-            operation in NOTIFY_ACTIONS and \
-                notify(request.user.username, operation, 'success', {'response': response})
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc
@@ -155,8 +153,6 @@ class TapisFilesView(BaseApiView):
                                                                 body['uploaded_file'].name))
 
             response = tapis_post_handler(client, scheme, system, path, operation, body=body)
-            operation in NOTIFY_ACTIONS and \
-                notify(request.user.username, operation, 'success', {'response': response})
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc
@@ -191,8 +187,6 @@ class GoogleDriveFilesView(BaseApiView):
         try:
             response = googledrive_put_handler(client, scheme, system, path,
                                                operation, body=body)
-            operation in NOTIFY_ACTIONS and \
-                notify(request.user.username, operation, 'success', {'response': response})
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc
@@ -224,14 +218,6 @@ class TransferFilesView(BaseApiView):
             else:
                 transfer(src_client, dest_client, **body)
 
-            # Respond with tapis-like info for a toast notification
-            file_info = {
-                'nativeFormat': filetype,
-                'name': body['dirname'],
-                'path': os.path.join(body['dest_path_name'], body['dirname']),
-                'systemId': body['dest_system']
-            }
-            notify(request.user.username, 'copy', 'success', {'response': file_info})
             return JsonResponse({'success': True})
         except Exception as exc:
             logger.info(exc)


### PR DESCRIPTION
## Overview: ##
"Basically for file uploads and transfers, if the files were all selected in the same Move, Upload, or Copy operation, then 1 toaster should appear when they are all finished"
## Related Jira tickets: ##

* [FP-822](https://jira.tacc.utexas.edu/browse/FP-822)

## Summary of Changes: ##
- Individual move/copy/upload operations now return `SUCCESS`/`ERR` and that result is aggregated during the race saga. If there were no errors, a toast is dispatched directly from the saga.
- On the backend, individual file PUT/POST operations no longer trigger notifications since there is no way from inside an operation whether it will be the last to resolve.

## Testing Steps: ##
1. Select multiple files and do a move/copy/upload operation. Verify that you only see a toast pop up after the last operation succeeds.

