### PR TITLE
task/FP-1258: Enable html and large file previews

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, ModalHeader, ModalBody } from 'reactstrap';
-import { LoadingSpinner, Message } from '_common';
+import { Modal, ModalHeader, ModalBody, Button } from 'reactstrap';
+import { LoadingSpinner, SectionMessage } from '_common';
 import './DataFilesPreviewModal.module.scss';
 
 const DataFilesPreviewModal = () => {
@@ -21,7 +21,6 @@ const DataFilesPreviewModal = () => {
       type: 'DATA_FILES_TOGGLE_MODAL',
       payload: { operation: 'preview', props: {} }
     });
-
 
   const onOpen = () => {
     setIsFrameLoading(true);
@@ -86,9 +85,15 @@ const DataFilesPreviewModal = () => {
           </div>
         )}
         {hasError && (
-          <Message type="warning" styleName="error">
-            {error}
-          </Message>
+          <div styleName="error">
+            <SectionMessage type="warning" styleName="error-message">
+              {error}
+            </SectionMessage>
+            <Button styleName="button" href={href} target="_blank">
+              <i className="icon-exit" />
+              <span className="toolbar-button-text">Preview File</span>
+            </Button>
+          </div>
         )}
       </ModalBody>
     </Modal>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
@@ -22,6 +22,7 @@ const DataFilesPreviewModal = () => {
       payload: { operation: 'preview', props: {} }
     });
 
