### PR TITLE
task/BM-21: Add project request queue setting

### DIFF
--- a/server/portal/apps/onboarding/steps/project_membership.py
+++ b/server/portal/apps/onboarding/steps/project_membership.py
@@ -85,7 +85,7 @@ class ProjectMembershipStep(AbstractStep):
         try:
             if tracker.login():
                 result = tracker.create_ticket(
-                    Queue='Accounting',
+                    Queue=self.settings.get('rt_queue') or 'Accounting',
                     Subject='{project} Project Membership Request for {username}'.format(
                         project=self.project['title'],
                         username=self.user.username

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -160,20 +160,22 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
         'settings': {}
     },
     {
-        'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',
-        'settings': {
-            'project_sql_id': 12345
-        }
-    },
-    {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {}
+    },
+    {
+        'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',
+        'settings': {
+            'project_sql_id': 12345,
+            'rt_queue': 'Life Sciences'     # Defaults to 'Accounting' if left blank
+        }
     },
     {
         'step': 'portal.apps.onboarding.steps.system_access.SystemAccessStep',
         'settings': {
             'required_systems': ['stampede2.tacc.utexas.edu','ls5.tacc.utexas.edu'],
             'project_sql_id': 12345,
+            'rt_queue': 'Life Sciences'     # Defaults to 'Accounting' if left blank
         }
     },
     {

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -160,20 +160,22 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
         'settings': {}
     },
     {
-        'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',
-        'settings': {
-            'project_sql_id': 12345
-        }
-    },
-    {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {}
+    },
+    {
+        'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',
+        'settings': {
+            'project_sql_id': 12345,
+            'rt_queue': 'Life Sciences'     # Defaults to 'Accounting' if left blank
+        }
     },
     {
         'step': 'portal.apps.onboarding.steps.system_access.SystemAccessStep',
         'settings': {
             'required_systems': ['stampede2.tacc.utexas.edu','ls5.tacc.utexas.edu'],
             'project_sql_id': 12345,
+            'rt_queue': 'Life Sciences'     # Defaults to 'Accounting' if left blank
         }
     },
     {


### PR DESCRIPTION
## Overview: ##
BM wants to control which queue project request tickets get sent to.

## Related Jira tickets: ##

* [BM-21](https://jira.tacc.utexas.edu/browse/BM-21)

## Testing Steps: ##
1. Add this to `_PORTAL_USER_ACCOUNT_SETUP_STEPS` in `settings_custom.py`:
```
    {
        'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',
        'settings': {
            'project_sql_id': 57729,
            'rt_queue': 'Web & Mobile Apps'
        }
    },
```
2. Login with a test user that is not on the BrainMap project
3. Confirm that the ticket goes to the WMA queue, and not the Accounting queue
4. Repeat steps 1-3, this time setting `rt_queue` to an empty string or removing it entirely, and confirm the ticket ends up in the [Accounting](https://consult.tacc.utexas.edu/Search/Results.html?Query=Queue%20%3D%20%27Accounting%27%20AND%20Status%20%3D%20%27new%27) queue
5. Delete your test tickets