### PR TITLE
bug/FP-1362: Make hideSearchBar param optional on systems

### DIFF
--- a/server/portal/apps/search/tasks.py
+++ b/server/portal/apps/search/tasks.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 def agave_indexer(self, systemId, filePath='/', recurse=True, update_pems=False, ignore_hidden=True, reindex=False):
 
     if next((sys for sys in settings.PORTAL_DATAFILES_STORAGE_SYSTEMS
-            if sys['scheme'] == 'projects'
-            and sys['hideSearchBar']
+            if sys.get('scheme', None) == 'projects'
+            and sys.get('hideSearchBar', None)
             and systemId.startswith(settings.PORTAL_PROJECTS_SYSTEM_PREFIX)), None):
         return
 


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)

## Summary of Changes: ##
Prevent the indexer from throwing an exception when hideSearchBar isn't defined.

## Testing Steps: ##
1. Restart web and worker containers
2. Rename a file and check that the indexer task runs without an exception.

## UI Photos:

## Notes: ##
