### PR TITLE
(Quickfix) Bug/FP-1295: Handle create workspace user error.

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
@@ -14,7 +14,9 @@ const DataFilesAddProjectModal = () => {
   const match = useRouteMatch();
   const dispatch = useDispatch();
   const { user } = useSelector(state => state.authenticatedUser);
-  const [members, setMembers] = useState([{ user, access: 'owner' }]);
+  const [members, setMembers] = useState(
+    user ? [{ user, access: 'owner' }] : []
+  );
   const isOpen = useSelector(state => state.files.modals.addproject);
   const isCreating = useSelector(state => {
     return (

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import * as Yup from 'yup';
 import { Formik, Form } from 'formik';
@@ -14,9 +14,23 @@ const DataFilesAddProjectModal = () => {
   const match = useRouteMatch();
   const dispatch = useDispatch();
   const { user } = useSelector(state => state.authenticatedUser);
+
+  user ??
+    useEffect(() => {
+      dispatch({ type: 'FETCH_AUTHENTICATED_USER' });
+    }, [dispatch]);
+
   const [members, setMembers] = useState(
     user ? [{ user, access: 'owner' }] : []
   );
+
+  useEffect(() => {
+    setMembers([
+      ...members.filter(member => member.user.username !== user.username),
+      { user, access: 'owner' }
+    ]);
+  }, [user]);
+
   const isOpen = useSelector(state => state.files.modals.addproject);
   const isCreating = useSelector(state => {
     return (

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesAddProjectModal.test.js
@@ -99,4 +99,25 @@ describe("DataFilesAddProjectModal", () => {
 
     await waitForElement(() => getAllByText(/Title must be at most 150 characters/));
   });
+
+  it("dispatches fetch authenticated user when authenticated user is null", () => {
+    const store = mockStore({
+      ...initialMockState,
+      authenticatedUser: {
+        user: null
+      }
+    });
+    const history = createMemoryHistory();
+    history.push('/workbench/data/tapis/private/test.system/');
+    const { getAllByText, getByRole } = renderComponent(
+      <DataFilesAddProjectModal />,
+      store,
+      history
+    )
+
+    expect(store.getActions()).toEqual([
+      {type: 'FETCH_AUTHENTICATED_USER'}
+    ]);
+  });
+
 });


### PR DESCRIPTION
## Overview: ##
There was an uncaught error when I was testing the create shared workspaces functionality in 3dem.
It seems like at the moment, the `authenticatedUser` state was at it's default state (`{user: null}`). 
Maybe because for some reason the call to [fetchAuthenticatedUserUtil](https://github.com/TACC/Core-Portal/blob/5a0610ff757100da1295820e834042b497dc03b3/client/src/redux/sagas/authenticated_user.sagas.js) didn't trigger?

I wasn't sure if I should re-request if user was null. 
It seemed like a seamless way would be to ensure that the members list didn't include the incorrect state, so that the code wouldn't reach the errors in the first place (`TypeError: e.user is null`).
This way users could just add themselves to the list if for some reason the authenticatedUser is not set properly.

## Related Jira tickets: ##

* [FP-1295](https://jira.tacc.utexas.edu/browse/FP-1295)

## Summary of Changes: ##
Added condition, in the `DataFilesAddProjectModal` component, to check if the `user` in `state.authencatedUser` is null and made the `members` array empty accordingly.

## Testing Steps: ##
1. Make the `authenticatedUser.user` null.
2. Ensure that the members list is just null (i.e. the user list in in the Add Shared Workspaces modal is empty) and there are no errors in the console.

## UI Photos:
N/A

## Notes: ##
Would it be better to re-request the current authenticated user instead if user is null?