### PR TITLE
Noop: Remove Dangling "styleName" Reference (since #520)

### DIFF
--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.jsx
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.jsx
@@ -176,7 +176,7 @@ DataFilesSearchbar.propTypes = {
   scheme: PropTypes.string.isRequired,
   system: PropTypes.string.isRequired,
   resultCount: PropTypes.number,
-  /** Additional `className` (or transpiled `styleName`) for the root element */
+  /** Additional className(s) for the root element */
   className: PropTypes.string,
   siteSearch: PropTypes.bool,
   disabled: PropTypes.bool,


### PR DESCRIPTION
## Overview: ##

Remove dangling reference found during cleanup and review after:
- #520

## Related Jira tickets: ##

None

## Summary of Changes: ##

- Edit comment to not reference `styleName` (and be consistent with similar comments).

## Testing Steps: ##
N/A

## UI Photos:
N/A

## Notes: ##
