### PR TITLE
Task/FP-357: 

### DIFF
--- a/client/src/components/Tickets/TicketModal.js
+++ b/client/src/components/Tickets/TicketModal.js
@@ -221,16 +221,34 @@ const TicketHistoryCard = ({
   return (
     <Card className="mt-1">
       <CardHeader
+        tabIndex="0"
         onClick={() =>
           dispatch({
             type: 'TICKET_DETAILED_VIEW_TOGGLE_SHOW_ITEM',
             payload: { index: historyId }
           })
         }
+        onKeyDown={useCallback(
+          e =>
+            e.key === ' ' &&
+            dispatch(
+              {
+                type: 'TICKET_DETAILED_VIEW_TOGGLE_SHOW_ITEM',
+                payload: { index: historyId }
+              },
+              e.preventDefault()
+            )
+        )}
       >
         <span className="ticket-history-header d-inline-block text-truncate">
           <strong>
-            <span className={ticketHeaderClassName}>
+            <span
+              className={ticketHeaderClassName}
+              id="TicketHeader"
+              role="button"
+              aria-expanded="false"
+              aria-controls="CardBody"
+            >
               {creator} | {`${formatDateTime(created)}`}
             </span>
             {!!attachmentTitles.length && (
@@ -245,7 +263,9 @@ const TicketHistoryCard = ({
         {toggleIcon}
       </CardHeader>
       <Collapse isOpen={isOpen}>
-        <CardBody>{content}</CardBody>
+        <CardBody id="CardBody" role="region" aria-labelledby="TicketHeader">
+          {content}
+        </CardBody>
         {!!attachmentTitles.length && (
           <CardBody>
             <Attachments attachments={attachmentTitles} ticketId={ticketId} />


### PR DESCRIPTION
When accessing a ticket under the "My Tickets" section of the Dashboard, the Tickets modal only allows users to expand the message contents by clicking on the message headers.

By completing the two related tickets, users would also be able to navigate through message headers and expand message contents by using the keyboard.

## Related Jira tickets: ##

* [FP-357](https://jira.tacc.utexas.edu/browse/FP-357)
* [FP-1326](https://jira.tacc.utexas.edu/browse/FP-1326)

## Summary of Changes: ##
* Added an onKeyDown callback in TicketModal.js to make the ticket history cards keyboard-accessible
* Set tabIndex=0 to make sure the message headers are reachable
* Added ARIA roles to make the HTML follow the ARIA spec

## Testing Steps: ##
1. Go to the "My Tickets" section of the Dashboard and open an existing ticket.
2. Use "Tab" and "Shift+Tab" to cycle between the message headers.
3. While a header has focus (is boxed), press the Spacebar to open/close the message content.
4. Make sure the you can still open a message manually by clicking on the drop-down icon.

## UI Photos:
https://user-images.githubusercontent.com/51714485/145103469-dec20ec2-649e-4188-9482-a5636ea139a7.mov

## Notes: ##
