### PR TITLE
task/FP-1514: Fix project membership step to handle allocation-less projects

### DIFF
--- a/server/portal/apps/onboarding/steps/project_membership.py
+++ b/server/portal/apps/onboarding/steps/project_membership.py
@@ -61,12 +61,8 @@ class ProjectMembershipStep(AbstractStep):
     def is_project_member(self):
         username = self.user.username
         tas_client = self.get_tas_client()
-        projects = tas_client.projects_for_user(username)
-        return any(
-            [
-                project['id'] == self.settings['project_sql_id'] for project in projects
-            ]
-        )
+        project_users = tas_client.get_project_users(self.settings['project_sql_id'])
+        return any([u['username'] == username for u in project_users])
 
     def send_project_request(self, request):
         tracker = self.get_tracker()

--- a/server/portal/apps/onboarding/steps/project_membership_unit_test.py
+++ b/server/portal/apps/onboarding/steps/project_membership_unit_test.py
@@ -11,9 +11,11 @@ import os
 def tas_client(mocker):
     with open(os.path.join(settings.BASE_DIR, 'fixtures/tas/tas_project.json')) as f:
         tas_project = json.load(f)
+    with open(os.path.join(settings.BASE_DIR, 'fixtures/tas/tas_project_users.json')) as f:
+        tas_project_users = json.load(f)
     tas_client_mock = mocker.patch('portal.apps.onboarding.steps.project_membership.TASClient', autospec=True)
     tas_client_mock.return_value.project.return_value = tas_project
-    tas_client_mock.return_value.projects_for_user.return_value = [tas_project]
+    tas_client_mock.return_value.get_project_users.return_value = tas_project_users
     yield tas_client_mock
 
 
@@ -57,7 +59,7 @@ def project_membership_complete(mocker):
 
 def test_is_project_member(tas_client, project_membership_step):
     assert project_membership_step.is_project_member()
-    tas_client.return_value.projects_for_user.return_value = []
+    tas_client.return_value.get_project_users.return_value = []
     assert not project_membership_step.is_project_member()
 
 

--- a/server/portal/fixtures/tas/tas_project_users.json
+++ b/server/portal/fixtures/tas/tas_project_users.json
@@ -1,0 +1,26 @@
+[
+    {
+        "email": "pi_user@username.com",
+        "firstName": "PILastname",
+        "id": 1234567,
+        "lastName": "PIFirstname",
+        "role": "PI",
+        "username": "username"
+    },
+    {
+      "email": "deleage_user@username.com",
+      "firstName": "DelegateLastname",
+      "id": 123456,
+      "lastName": "DelegateFirstname",
+      "role": "Delegate",
+      "username": "username"
+    },
+    {
+      "email": "user@username.com",
+      "firstName": "Lastname",
+      "id": 12345,
+      "lastName": "Firstname",
+      "role": "Standard",
+      "username": "username"
+    }
+]


### PR DESCRIPTION
## Overview: ##

When checking if a user is a project member, the membership step uses pytas's `projects_for_user `(ie. /v1/projects/username/) and returns a list of projects. **BUT** it does not include projects who don't have any allocations. Using get_project_users is a better approach and avoids this issue.  

 https://tas.tacc.utexas.edu/TACCAdministration/Projects/EditProject.aspx?id=57877).

See [COOKS-211](https://jira.tacc.utexas.edu/browse/COOKS-211) and discussed with TAS developers on slack [here](https://tacc-team.slack.com/archives/C027DA88DRV/p1645463242246379)

## Related Jira tickets: ##

* [FP-1514](https://jira.tacc.utexas.edu/browse/FP-1514)
* [COOKS-211](https://jira.tacc.utexas.edu/browse/COOKS-211)

## Summary of Changes: ##
* Use pytas's `get_project_users` instead of `projects_for_user` in determining project membership

## Testing Steps: ##
1. Make sure you are will do onboarding (e.g. no user in db https://github.com/TACC/Core-Portal/wiki/How-to-Delete-Your-User)
2. Check your settings to ensure you are using same onboarding steps used by protx ( 👀  https://github.com/TACC/Core-Portal-Deployments/blob/main/protx/camino/pprd.settings_custom.py#L146-L173)
2. Login to cep.dev and ensure a that onboarding occurs and that the project membership step is automatically completed 

