### PR TITLE
task/FP-1191-Sidebar Link Hover/Active/Focus UI

### DIFF
--- a/client/src/components/Allocations/Allocations.scss
+++ b/client/src/components/Allocations/Allocations.scss
@@ -54,8 +54,13 @@
         }
         .link-text {
             font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
-            font-weight: 500;
             padding-left: 16px;
+        }
+        &.active {
+            font-weight: 700;
+        }
+        &:active {
+            font-weight: 700;
         }
     }
 }

--- a/client/src/components/Allocations/Allocations.scss
+++ b/client/src/components/Allocations/Allocations.scss
@@ -56,10 +56,9 @@
             font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
             padding-left: 16px;
         }
-        &.active {
-            font-weight: 700;
-        }
-        &:active {
+        &.active,
+        &:active
+        {
             font-weight: 700;
         }
     }

--- a/client/src/components/Applications/AppBrowser/AppBrowser.scss
+++ b/client/src/components/Applications/AppBrowser/AppBrowser.scss
@@ -66,15 +66,28 @@ ul#appBrowser-sidebar {
   border: none;
 }
 
+#appBrowser-sidebar .nav-link.active {
+  font-weight: 700;
+}
+
+#appBrowser-sidebar .nav-link:active {
+  font-weight: 700;
+}
+
+
 #appBrowser-tray {
   flex-grow: 1;
 
   background-color: #f4f4f4;
 }
 
-#appBrowser-sidebar .nav-text,
 #appBrowser-tray .nav-text {
   padding-left: 15px;
   font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
   font-weight: 500;
+}
+
+#appBrowser-sidebar .nav-text {
+  padding-left: 15px;
+  font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
 }

--- a/client/src/components/Applications/AppBrowser/AppBrowser.scss
+++ b/client/src/components/Applications/AppBrowser/AppBrowser.scss
@@ -54,6 +54,7 @@ ul#appBrowser-sidebar {
 }
 #appBrowser-sidebar .nav-link {
   /* RFE: Add `href` on links to: obviate this CSS, provide URL to app state */
+  font-weight: 500;
   cursor: pointer;
 }
 

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -16,6 +16,7 @@
 
   padding-left: var(--horizontal-buffer);
   color: var(--global-color-primary--dark);
+  font-weight: 500;
 }
 
 .data-files-sidebar .nav-link.active,
@@ -24,10 +25,17 @@
   background: var(--global-color-accent--weak);
 }
 
+.data-files-sidebar .nav-link.active {
+  font-weight: 700;
+}
+
+.data-files-sidebar .nav-link:active {
+  font-weight: 700;
+}
+
 .data-files-sidebar .nav-text {
   padding-left: 16px;
   font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
-  font-weight: 500;
 }
 
 .data-files-btn {

--- a/client/src/components/History/History.module.scss
+++ b/client/src/components/History/History.module.scss
@@ -52,10 +52,9 @@
             font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
             padding-left: 16px;
         }
-        &.active {
-            font-weight: 700;
-        }
-        &:active {
+        &.active,
+        &:active
+        {
             font-weight: 700;
         }
     }

--- a/client/src/components/History/History.module.scss
+++ b/client/src/components/History/History.module.scss
@@ -50,8 +50,13 @@
         }
         .link-text {
             font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
-            font-weight: 500;
             padding-left: 16px;
+        }
+        &.active {
+            font-weight: 700;
+        }
+        &:active {
+            font-weight: 700;
         }
     }
 }

