### PR TITLE
bug/FP-1536: Paginator endcaps have different styles

### DIFF
--- a/client/src/components/_common/Paginator/Paginator.jsx
+++ b/client/src/components/_common/Paginator/Paginator.jsx
@@ -76,7 +76,7 @@ const Paginator = ({ pages, current, callback, spread }) => {
       )}
       <Button
         color="link"
-        className={styles.endca}
+        className={styles.endcap}
         onClick={() => callback(current + 1)} // eslint-disable-line
         disabled={current === pages}
       >


### PR DESCRIPTION
## Overview: ##
Fixed paginator endcaps having different styles

## Related Jira tickets: ##

* [FP-1536](https://jira.tacc.utexas.edu/browse/FP-1536)

## Summary of Changes: ##
- Fixed a typo in the CSS module className applied to 'Next >' endcap button

## Testing Steps: ##
1. Navigate to UI Patterns, then scroll to the **Paginator** section
2. Confirm '< Previous' and 'Next >' endcap buttons have the same text size and padding

## UI Photos:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/43251554/156624585-9f4e49d1-7444-4955-9d29-f68937e2da29.png">


## Notes: ##
