### PR TITLE
FP-1540: Hotfix: Update ES to Fix Security Issue

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -33,7 +33,7 @@ services:
     container_name: core_portal_memcached
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     ulimits:
       memlock: -1
     environment:


### PR DESCRIPTION
## Overview

Update ElasticSearch version by changing out base image for docker service.

## Related

* [FP-1540](https://jira.tacc.utexas.edu/browse/FP-1540)

## Changes

* Update `elasticsearch` image to one with version `7.17.0`.

</details>

## Testing

1. Re-build `elasticsearch` container.
2. Enter shell in `elasticsearch` container.
3. Run `curl -XGET 'http://localhost:9200`. ([source](https://kb.objectrocket.com/elasticsearch/how-to-check-your-elasticsearch-version-from-the-command-line))
4. Confirm version of ElasticSearch is updated.

## Screenshots

![Portal ElasticSearch 7 17 0](https://user-images.githubusercontent.com/62723358/156820900-a975eb1c-c12d-469d-aa66-0544d3c83241.png)

## Notes

- [The fix and related patch came in version `7.16.2`.](https://www.elastic.co/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2)
- [The Portal recently had its version updated to `7.17.0`.](https://github.com/TACC/Core-Portal/blob/579349b/server/poetry.lock#L545-L547)