+
   const onOpen = () => {
     setIsFrameLoading(true);
     dispatch({

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.module.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.module.scss
@@ -2,18 +2,15 @@
   min-height: 30vh;
 }
 
-.text-preview{
+.text-preview {
   max-height: 75vh;
   overflow-x: auto;
   white-space: pre-wrap;
   word-wrap: break-word;
 }
 
-.error {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
+.error-message {
+  width: fit-content;
 }
 
 .loading-style {
@@ -21,4 +18,28 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+}
+
+.error {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-direction: column;
+  height: 100%;
+}
+
+.button {
+  background-color: var(--global-color-accent--normal);
+  border-color: var(--global-color-accent--normal);
+  border-radius: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  white-space: nowrap;
+
+  i {
+    display: flex;
+    padding-right: 5px;
+    font-size: 1.3em;
+  }
 }

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
@@ -66,5 +66,6 @@ describe('Data Files Preview Modal', () => {
     expect(getByText(/File Preview:/)).toBeDefined();
     expect(getByText(/test\.txt/)).toBeDefined();
     expect(getByText('Unable to show preview.')).toBeDefined();
+    expect(getByText(/Preview File/)).toBeDefined();
   });
 });

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -274,3 +274,28 @@ def test_tapis_file_view_preview_other_text_file(client, authenticated_user, moc
                           data={"href": "https//tapis.example/href"})
     assert response.status_code == 200
     assert response.json() == {"data": {"href": POSTIT_HREF, "fileType": "other", "content": "file content", "error": None}}
+
+
+def test_tapis_file_view_preview_unsupported_file(client, authenticated_user, mock_agave_client, agave_file_listing_mock,
+                                                 requests_mock, agave_indexer):
+    mock_agave_client.files.list.return_value = agave_file_listing_mock
+    mock_agave_client.postits.create.return_value = {"_links": {"self": {"href": POSTIT_HREF}}}
+    requests_mock.get(POSTIT_HREF, text="file content")
+    response = client.put("/api/datafiles/tapis/preview/private/frontera.home.username/test.html/",
+                          content_type="application/json",
+                          data={"href": "https//tapis.example/href"})
+    assert response.status_code == 200
+    assert response.json() == {"data": {"href": POSTIT_HREF, "fileType": None, "content": None, "error": "This file type must be previewed in a new window."}}
+
+
+def test_tapis_file_view_preview_large_file(client, authenticated_user, mock_agave_client, agave_file_listing_mock,
+                                                  requests_mock, agave_indexer):
+    agave_file_listing_mock[0]["length"] = 5000000
+    mock_agave_client.files.list.return_value = agave_file_listing_mock
+    mock_agave_client.postits.create.return_value = {"_links": {"self": {"href": POSTIT_HREF}}}
+    requests_mock.get(POSTIT_HREF, text="file content")
+    response = client.put("/api/datafiles/tapis/preview/private/frontera.home.username/test.log/",
+                          content_type="application/json",
+                          data={"href": "https//tapis.example/href"})
+    assert response.status_code == 200
+    assert response.json() == {"data": {"href": POSTIT_HREF, "fileType": 'other', "content": None, "error": "File too large to preview in this window."}}

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -249,7 +249,7 @@ def test_tapis_file_view_preview_supported_non_text_files(client, authenticated_
         else "https://view.officeapps.live.com/op/view.aspx?src={}".format(POSTIT_HREF)
 
     assert response.status_code == 200
-    assert response.json() == {"data": {"href": href, "fileType": TYPE}}
+    assert response.json() == {"data": {"href": href, "fileType": TYPE, 'content': None, 'error': None}}
 
 
 def test_tapis_file_view_preview_text_file(client, authenticated_user, mock_agave_client, agave_file_listing_mock,

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -472,6 +472,8 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, **kwargs):
     result = client.postits.create(body=args)
     url = result['_links']['self']['href']
     txt = None
+    error = None
+    file_type = None
     if file_ext in settings.SUPPORTED_TEXT_PREVIEW_EXTS:
         file_type = 'text'
     elif file_ext in settings.SUPPORTED_IMAGE_PREVIEW_EXTS:
@@ -486,6 +488,8 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, **kwargs):
         file_type = 'ipynb'
         tmp = url.replace('https://', '')
         url = 'https://nbviewer.jupyter.org/urls/{tmp}'.format(tmp=tmp)
+    elif file_ext in settings.SUPPORTED_NEW_WINDOW_PREVIEW_EXTS:
+        error = "This file type must be previewed in a new window."
     else:
         file_type = 'other'
 
@@ -493,13 +497,12 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, **kwargs):
         if get_file_size(client, system, path) < 5000000:
             try:
                 txt = text_preview(url)
-                return {'href': url, 'fileType': file_type, 'content': txt, 'error': None}
             except ValueError:
                 # unable to get text content
-                pass
-        return {'href': url, 'fileType': file_type, 'content': txt, 'error': "Unable to show preview"}
-    else:
-        return {'href': url, 'fileType': file_type }
+                error = "Unable to show preview."
+        else:
+            error = "File too large to preview in this window."
+    return {'href': url, 'fileType': file_type, 'content': txt, 'error': error }
 
 
 def download_bytes(client, system, path):

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -674,7 +674,7 @@ SUPPORTED_IMAGE_PREVIEW_EXTS = [
 SUPPORTED_TEXT_PREVIEW_EXTS = [
     '.as', '.as3', '.asm', '.bat', '.c', '.cc', '.cmake', '.cpp',
     '.cs', '.css', '.csv', '.cxx', '.diff', '.groovy', '.h', '.haml',
-    '.hh', '.htm', '.html', '.java', '.js', '.less', '.m', '.make', '.md',
+    '.hh', '.java', '.js', '.less', '.m', '.make', '.md',
     '.ml', '.mm', '.msg', '.php', '.pl', '.properties', '.py', '.rb',
     '.sass', '.scala', '.script', '.sh', '.sml', '.sql', '.txt', '.vi',
     '.vim', '.xml', '.xsd', '.xsl', '.yaml', '.yml', '.tcl', '.json',
@@ -687,6 +687,10 @@ SUPPORTED_OBJECT_PREVIEW_EXTS = [
 
 SUPPORTED_IPYNB_PREVIEW_EXTS = [
     '.ipynb'
+]
+
+SUPPORTED_NEW_WINDOW_PREVIEW_EXTS = [
+    '.htm', '.html'
 ]
 
 SUPPORTED_PREVIEW_EXTENSIONS = (SUPPORTED_IMAGE_PREVIEW_EXTS +

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -400,7 +400,7 @@ SUPPORTED_IMAGE_PREVIEW_EXTS = [
 SUPPORTED_TEXT_PREVIEW_EXTS = [
     '.as', '.as3', '.asm', '.bat', '.c', '.cc', '.cmake', '.cpp',
     '.cs', '.css', '.csv', '.cxx', '.diff', '.groovy', '.h', '.haml',
-    '.hh', '.htm', '.html', '.java', '.js', '.less', '.m', '.make', '.md',
+    '.hh', '.java', '.js', '.less', '.m', '.make', '.md',
     '.ml', '.mm', '.msg', '.php', '.pl', '.properties', '.py', '.rb',
     '.sass', '.scala', '.script', '.sh', '.sml', '.sql', '.txt', '.vi',
     '.vim', '.xml', '.xsd', '.xsl', '.yaml', '.yml', '.tcl', '.json',
@@ -413,6 +413,10 @@ SUPPORTED_OBJECT_PREVIEW_EXTS = [
 
 SUPPORTED_IPYNB_PREVIEW_EXTS = [
     '.ipynb'
+]
+
+SUPPORTED_NEW_WINDOW_PREVIEW_EXTS = [
+    '.htm', '.html'
 ]
 
 SUPPORTED_PREVIEW_EXTENSIONS = (SUPPORTED_IMAGE_PREVIEW_EXTS +


### PR DESCRIPTION
## Overview: ##
Displays a button to preview large and html files in a new tab.

## Related Jira tickets: ##

* [FP-1258](https://jira.tacc.utexas.edu/browse/FP-1258)

## Testing Steps: ##
1. Create and upload an html file to your My Data system
2. Confirm that there is a prompt to preview the file in a new window
3. In `server/portal/libs/agave/operations.py` on line `487`, change `5000000` to `1`
4. Try to preview a text file and confirm that it prompts to open preview in a new window

## UI Photos:
<img width="770" alt="Screen Shot 2021-10-06 at 3 53 29 PM" src="https://user-images.githubusercontent.com/20326896/136286705-1ee42d90-95a9-4340-bd97-d3a24b2f0afc.png">
<img width="768" alt="Screen Shot 2021-10-06 at 3 57 49 PM" src="https://user-images.githubusercontent.com/20326896/136286707-e60f0dd5-2e0a-4375-8775-56e40264bbd2.png">

