### PR TITLE
Task/fp 1100 system creation failures

### DIFF
--- a/server/portal/apps/onboarding/steps/key_service_creation.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation.py
@@ -55,7 +55,7 @@ class KeyServiceCreationStep(AbstractStep):
         # Create only storage systems that are not currently accessible
         systemList = []
         for systemId in systems.keys():
-            success, result = StorageSystem(self.user.agave_oauth.client, id=systemId).test()
+            success, _ = StorageSystem(self.user.agave_oauth.client, id=systemId, load=False).test()
             if success:
                 self.logger.info(
                     "{username} has valid configuration for {systemId}, skipping creation".format(

--- a/server/portal/libs/agave/models/systems/base.py
+++ b/server/portal/libs/agave/models/systems/base.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from portal.libs.agave.exceptions import ValidationError
 from portal.libs.agave.models.base import BaseAgaveResource
 from portal.libs.agave.models.systems.roles import Roles
-
+from json.decoder import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 METRICS = logging.getLogger('metrics.{}'.format(__name__))
@@ -361,21 +361,20 @@ class BaseSystem(BaseAgaveResource):
             by doing a `files-listing` on it.
             What is a good way to test exec systems?
         """
-        result = 'FAIL'
         success = True
-        # if self.type == self.TYPES.STORAGE:
+        result = 'SUCCESS'
         try:
             self._ac.files.list(
                 systemId=self.id,
                 filePath=''
             )
-            result = 'SUCCESS'
         except HTTPError as err:
+            logger.info("Test of system '{}' failed. Listing of system returned: {}".format(self.id, str(err)))
             success = False
-            result = err.response.json()
-        # elif self.type == self.TYPES.EXECUTION:
-        #     result = 'SUCCESS'
-
+            try:
+                result = err.response.json()
+            except JSONDecodeError:
+                result = 'FAIL'
         return success, result
 
     def enable(self):

--- a/server/portal/libs/agave/models/systems/base_unit_test.py
+++ b/server/portal/libs/agave/models/systems/base_unit_test.py
@@ -1,0 +1,34 @@
+from portal.libs.agave.utils import service_account
+from django.conf import settings
+
+from portal.libs.agave.models.systems.storage import StorageSystem
+
+
+def test_system_success(mock_agave_client):
+    storage = StorageSystem(mock_agave_client, id="systemId", load=False)
+    success, result = storage.test()
+    assert success
+    assert result == 'SUCCESS'
+
+
+SYSTEM_LISTING_URL = "{}/files/v2/listings/system/{}/".format(settings.AGAVE_TENANT_BASEURL, "systemId")
+
+
+def test_system_failure(requests_mock):
+    requests_mock.get(SYSTEM_LISTING_URL, text='Not Found', status_code=404)
+    storage = StorageSystem(service_account(), id="systemId", load=False)
+    success, result = storage.test()
+    assert not success
+    assert result == 'FAIL'
+
+
+def test_system_failure_with_json_response(requests_mock):
+    json_response = {"custon_error_response_key": "value"}
+    requests_mock.get(SYSTEM_LISTING_URL, json=json_response, status_code=500)
+    storage = StorageSystem(service_account(), id="systemId", load=False)
+    success, result = storage.test()
+    assert not success
+    assert result == json_response
+
+
+


### PR DESCRIPTION
## Overview: ##

TODO (draft PR; will summarize shortly)

## Related Jira tickets: ##

* [FP-1100](https://jira.tacc.utexas.edu/browse/FP-1100)

## Summary of Changes: ##
* Set `load` to False when creating `StorageSystem` which is main bug as non 404s are thrown in __init__ and then `test()` is never called
* Ensure logging and exception handling is working correctly and tested

## Testing Steps: ##
1. Run tests
2. You could also ensure that onboarding works but getting a non-404 from agave would be hard to recreate. 🤔 

## Notes: ##

 - [ ] ensure we are logging the errors+codes and messages for json and non json
 - [ ] consider catching bare except or see what agavepy could return besides HTTPError

    Note catching  requests.exceptions.HTTPError but agavepy has different exceptions for HTTPError. 🤔 https://github.com/TACC/agavepy/blob/master/agavepy/errors.py

