### PR TITLE
Fix listing path for shared workspaces in data files modal listings.

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
@@ -160,7 +160,6 @@ const DataFilesModalListingTable = ({
   const params = useSelector(state => state.files.params.modal, shallowEqual);
   const systemList = useSelector(state => state.systems.storage.configuration);
   const projectsList = useSelector(state => state.projects.listing.projects);
-  const projectTitle = useSelector(state => state.projects.metadata.title);
   const isNotRoot = params.path.length > 0;
 
   const alteredData = useMemo(() => {
@@ -175,7 +174,13 @@ const DataFilesModalListingTable = ({
       const currentFolderEntry = {
         name: isNotRoot
           ? getCurrentDirectory(params.path)
-          : findSystemOrProjectDisplayName(params.scheme, systemList, projectsList, params.system, !isNotRoot),
+          : findSystemOrProjectDisplayName(
+              params.scheme,
+              systemList,
+              projectsList,
+              params.system,
+              !isNotRoot
+            ),
         format: 'folder',
         system: params.system,
         path: params.path,

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
@@ -6,7 +6,7 @@ import { useLocation } from 'react-router-dom';
 import { parse } from 'query-string';
 
 import { Icon } from '_common';
-import { findSystemDisplayName } from 'utils/systems';
+import { findSystemOrProjectDisplayName } from 'utils/systems';
 
 import DataFilesTable from '../../DataFilesTable/DataFilesTable';
 import { FileIcon } from '../../DataFilesListing/DataFilesListingCells';
@@ -159,6 +159,8 @@ const DataFilesModalListingTable = ({
   const error = useSelector(state => state.files.error.modal);
   const params = useSelector(state => state.files.params.modal, shallowEqual);
   const systemList = useSelector(state => state.systems.storage.configuration);
+  const projectsList = useSelector(state => state.projects.listing.projects);
+  const projectTitle = useSelector(state => state.projects.metadata.title);
   const isNotRoot = params.path.length > 0;
 
   const alteredData = useMemo(() => {
@@ -173,7 +175,7 @@ const DataFilesModalListingTable = ({
       const currentFolderEntry = {
         name: isNotRoot
           ? getCurrentDirectory(params.path)
-          : findSystemDisplayName(systemList, params.system, !isNotRoot),
+          : findSystemOrProjectDisplayName(params.scheme, systemList, projectsList, params.system, !isNotRoot),
         format: 'folder',
         system: params.system,
         path: params.path,

--- a/client/src/utils/systems.js
+++ b/client/src/utils/systems.js
@@ -57,6 +57,8 @@ export function findProjectTitle(projectsList, projectSystem, projectTitle) {
  * @param {Array} systemList
  * @param {Array} projectsList
  * @param {string} system
+ * @param {string} projectTitle
+ * @param {boolean} isRoot
  * @return {string} display name of system or project
  */
 export function findSystemOrProjectDisplayName(
@@ -64,12 +66,13 @@ export function findSystemOrProjectDisplayName(
   systemList,
   projectsList,
   system,
-  projectTitle
+  projectTitle,
+  isRoot
 ) {
   switch (scheme) {
     case 'projects':
       return findProjectTitle(projectsList, system, projectTitle);
     default:
-      return findSystemDisplayName(systemList, system);
+      return findSystemDisplayName(systemList, system, isRoot);
   }
 }


### PR DESCRIPTION
## Overview: ##
Fixes the naming of the root path folder for Shared Workspaces in file listings for data files modals (e.g. copy file modal) 
Previously, it displayed it `/`, now it correctly displays the Shared Workspace title.

## Related Jira tickets: ##

* [FP-1296](https://jira.tacc.utexas.edu/browse/FP-1296)

## Summary of Changes: ##
Made use of a better system utility function (`findSystemOrProjectDisplayName`) for rendering system name. 

## Testing Steps: ##
1. Go to the copy file modal.
2. Make the destination a Shared Workspace.
3. Confirm that the rendering of the Shared Workspace's root folder is not a `/` but the title of the Shared Workspace. 

## UI Photos:
![Peek 2021-10-28 14-23](https://user-images.githubusercontent.com/9425579/139322028-d52fe76f-3ea2-49cc-b493-2c7a719e6100.gif)

## Notes: ##
