### PR TITLE
Bug/FP-1479: Site Search WEB results should be purple

### DIFF
--- a/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.jsx
+++ b/client/src/components/SiteSearch/SiteSearchListing/SiteSearchListing.jsx
@@ -15,7 +15,7 @@ import './SiteSearchListing.css';
 
 export const CMSListingItem = ({ title, url, highlight }) => (
   <article
-    className={styles['sitesearch-cms-item"']}
+    className={styles['sitesearch-cms-item']}
     data-testid="sitesearch-cms-item"
   >
     <a href={url}>{title}</a>


### PR DESCRIPTION
## Overview: ##

This PR fixes a className typo in the site search results

## Related Jira tickets: ##

* [FP-1479](https://jira.tacc.utexas.edu/browse/FP-1479)

## Testing Steps: ##

Use site search locally to test that the web results no longer use default bootstrap styles

## UI Photos:
![image](https://user-images.githubusercontent.com/47395902/152427304-f5f3d91d-ec86-46a1-a60f-51673ee9bfb6.png)

