### PR TITLE
Bug/FP-1109: Update Job Status on View Detail and Job Listing

### DIFF
--- a/client/src/components/History/History.js
+++ b/client/src/components/History/History.js
@@ -81,6 +81,11 @@ export const Routes = () => {
             pathname === `${root}${ROUTES.JOBS}` &&
             !locationState.fromJobHistoryModal
           ) {
+            dispatch({
+              type: 'GET_JOBS',
+              params: { offset: 0 }
+            });
+
             // Chain events to properly update UI based on read action
             dispatch({
               type: 'FETCH_NOTIFICATIONS',

--- a/client/src/components/History/History.test.js
+++ b/client/src/components/History/History.test.js
@@ -1,12 +1,17 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import configureStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
+import {Provider} from 'react-redux';
+import {render} from '@testing-library/react';
+import renderComponent from 'utils/testing';
 import Routes from './History';
 import { initialState as workbench } from '../../redux/reducers/workbench.reducers';
 import { initialState as notifications } from '../../redux/reducers/notifications.reducers';
-import { initialState as jobs } from '../../redux/reducers/jobs.reducers';
+import {initialState as jobs} from '../../redux/reducers/jobs.reducers';
+import jobDetailFixture from '../../redux/sagas/fixtures/jobdetail.fixture';
+import jobDetailDisplayFixture from '../../redux/sagas/fixtures/jobdetaildisplay.fixture';
+import appDetailFixture from '../../redux/sagas/fixtures/appdetail.fixture';
 
 const mockStore = configureStore();
 
@@ -23,5 +28,60 @@ describe('History Routes', () => {
       </Provider>
     );
     expect(container.children.length).toBeGreaterThan(0);
+  });
+
+  it('should dispatch the get jobs event', () => {
+    const store = mockStore({
+      notifications, jobs,
+      workbench: {...workbench, config: {hideDataFiles: false}}
+    });
+
+    render(
+      <Provider store={store}>
+        <BrowserRouter>
+          <Routes />
+        </BrowserRouter>
+      </Provider>
+    );
+
+    expect(store.getActions()).toEqual([
+      {type: 'GET_JOBS', params: {offset: 0}},
+      expect.anything()
+    ]);
+  });
+
+  it('should dispatch the get job detail event type when opening the job detail modal', () => {
+    const history = createMemoryHistory();
+    history.push('/workbench/history/jobs/1')
+
+    const store = mockStore({
+      notifications,
+      jobs,
+      jobDetail: {
+        jobId: 'job_id',
+        app: appDetailFixture,
+        job: jobDetailFixture,
+        display: jobDetailDisplayFixture,
+        loading: false,
+        loadingError: false,
+        loadingErrorMessage: '',
+      },
+      workbench: {...workbench, config: {hideDataFiles: false}}
+    })
+
+    renderComponent(
+      <MemoryRouter initialEntries={['/workbench/history/jobs/1']}>
+        <Routes />
+      </MemoryRouter>,
+      store,
+      history
+    );
+
+    expect(store.getActions()).toEqual([{ 
+      type: 'GET_JOB_DETAILS', 
+      payload: {
+        jobId: "1"
+      }
+    }]);
   });
 });

--- a/client/src/redux/reducers/jobs.reducers.js
+++ b/client/src/redux/reducers/jobs.reducers.js
@@ -39,6 +39,13 @@ export function jobs(state = initialState, action) {
         list: state.list.concat(action.payload.list),
         reachedEnd: action.payload.reachedEnd
       };
+    case 'JOBS_LIST_UPDATE_JOB':
+      return {
+        ...state,
+        list: state.list.map(job =>
+          job.id === action.payload.job.id ? action.payload.job : job
+        )
+      };
     case 'JOBS_LIST_ERROR':
       return {
         ...state,

--- a/client/src/redux/sagas/jobs.sagas.js
+++ b/client/src/redux/sagas/jobs.sagas.js
@@ -124,6 +124,11 @@ export function* getJobDetails(action) {
       type: 'JOB_DETAILS_FETCH_SUCCESS',
       payload: { app, job }
     });
+
+    yield put({
+      type: 'JOBS_LIST_UPDATE_JOB',
+      payload: { job }
+    });
   } catch (error) {
     yield put({
       type: 'JOB_DETAILS_FETCH_ERROR',

--- a/client/src/redux/sagas/jobs.sagas.test.js
+++ b/client/src/redux/sagas/jobs.sagas.test.js
@@ -53,6 +53,12 @@ describe('getJobDetails Saga', () => {
           job: jobDetailFixture
         }
       })
+      .put({
+        type: 'JOBS_LIST_UPDATE_JOB',
+        payload: {
+          job: jobDetailFixture
+        }
+      })
 
       .hasFinalState({
         ...initialJobDetail,


### PR DESCRIPTION
## Overview: ##
Made to update job status(es) for the Job Listings on opening the `JobHistoryModal` and on routing to Job Listings. 

## Related Jira tickets: ##

* [FP-1109](https://jira.tacc.utexas.edu/browse/FP-1109)

## Summary of Changes: ##

## Testing Steps: ##
1. Add a job request.
2. Route to the History tab from the sidebar.
3. Ensure that the recent job request is displayed in the listing.
4. After a while (about when the job status should change), try clicking on `View Details`
5. Ensure that the `Job Status` for the job has been updated in the listing.

## UI Photos:

## Notes: ##
