### PR TITLE
FP-1154: Fix modal props

### DIFF
--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.jsx
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.jsx
@@ -73,6 +73,7 @@ BreadcrumbLink.defaultProps = {
 
 const RootProjectsLink = ({ api, section, operation, label }) => {
   const dispatch = useDispatch();
+  const modalProps = useSelector((state) => state.files.modalProps[operation]);
   if (section === 'modal') {
     const onClick = (e) => {
       e.stopPropagation();
@@ -81,7 +82,7 @@ const RootProjectsLink = ({ api, section, operation, label }) => {
         type: 'DATA_FILES_SET_MODAL_PROPS',
         payload: {
           operation,
-          props: { showProjects: true },
+          props: { ...modalProps, showProjects: true },
         },
       });
     };

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.test.js
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.test.js
@@ -4,6 +4,7 @@ import configureStore from 'redux-mock-store';
 import renderComponent from 'utils/testing';
 import DataFilesBreadcrumbs from './DataFilesBreadcrumbs';
 import systemsFixture from '../fixtures/DataFiles.systems.fixture';
+import filesFixture from '../fixtures/DataFiles.files.fixture';
 import { initialSystemState } from '../../../redux/reducers/datafiles.reducers';
 import { projectsFixture } from '../../../redux/sagas/fixtures/projects.fixture';
 
@@ -70,6 +71,7 @@ describe('DataFilesBreadcrumbs', () => {
     const store = mockStore({
       systems: systemsFixture,
       projects: projectsFixture,
+      files: filesFixture,
     });
     const history = createMemoryHistory();
     const { getByText, debug } = renderComponent(

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
@@ -164,7 +164,9 @@ const DataFilesCopyModal = React.memo(() => {
               Destination
               <DataFilesSystemSelector
                 operation="copy"
-                systemId={params.scheme === 'projects' ? 'shared' : params.system}
+                systemId={
+                  params.scheme === 'projects' ? 'shared' : params.system
+                }
                 section="modal"
                 disabled={disabled}
                 showProjects={showProjects}

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
@@ -61,11 +61,6 @@ const DataFilesCopyModal = React.memo(() => {
     });
 
   const onOpened = () => {
-    const systemParams = {
-      api: 'tapis',
-      scheme: 'private',
-      system: params.system,
-    };
     dispatch({
       type: 'FETCH_FILES_MODAL',
       payload: {
@@ -77,7 +72,7 @@ const DataFilesCopyModal = React.memo(() => {
   };
 
   const excludedSystems = systems
-    .filter((s) => s.scheme !== 'private')
+    .filter((s) => s.scheme !== 'private' && s.scheme !== 'projects')
     .filter((s) => !(s.scheme === 'public' && canMakePublic))
     .map((s) => s.system);
 
@@ -169,7 +164,7 @@ const DataFilesCopyModal = React.memo(() => {
               Destination
               <DataFilesSystemSelector
                 operation="copy"
-                systemId={(systems[0] || params).system}
+                systemId={params.scheme === 'projects' ? 'shared' : params.system}
                 section="modal"
                 disabled={disabled}
                 showProjects={showProjects}

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.jsx
@@ -16,6 +16,7 @@ const DataFilesProjectsList = ({ modal }) => {
   const { error, loading, projects } = useSelector(
     (state) => state.projects.listing
   );
+  const modalProps = useSelector((state) => state.files.modalProps[modal]);
   const query = queryStringParser.parse(useLocation().search);
 
   const infiniteScrollCallback = useCallback(() => {});
@@ -50,7 +51,7 @@ const DataFilesProjectsList = ({ modal }) => {
       type: 'DATA_FILES_SET_MODAL_PROPS',
       payload: {
         operation: modal,
-        props: { showProjects: false },
+        props: { ...modalProps, showProjects: false },
       },
     });
   };

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.test.js
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.test.js
@@ -6,10 +6,12 @@ import configureStore from 'redux-mock-store';
 import DataFilesProjectsList from './DataFilesProjectsList';
 import { projectsFixture } from '../../../redux/sagas/fixtures/projects.fixture';
 import systemsFixture from '../fixtures/DataFiles.systems.fixture';
+import filesFixture from '../fixtures/DataFiles.files.fixture';
 
 const mockStore = configureStore();
 const initialMockState = {
   projects: projectsFixture,
+  files: filesFixture,
   systems: systemsFixture,
 };
 

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.jsx
@@ -69,7 +69,9 @@ const DataFilesSystemSelector = ({
     setSelectedSystem(systemId);
   }, []);
 
-  const dropdownSystems = systemList.filter(s => !excludedSystems.includes(s.system));
+  const dropdownSystems = systemList.filter(
+    (s) => !excludedSystems.includes(s.system)
+  );
 
   return (
     <>
@@ -79,7 +81,14 @@ const DataFilesSystemSelector = ({
         className={styles['system-select']}
         disabled={disabled || !dropdownSystems.length}
       >
-        {dropdownSystems.map(s => <option key={uuidv4()} value={s.scheme === 'projects' ? 'shared' : s.system}>{s.name}</option>)}
+        {dropdownSystems.map((s) => (
+          <option
+            key={uuidv4()}
+            value={s.scheme === 'projects' ? 'shared' : s.system}
+          >
+            {s.name}
+          </option>
+        ))}
       </DropdownSelector>
       {selectedSystem === 'shared' && !showProjects && (
         <button

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.jsx
@@ -60,7 +60,7 @@ const DataFilesSystemSelector = ({
       type: 'DATA_FILES_SET_MODAL_PROPS',
       payload: {
         operation,
-        props: { showProjects: true },
+        props: { ...modalProps, showProjects: true },
       },
     });
   };
@@ -69,29 +69,17 @@ const DataFilesSystemSelector = ({
     setSelectedSystem(systemId);
   }, []);
 
+  const dropdownSystems = systemList.filter(s => !excludedSystems.includes(s.system));
+
   return (
     <>
       <DropdownSelector
         onChange={openSystem}
         value={selectedSystem}
         className={styles['system-select']}
-        disabled={disabled}
+        disabled={disabled || !dropdownSystems.length}
       >
-        {systemList
-          .filter(
-            (s) =>
-              s.scheme !== 'projects' && !excludedSystems.includes(s.system)
-          )
-          .map((system) => (
-            <option key={uuidv4()} value={system.system}>
-              {system.name}
-            </option>
-          ))}
-        {systemList.find((s) => s.scheme === 'projects') ? (
-          <option value="shared">Shared Workspaces</option>
-        ) : (
-          <></>
-        )}
+        {dropdownSystems.map(s => <option key={uuidv4()} value={s.scheme === 'projects' ? 'shared' : s.system}>{s.name}</option>)}
       </DropdownSelector>
       {selectedSystem === 'shared' && !showProjects && (
         <button


### PR DESCRIPTION
## Overview: ##

- Adds missing `modalProps` when updating modal state after projects are listed.
- Make default dropdown selection be valid - i.e. not an item in the excluded list
- Simplify file dropdown

A bug would occur where the `modalProps` would be overwritten when switching to the base project listing, removing the `canMakePublic` prop as well as others, ultimately causing the dropdown

## Related Jira tickets: ##

* [FP-123](https://jira.tacc.utexas.edu/browse/FP-1154)

## Testing Steps: ##
1. Click around the breadcrumbs in the dropdown and confirm the dropdown items remain the same, no matter where you click.

## UI Photos:
![Screen Shot 2022-02-24 at 2 59 48 PM](https://user-images.githubusercontent.com/20326896/155607220-2c3df8e5-0c9f-40c0-b417-946ff79c046d.png)
