### PR TITLE
Fix indexer exception when no project system to skip

### DIFF
--- a/server/portal/apps/search/tasks.py
+++ b/server/portal/apps/search/tasks.py
@@ -18,10 +18,11 @@ logger = logging.getLogger(__name__)
 @shared_task(bind=True, max_retries=3, queue='indexing', retry_backoff=True, rate_limit="12/m")
 def agave_indexer(self, systemId, filePath='/', recurse=True, update_pems=False, ignore_hidden=True, reindex=False):
 
-    if next(sys for sys in settings.PORTAL_DATAFILES_STORAGE_SYSTEMS
-        if sys['scheme'] == 'projects' and sys['hideSearchBar'] == True
-        and systemId.startswith(settings.PORTAL_PROJECTS_SYSTEM_PREFIX)):
-            return
+    if next((sys for sys in settings.PORTAL_DATAFILES_STORAGE_SYSTEMS
+            if sys['scheme'] == 'projects'
+            and sys['hideSearchBar']
+            and systemId.startswith(settings.PORTAL_PROJECTS_SYSTEM_PREFIX)), None):
+        return
 
     from portal.libs.elasticsearch.utils import index_level
     from portal.libs.agave.utils import walk_levels


### PR DESCRIPTION
## Overview: ##
There is a block of python code in a `next` function that checks for a project system with `hideSearchBar` set to `True`, which raises an exception if no system is found. This adds a default `None` to prevent the iterator from failing.

## Testing Steps: ##
1. Delete a file
2. Confirm that the indexer does not fail