--- a/client/src/components/Sidebar/Sidebar.module.scss
+++ b/client/src/components/Sidebar/Sidebar.module.scss
@@ -13,11 +13,18 @@ $width: 215px;
 
 .link {
   color: var(--global-color-primary--dark);
+  font-weight: 500;
 }
 .link:hover,
 .link--active {
   color: var(--global-color-primary--x-dark); /* to pass color contrast test */
   background-color: var(--global-color-accent--weak);
+}
+.link--active {
+  font-weight: 700;
+}
+.link:active {
+  font-weight: 700;
 }
 
 .content {
@@ -27,7 +34,6 @@ $width: 215px;
 .text {
   padding-left: 20px;
   font-size: 0.75em; /* ~20px (16px design * 1.2 design-to-app ratio) */
-  font-weight: 500;
 }
 
 .feedback-nav-item {

--- a/client/src/components/Sidebar/Sidebar.module.scss
+++ b/client/src/components/Sidebar/Sidebar.module.scss
@@ -20,10 +20,9 @@ $width: 215px;
   color: var(--global-color-primary--x-dark); /* to pass color contrast test */
   background-color: var(--global-color-accent--weak);
 }
-.link--active {
-  font-weight: 700;
-}
-.link:active {
+.link--active,
+.link:active
+{
   font-weight: 700;
 }
 

--- a/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.scss
+++ b/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.scss
@@ -10,6 +10,7 @@ $core-portal-color-primary: var(--global-color-accent--normal);
 .site-search-sidebar .nav-link {
   padding-left: $data-files-wrapper-horizontal-padding;
   color: var(--global-color-primary--dark);
+  font-weight: 500;
 }
 
 .site-search-sidebar .nav-link.active,

--- a/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.scss
+++ b/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.scss
@@ -19,11 +19,9 @@ $core-portal-color-primary: var(--global-color-accent--normal);
   background: var(--global-color-accent--weak);
 }
 
-.site-search-sidebar .nav-link.active {
-  font-weight: 700;
-}
-
-.site-search-sidebar .nav-link:active {
+.site-search-sidebar .nav-link:active,
+.site-search-sidebar .nav-link.active
+{
   font-weight: 700;
 }
 

--- a/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.scss
+++ b/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.scss
@@ -18,10 +18,17 @@ $core-portal-color-primary: var(--global-color-accent--normal);
   background: var(--global-color-accent--weak);
 }
 
+.site-search-sidebar .nav-link.active {
+  font-weight: 700;
+}
+
+.site-search-sidebar .nav-link:active {
+  font-weight: 700;
+}
+
 .site-search-sidebar .nav-text {
   padding-left: 15px;
   font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
-  font-weight: 500;
 }
 
 .site-search-sidebar .nav-content {


### PR DESCRIPTION
## Overview: ##

Update sidebar link hover/focus/active states

## Related Jira tickets: ##

* [FP-1191](https://jira.tacc.utexas.edu/browse/FP-1191)

## Summary of Changes: ##

Sidebar links on Main, Allocations, Applications, Data Files, History, and Search updated:

- :hover - purple background and not bold text
- -active - purple background and bold text
- :active - purple background and bold text

## Testing Steps: ##
1.  Navigate to Portal Dashboard.  On the "Main" sidebar, a selected (-active) sidebar link should have a purple background with bold text.  Any Sidebar link "hovered over" should have a purple background with non-bold text. All other links should have a grey background with non-bold text.
2. With the mouse, hover over a non-active Sidebar link and "left-click and hold" on the link.  That link is now :active.  It should have a purple background and bold text.
3. Perform the same above testing steps for the Allocations, Applications, Data Files, History, and Search "sub-Sidebars". NOTE: For the Search sidebar, it may be necessary modify the code in [SiteSearchSidebar.js](https://github.com/TACC/Core-Portal/blob/task/FP-1191-sidebar-link-states/client/src/components/SiteSearch/SiteSearchSidebar/SiteSearchSidebar.js) to add additional links to the sidebar.  To do this:

- On line 32, temporarily change:
     `{schemes.includes('public') && (` to `{true && (`

- On line 47, temporarily change:
     ` {authenticated && schemes.includes('community') && (` to ` {authenticated && true) && (`

## UI Photos:
Main Sidebar - -active link bold text with purple background
![FP-1191-Main-Sidebar](https://user-images.githubusercontent.com/77903391/141312971-5c0baa51-04b5-462f-9b3c-8863a73d6684.png)

Main Sidebar - :hover link non-bold text with purple background

https://user-images.githubusercontent.com/77903391/141314166-8442d9c4-56aa-4ce5-bb0e-ae4368522cbc.mov

Main Sidebar - :active link bold text with purple background

https://user-images.githubusercontent.com/77903391/141314525-49d2f1d7-ba7f-4049-a16a-0d372ed60fbd.mov

## Notes: 

##
