### PR TITLE
Bug/FP-1242: Clarify text when copying between different systems.

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
@@ -23,6 +23,7 @@ const DataFilesCopyModal = React.memo(() => {
     state => state.files.params.modal,
     shallowEqual
   );
+
   const reloadPage = () => {
     history.push(location.pathname);
     dispatch({
@@ -124,9 +125,9 @@ const DataFilesCopyModal = React.memo(() => {
     [selectedFiles]
   );
 
-  const actionString = `Copying ${selected.length} File${
-    selected.length > 1 ? 's' : ''
-  }`;
+  const actionString = `${
+    params.system === modalParams.system ? 'Copying' : 'Start copying'
+  } ${selected.length} File${selected.length > 1 ? 's' : ''}`;
 
   return (
     <Modal

--- a/client/src/components/DataFiles/DataFilesStatus/DataFilesStatus.js
+++ b/client/src/components/DataFiles/DataFilesStatus/DataFilesStatus.js
@@ -42,16 +42,35 @@ const OPERATION_MAP = {
           .slice(0, -1)
           .join('/');
         const projectName = findProjectTitle(projectList, response.systemId);
-        if (projectName) {
-          const dest =
-            destPath === '/' || destPath === '' ? `${projectName}/` : destPath;
-          return `${type} ${mappedOp} to ${truncateMiddle(dest, 20)}`;
+
+        const srcSystem =
+          response.source.split('/')[0] === 'https:'
+            ? response.source.split('/')[7]
+            : response.source.split('/')[2];
+        const destSystem = response.systemId;
+
+        let op = mappedOp;
+        let dest;
+
+        if (srcSystem !== destSystem) {
+          if (mappedOp === 'copied') {
+            op = 'started copying';
+          } else {
+            op = 'started moving';
+          }
         }
-        const dest =
-          destPath === '/' || destPath === ''
-            ? `${findSystemDisplayName(systemList, response.systemId)}/`
-            : destPath;
-        return `${type} ${mappedOp} to ${truncateMiddle(dest, 20)}`;
+
+        if (projectName) {
+          dest =
+            destPath === '/' || destPath === '' ? `${projectName}/` : destPath;
+        } else {
+          dest =
+            destPath === '/' || destPath === ''
+              ? `${findSystemDisplayName(systemList, response.systemId)}/`
+              : destPath;
+        }
+
+        return `${type} ${op} to ${truncateMiddle(dest, 20)}`;
       }
       case 'makepublic':
         return `${type} ${mappedOp} to Public Data`;


### PR DESCRIPTION
## Overview: ##
Clarifies status message when copying between different systems so that user doesn't assume
that copy has already finished on "success".

## Related Jira tickets: ##

* [FP-1242](https://jira.tacc.utexas.edu/browse/FP-1242)
* [FP-1220](https://jira.tacc.utexas.edu/browse/FP-1220)
* [FP-1167](https://jira.tacc.utexas.edu/browse/FP-1167)

## Summary of Changes: ##
Compares src/dest systems and renders text accordingly.

## Testing Steps: ##
1. Ensure that copying between different systems shows "started copying" message (e.g. My Data(corral) and a Shared Workspace).
2. Ensure that copying between same systems still shows "copied" message.

## UI Photos:

## Notes: ##
