### PR TITLE
task/FP-1251: Shorten "Principal Investigator" to "PI" in Allocations view

### DIFF
--- a/client/src/components/Allocations/AllocationsTables.js
+++ b/client/src/components/Allocations/AllocationsTables.js
@@ -21,7 +21,7 @@ export const useAllocations = page => {
         sortType: 'alphanumeric'
       },
       {
-        Header: 'Principal Investigator',
+        Header: 'PI',
         accessor: 'pi'
       },
       {

--- a/client/src/components/Allocations/AllocationsTables.module.scss
+++ b/client/src/components/Allocations/AllocationsTables.module.scss
@@ -1,7 +1,9 @@
 .root {
   /* title */     tr > *:nth-child(1) { width: 13%; }
-  /* pi */        tr > *:nth-child(2) { width: 20%; }
-  /* team */      tr > *:nth-child(3) { width: 7%; }
+  // /* pi */        tr > *:nth-child(2) { width: 20%; }
+  /* pi */        tr > *:nth-child(2) { width: 14%; }
+  /* team */      tr > *:nth-child(3) { width: 13%; }
+  // /* team */      tr > *:nth-child(3) { width: 7%; }
   /* systems */   tr > *:nth-child(4) { width: 18%; }
   /* awarded */   tr > *:nth-child(5) { width: 14%; }
   /* remaining */ tr > *:nth-child(6) { width: 14%; }

--- a/client/src/components/Allocations/AllocationsTables.module.scss
+++ b/client/src/components/Allocations/AllocationsTables.module.scss
@@ -1,9 +1,7 @@
 .root {
   /* title */     tr > *:nth-child(1) { width: 13%; }
-  // /* pi */        tr > *:nth-child(2) { width: 20%; }
   /* pi */        tr > *:nth-child(2) { width: 14%; }
   /* team */      tr > *:nth-child(3) { width: 13%; }
-  // /* team */      tr > *:nth-child(3) { width: 7%; }
   /* systems */   tr > *:nth-child(4) { width: 18%; }
   /* awarded */   tr > *:nth-child(5) { width: 14%; }
   /* remaining */ tr > *:nth-child(6) { width: 14%; }

--- a/client/src/components/Allocations/tests/AllocationsTables.test.js
+++ b/client/src/components/Allocations/tests/AllocationsTables.test.js
@@ -41,7 +41,7 @@ describe('Allocations Table', () => {
 
   it("should have relevant columns for data for the Allocations Table", () => {
     expect(getByText(/Title/)).toBeDefined();
-    expect(getByText(/Principal Investigator/));
+    expect(getByText(/PI/));
     expect(getByText(/Team/)).toBeDefined();
     expect(getByText(/Systems/)).toBeDefined();
     expect(getByText(/Awarded/)).toBeDefined();


### PR DESCRIPTION
## Overview: ##

Shorten "Principal Investigator" to "PI" in Allocations view.
Craig: Shorten Principal Investigator to PI to allow View Team to be wider and the hyperlink to be 1 row.

## Related Jira tickets: ##

* [FP-1251](https://jira.tacc.utexas.edu/browse/FP-1251)

## Summary of Changes: ##
1.  Changed "Principal Investigator" to "PI" in table header of `AllocationsTables.js`.
2. Changed width of PI column from 20% to 14% and width of Team column from 7% to 13% of table in `AllocationsTables.module.scss`.
3. Updated `AllocationsTables.test.js` to test for "PI" column in place of "Principal Investigator".

## Testing Steps: ##
1. Navigate to Allocations page in Workbench.
2. View "Allocations" full screen and with browser width reduced to see that Team column now has more room.  Page is responsive so "Team" column will still move to two columns when screen size is reduced.

## UI Photos:

Allocation Page Before Changes
![Allocations Page Before Changes](https://user-images.githubusercontent.com/77903391/136041330-5a119b20-6cf2-4edc-aefb-0a1c9d9e658c.png)

Allocations Page After Changes Full Screen
![Allocations Page After Changes Full Screen](https://user-images.githubusercontent.com/77903391/136041573-2047b00b-17c5-4560-9eae-4688bb69df0d.png)

Allocations Page After Changes With Reduced Width
![Allocations Page After Changes With Reduced Width](https://user-images.githubusercontent.com/77903391/136042085-bde7f390-7df7-4480-a94f-752327baf278.png)

Allocation Page After Changes With Reduced Width Team at Two Rows
![Allocation Page After Changes With Reduced Width Team at Two Rows](https://user-images.githubusercontent.com/77903391/136042169-bdd2d897-f5c9-4a29-aec6-6e8ab01fc221.png)

## Notes: ##
Columns are responsive so Team column will still shrink when browser width is reduced.