### PR TITLE
Bug/FP-1292: File listing error handling when network connection failure.

### DIFF
--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -187,24 +187,15 @@ export function* fetchFiles(action) {
       }
     });
   } catch (e) {
-    if (e.status) {
-      yield put({
-        type: 'FETCH_FILES_ERROR',
-        payload: {
-          section: action.payload.section,
-          code: e.status.toString()
-        }
-      });
-    } else {
-      // When there isn't a status due to network connection error.
-      yield put({
-        type: 'FETCH_FILES_ERROR',
-        payload: {
-          section: action.payload.section,
-          code: '503'
-        }
-      });
-    }
+    yield put({
+      type: 'FETCH_FILES_ERROR',
+      payload: {
+        section: action.payload.section,
+        // When there isn't a status due to network connection error return 503.
+        code : e.status ? e.status.toString() : `503`
+      }
+    });
+
     // If listing returns 502, body should contain a system def for key pushing.
     yield e.status === 502 &&
       put({

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -192,10 +192,9 @@ export function* fetchFiles(action) {
       payload: {
         section: action.payload.section,
         // When there isn't a status due to network connection error return 503.
-        code : e.status ? e.status.toString() : `503`
+        code: e.status ? e.status.toString() : '503'
       }
     });
-
     // If listing returns 502, body should contain a system def for key pushing.
     yield e.status === 502 &&
       put({

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -187,7 +187,6 @@ export function* fetchFiles(action) {
       }
     });
   } catch (e) {
-    // When there isn't a status due to network connection error.
     if (e.status) {
       yield put({
         type: 'FETCH_FILES_ERROR',
@@ -735,7 +734,6 @@ export function* fileLink(action) {
       }
     });
   } catch (error) {
-    console.log("hehehe");
     yield put({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
       payload: {

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -187,13 +187,25 @@ export function* fetchFiles(action) {
       }
     });
   } catch (e) {
-    yield put({
-      type: 'FETCH_FILES_ERROR',
-      payload: {
-        section: action.payload.section,
-        code: e.status.toString()
-      }
-    });
+    // When there isn't a status due to network connection error.
+    if (e.status) {
+      yield put({
+        type: 'FETCH_FILES_ERROR',
+        payload: {
+          section: action.payload.section,
+          code: e.status.toString()
+        }
+      });
+    } else {
+      // When there isn't a status due to network connection error.
+      yield put({
+        type: 'FETCH_FILES_ERROR',
+        payload: {
+          section: action.payload.section,
+          code: '503'
+        }
+      });
+    }
     // If listing returns 502, body should contain a system def for key pushing.
     yield e.status === 502 &&
       put({
@@ -723,6 +735,7 @@ export function* fileLink(action) {
       }
     });
   } catch (error) {
+    console.log("hehehe");
     yield put({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
       payload: {


### PR DESCRIPTION
## Overview: ##
Based on the error message that Nathan was getting during the test session.
```
TypeError: Cannot read properties of undefined (reading 'toString')
The above error occurred in task Wi created by takeLatest(FETCH_FILES, Wi) created by xp created by xp Tasks 
cancelled due to error: 
takeLatest(FETCH_FILES, Wi) VM75:1 GET https://pprd.frontera-portal.tacc.utexas.edu/api/datafiles/tapis/listing/private/longhorn.home.user/?
limit=100&nextPageToken&offset=0&query_string= net::ERR_CONNECTION_REFUSED VM75:1 
GET https://pprd.frontera-
portal.tacc.utexas.edu/api/datafiles/systems/definition/longhorn.home.user/ net::ERR_CONNECTION_REFUSED
```
I could not reproduce the exact error, but it seemed reasonable that there be a handle for this kind of an error.

## Related Jira tickets: ##

* [FP-1292](https://jira.tacc.utexas.edu/browse/FP-1292)

## Summary of Changes: ##
Tried to handle `net::ERR_CONNECTION_REFUSED` in the `FETCH_FILES` request (for file listings), which does not return a status message (thus `toString` fails).

I've given an arbitrary 503 (Service Unavailable) error for this case. But I'm not sure if that would be the best indicator of the problem. Please leave suggestions on what could be better.

## Testing Steps: ##
Again, wasn't sure how to reproduce the exact error...

## UI Photos:
N/A

## Notes: ##
