### PR TITLE
bug/FP-1170: Add `filesize` to datafiles preview logs

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
@@ -91,6 +91,7 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
           scheme={scheme}
           href={row.original._links.self.href}
           isPublic={isPublic}
+          length={row.original.length}
         />
       );
     },

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
@@ -87,6 +87,7 @@ describe('FileNavCell', () => {
         api="tapis"
         scheme="private"
         href="href"
+        length={1234}
       />,
       store,
       history
@@ -111,6 +112,7 @@ describe('FileNavCell', () => {
         api="tapis"
         scheme="private"
         href="href"
+        length={1234}
       />,
       store,
       history
@@ -192,7 +194,7 @@ describe('DataFilesListing', () => {
     ],
     [
       '502',
-      /There was a problem accessing this file system. If this is your/, 
+      /There was a problem accessing this file system. If this is your/,
       'private'
     ],
     [

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
@@ -45,7 +45,7 @@ CheckboxCell.propTypes = {
 };
 
 export const FileNavCell = React.memo(
-  ({ system, path, name, format, api, scheme, href, isPublic }) => {
+  ({ system, path, name, format, api, scheme, href, isPublic, length }) => {
     const dispatch = useDispatch();
     const previewCallback = e => {
       e.stopPropagation();
@@ -58,7 +58,7 @@ export const FileNavCell = React.memo(
         type: 'DATA_FILES_TOGGLE_MODAL',
         payload: {
           operation: 'preview',
-          props: { api, scheme, system, path, name, href }
+          props: { api, scheme, system, path, name, href, length }
         }
       });
     };
@@ -91,7 +91,8 @@ FileNavCell.propTypes = {
   api: PropTypes.string.isRequired,
   scheme: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
-  isPublic: PropTypes.bool
+  isPublic: PropTypes.bool,
+  length: PropTypes.number.isRequired
 };
 FileNavCell.defaultProps = {
   isPublic: false

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
@@ -31,7 +31,8 @@ const DataFilesPreviewModal = () => {
         scheme: params.scheme,
         system: params.system,
         path: params.path,
-        href: params.href
+        href: params.href,
+        length: params.length
       }
     });
   };

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
@@ -14,7 +14,8 @@ const files = {
       system: 'test.site.project.PROJECT-3',
       path: 'something/test.txt',
       href: 'href',
-      name: 'test.txt'
+      name: 'test.txt',
+      length: 1234
     }
   }
 };


### PR DESCRIPTION
## Overview: ##
This adds the missing `length` param to the `FileNavCell` and propagates it to the `preview` datafiles operation to be sent to the backend to be used by our `METRICS` logger

## Related Jira tickets: ##

* [FP-1170](https://jira.tacc.utexas.edu/browse/FP-1170)

## Testing Steps: ##
1. Preview an image or text file
2. In the docker logs, confirm you see `filesize` populated in the logs for the action. e.g.:
```
core_portal_django         | [METRICS] INFO 2021-09-24 22:09:39,879 UTC views metrics.portal.apps.datafiles.views.get:88: user:sal op:preview api:tapis scheme:private system:frontera.home.sal path:1favicon.cep.png filesize:11772
```
