### PR TITLE
task/FP-1533: [A2CPS] Use User Client for SystemCreationStep

### DIFF
--- a/server/portal/apps/accounts/managers/user_systems.py
+++ b/server/portal/apps/accounts/managers/user_systems.py
@@ -7,7 +7,6 @@ import logging
 from django.conf import settings
 from portal.apps.accounts.models import SSHKeys
 from portal.libs.agave.models.systems.storage import StorageSystem
-from portal.libs.agave.utils import service_account
 from portal.utils import encryption as EncryptionUtil
 from portal.apps.users.utils import get_user_data
 from requests.exceptions import HTTPError
@@ -113,7 +112,7 @@ class UserSystemsManager():
         :returns: Agave response
         """
         try:
-            private_system = StorageSystem(service_account(), self.get_system_id(), ignore_error=None)
+            private_system = StorageSystem(self.user.agave_oauth.client, self.get_system_id(), ignore_error=None)
             # If system exists and is disabled, reset with config and enable
             if not private_system.available:
                 private_system = self.validate_storage_system(private_system.id)
@@ -180,7 +179,7 @@ class UserSystemsManager():
         """
         username = self.user.username
         system = StorageSystem(
-            service_account(),
+            self.user.agave_oauth.client,
             self.get_system_id()
         )
         system.site = 'portal.dev'


### PR DESCRIPTION
## Overview: ##
Currently the service account is used to generate a user's private system. A2CPS wants to use this instead of the keys service, but we need to use the user's client to generate the system instead.

## Related Jira tickets: ##

* [FP-1533](https://jira.tacc.utexas.edu/browse/FP-1533)

## Testing Steps: ##
1. In `settings_default.py`, make this your `_PORTAL_USER_ACCOUNT_SETUP_STEPS`:
```
_PORTAL_USER_ACCOUNT_SETUP_STEPS = [
    {
        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
        'settings': {}
    },
    {
        'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
        'settings': {}
    },
    {
        'step': 'portal.apps.onboarding.steps.system_creation.SystemCreationStep',
        'settings': {}
    }
]
```
2. Replace `_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT` and `_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS` with this:
```
_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT = 'frontera'
_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
    'frontera': {
        'name': 'My Data Test (Frontera)',
        'description': 'My Data on Frontera for {username}',
        'site': 'cep',
        'systemId': 'frontera.home.test2.{username}',
        'host': 'frontera.tacc.utexas.edu',
        'rootDir': '/home1/{tasdir}',
        'port': 22,
        'icon': None,
    }
}
```
3. Restart containers
4. Delete your user
```
> docker exec -it core_portal_django bash

> from django.contrib.auth.models import User
> u = User.objects.get(username='{USERNAME}')
> u.delete()
```
5. Login to the portal, and ensure your system creates correctly
6. With the tapis CLI, confirm the system has been created by your user, and you are the owner:
```
❯ tapis systems show frontera.home.test2.sal-test
+----------------------+---------------------------------------+
| Field                | Value                                 |
+----------------------+---------------------------------------+
| id                   | frontera.home.test2.sal-test          |
| name                 | frontera.home.test2.sal-test          |
| type                 | STORAGE                               |
| default              | False                                 |
| available            | True                                  |
| description          | Home system for user: sal_test        |
| executionType        | None                                  |
| globalDefault        | False                                 |
| lastModified         | 8 minutes ago                         |
| maxSystemJobs        | None                                  |
| maxSystemJobsPerUser | None                                  |
| owner                | sal_test                              |
| public               | False                                 |
| revision             | 1                                     |
| scheduler            | None                                  |
| scratchDir           | None                                  |
| site                 | portal.dev                            |
| status               | UP                                    |
| uuid                 | 6349666449315720724-242ac117-0001-006 |
| workDir              | None                                  |
+----------------------+---------------------------------------+
```