### PR TITLE
FP-1339: Ticket Attachment Cell Hover Underlines When Not over Link

### DIFF
--- a/client/src/components/Tickets/TicketModal.jsx
+++ b/client/src/components/Tickets/TicketModal.jsx
@@ -62,7 +62,7 @@ const Attachments = ({ attachments, ticketId }) => {
     },
     {
       Header: '',
-      className: 'link',
+      className: 'attachment-download',
       accessor: 'attachment_id',
       Cell: (el) => (
         <a

--- a/client/src/components/Tickets/TicketModal.scss
+++ b/client/src/components/Tickets/TicketModal.scss
@@ -104,13 +104,10 @@
     display: flex;
   }
   .attachment-download {
-    color: var(--global-color-accent--normal);
     text-align: right;
-    margin-right: 20px;
   }
   .link {
     color: var(--global-color-accent--normal);
-    text-align: right;
     margin-right: 20px;
     &:hover {
       color: var(--global-color-accent--normal);

--- a/client/src/components/Tickets/TicketModal.scss
+++ b/client/src/components/Tickets/TicketModal.scss
@@ -103,6 +103,11 @@
     font-size: 1.4em;
     display: flex;
   }
+  .attachment-download {
+    color: var(--global-color-accent--normal);
+    text-align: right;
+    margin-right: 20px;
+  }
   .link {
     color: var(--global-color-accent--normal);
     text-align: right;


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [FP-1339](https://jira.tacc.utexas.edu/browse/FP-1339)

## Summary of Changes: ##
Updated CSS to resolve visual bug

## Testing Steps: ##
1. Open a ticket modal for a ticket that contains an attachment
2. Open the accordion to the message that has the attachment
3. Make sure that the link underline only happens on the "Download" text and not when you hover over the attachment line
4. Make sure that the "Download" text is still right aligned and otherwise visually looks like it did before.

## UI Photos:
Hovering over the attachment box
<img width="383" alt="01-hovering-over-box" src="https://user-images.githubusercontent.com/7683802/156422774-79af7157-16cf-48b6-9395-d772b8f63800.png">


Hovering over the download text link
<img width="388" alt="02-hovering-over-link-text" src="https://user-images.githubusercontent.com/7683802/156422798-c597e956-62aa-4374-bdbe-76e4aa50d9cf.png">


Previous (bad) behavior for reference
<img width="388" alt="03-original-behavior" src="https://user-images.githubusercontent.com/7683802/156423505-43e95f3c-86a6-4c06-a932-57b23c4aab1c.png">


## Notes: ##
