### PR TITLE
Bug/FP-1528: Recursive indexer deletes documents it shouldn't

### DIFF
--- a/server/portal/libs/elasticsearch/unit_test.py
+++ b/server/portal/libs/elasticsearch/unit_test.py
@@ -103,6 +103,7 @@ class TestESUtils(TestCase):
         delete_recursive('test.system', '/test/file')
         mock_children.assert_called_once_with('test.system',
                                               '/test/file',
+                                              include_parent=True,
                                               recurse=True)
 
         mock_map = mock_bulk.call_args.args[1]

--- a/server/portal/libs/elasticsearch/utils.py
+++ b/server/portal/libs/elasticsearch/utils.py
@@ -75,7 +75,7 @@ def grouper(iterable, n, fillvalue=None):
     return zip_longest(*args, fillvalue=fillvalue)
 
 
-def walk_children(system, path, include_parent=True, recurse=False):
+def walk_children(system, path, include_parent=False, recurse=False):
     """
     Yield an elasticsearch hit for each child of an indexed file.
 
@@ -131,7 +131,7 @@ def delete_recursive(system, path):
     Void
     """
     from portal.libs.elasticsearch.docs.base import IndexedFile
-    hits = walk_children(system, path, recurse=True)
+    hits = walk_children(system, path, include_parent=True, recurse=True)
     idx = IndexedFile.Index.name
     client = get_connection('default')
 


### PR DESCRIPTION
## Overview: ##
The `include_parent` argument in `walk_children` was defaulted to `True`, which a) is semantically misleading and b) was causing a bug where documents were being deleted during indexing because we were expecting to find them in the list of their own children.

## Related Jira tickets: ##

* [FP-1528](https://jira.tacc.utexas.edu/browse/FP-1528)

## Summary of Changes: ##
Change the `include_parent` argument's default from `True` to `False`.

## Testing Steps: ##
In the shell:
```
In [1]: from portal.apps.search.tasks import agave_indexer

In [2]: agave_indexer(${YOUR_HOME_SYSTEM}, '/', recurse=True)
```
In the portal: Search for a folder in your home directory and make sure it shows up in the search results.

