### PR TITLE
Remove unused systemPrefix workbench settings

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
@@ -47,7 +47,6 @@ const initialMockState = {
     }
   },
   systems: systemsFixture,
-  workbench: { config: { systemPrefix: 'cep.local.project' } }
 };
 
 describe('CheckBoxCell', () => {

--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.test.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.test.js
@@ -61,7 +61,6 @@ const initialMockState = {
       username: 'username'
     }
   },
-  workbench: { config: { systemPrefix: 'cep.local.project' } }
 };
 
 describe('DataFilesProjectFileListing', () => {

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.test.js
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.test.js
@@ -11,7 +11,6 @@ const mockStore = configureStore();
 const initialMockState = {
   projects: projectsFixture,
   systems: systemsFixture,
-  workbench: { config: { systemPrefix: 'cep.local.project' } }
 };
 
 function renderProjectsListComponent(store) {

--- a/client/src/components/PublicData/PublicData.test.js
+++ b/client/src/components/PublicData/PublicData.test.js
@@ -40,7 +40,6 @@ describe('PublicData', () => {
         }
       },
       pushKeys: { target: {} },
-      workbench: { config: { systemPrefix: 'cep.local.project' } }
     });
     const { getByText } = renderComponent(<PublicData />, store, history);
 

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -249,6 +249,5 @@ _WORKBENCH_SETTINGS = {
     "extractApp": 'extract',
     "makePublic": False,
     "hideApps": False,
-    "systemPrefix": _PORTAL_PROJECTS_SYSTEM_PREFIX,
     "hideDataFiles": False
 }


### PR DESCRIPTION
## Overview: ##

Remove some unused settings.  https://github.com/TACC/Core-Portal/pull/464#discussion_r713335039 was resolved in one spot but there was some more remaining spots.

## Summary of Changes: ##
Dropped systemPrefix