### PR TITLE
bug/FP-1327: Fix onboarding link

### DIFF
--- a/server/portal/apps/onboarding/steps/project_membership.py
+++ b/server/portal/apps/onboarding/steps/project_membership.py
@@ -175,7 +175,7 @@ class ProjectMembershipStep(AbstractStep):
                 ticket_id = event.data["ticket"]
         tracker = self.get_tracker()
         request_text = """Your request for membership on the {project} project has been
-        granted. Please login at {base_url}/onboarding/setup to continue setting up your account.
+        granted. Please login at {base_url}/workbench/onboarding/setup to continue setting up your account.
         """.format(
             project=self.project['title'],
             base_url=settings.WH_BASE_URL


### PR DESCRIPTION
## Overview: ##
The link sent to users to continue onboarding is missing `/workbench`. Should be `Please login at {base_url}/workbench/onboarding/setup`

## Related Jira tickets: ##

* [FP-1327](https://jira.tacc.utexas.edu/browse/FP-1327)

## Testing Steps: ##
1. Enable project membership onboarding step by adding this to your `_PORTAL_USER_ACCOUNT_SETUP_STEPS`
```
    {
        'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',
        'settings': {
            'project_sql_id': 57729,
        }
    },
```
2. Go through onboarding with a user not on the specified allocation (BrainMap in this example)
3. Approve yourself via the onboarding admin panel
4. Confirm the link in the email you get in response works as intended
