### PR TITLE
bug/FP-1386 Data Files Table CheckboxHeaderCell keyboard accessible

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
@@ -22,7 +22,7 @@ export const CheckboxHeaderCell = () => {
         payload: { section: 'FilesListing' }
       });
   };
-  const handleKeyPress = e => e.key === 'enter' && toggleSelect();
+  const handleKeyPress = e => e.key === ' ' && toggleSelect();
   return (
     <Checkbox
       isChecked={selected}


### PR DESCRIPTION
## Overview: ##

`CheckboxHeaderCell` now is keyboard accessible in Data Files Table

## Related Jira tickets: ##

* [FP-1386](https://jira.tacc.utexas.edu/browse/FP-1386)

## Summary of Changes: ##

Changed the `CheckboxHeaderCell` to be accessible with Spacebar

## Testing Steps: ##
1. In Data Files Table select checkbox in header cell
2. Now able to select with Spacebar

## UI Photos:

https://user-images.githubusercontent.com/76450787/144930194-cc1ac517-34f9-4c24-96a1-9d5c769a1e64.mov

## Notes: ##
