### PR TITLE
task/FP-1541: [A2CPS] Add `hidden` flag option to data files storage systems

### DIFF
--- a/client/src/components/DataFiles/DataFiles.jsx
+++ b/client/src/components/DataFiles/DataFiles.jsx
@@ -28,7 +28,7 @@ import DataFilesProjectFileListing from './DataFilesProjectFileListing/DataFiles
 
 const DefaultSystemRedirect = () => {
   const systems = useSelector(
-    (state) => state.systems.storage.configuration,
+    (state) => state.systems.storage.configuration.filter((s) => !s.hidden),
     shallowEqual
   );
   const history = useHistory();
@@ -113,7 +113,9 @@ const DataFiles = () => {
   );
   const loading = useSelector((state) => state.systems.storage.loading);
   const error = useSelector((state) => state.systems.storage.error);
-  const systems = useSelector((state) => state.systems.storage.configuration);
+  const systems = useSelector((state) =>
+    state.systems.storage.configuration.filter((s) => !s.hidden)
+  );
   const noPHISystem = useSelector(
     (state) => state.workbench.config.noPHISystem
   );

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
@@ -72,7 +72,9 @@ const DataFilesCopyModal = React.memo(() => {
   };
 
   const excludedSystems = systems
-    .filter((s) => s.scheme !== 'private' && s.scheme !== 'projects')
+    .filter(
+      (s) => s.hidden || (s.scheme !== 'private' && s.scheme !== 'projects')
+    )
     .filter((s) => !(s.scheme === 'public' && canMakePublic))
     .map((s) => s.system);
 

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.jsx
@@ -9,7 +9,7 @@ import DataFilesProjectsList from '../DataFilesProjectsList/DataFilesProjectsLis
 
 const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
   const systems = useSelector(
-    (state) => state.systems.storage.configuration.filter((s) => !s.hidden),
+    (state) => state.systems.storage.configuration,
     shallowEqual
   );
   const files = useSelector((state) => state.files.listing.modal, shallowEqual);
@@ -26,7 +26,7 @@ const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
     const systemParams = {
       api: 'tapis',
       scheme: 'private',
-      system: systems[0].system,
+      system: systems.filter((s) => !s.hidden)[0].system,
     };
     dispatch({
       type: 'FETCH_FILES_MODAL',
@@ -64,9 +64,9 @@ const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
               Select Input
               <DataFilesSystemSelector
                 operation="select"
-                systemId={(systems[0] || modalParams).system}
+                systemId={(systems.filter((s) => !s.hidden)[0] || modalParams).system}
                 section="modal"
-                excludedSystems={['googledrive']}
+                excludedSystems={systems.filter((s) => s.api !== 'tapis' || s.hidden).map((s) => s.system)}
                 showProjects={showProjects}
               />
             </div>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.jsx
@@ -9,7 +9,7 @@ import DataFilesProjectsList from '../DataFilesProjectsList/DataFilesProjectsLis
 
 const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
   const systems = useSelector(
-    (state) => state.systems.storage.configuration,
+    (state) => state.systems.storage.configuration.filter((s) => !s.hidden),
     shallowEqual
   );
   const files = useSelector((state) => state.files.listing.modal, shallowEqual);

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.jsx
@@ -64,9 +64,13 @@ const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
               Select Input
               <DataFilesSystemSelector
                 operation="select"
-                systemId={(systems.filter((s) => !s.hidden)[0] || modalParams).system}
+                systemId={
+                  (systems.filter((s) => !s.hidden)[0] || modalParams).system
+                }
                 section="modal"
-                excludedSystems={systems.filter((s) => s.api !== 'tapis' || s.hidden).map((s) => s.system)}
+                excludedSystems={systems
+                  .filter((s) => s.api !== 'tapis' || s.hidden)
+                  .map((s) => s.system)}
                 showProjects={showProjects}
               />
             </div>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
@@ -31,7 +31,7 @@ const DataFilesSidebar = ({ readOnly }) => {
     (state) => state.files.params.FilesListing
   );
   const systems = useSelector(
-    (state) => state.systems.storage.configuration,
+    (state) => state.systems.storage.configuration.filter((s) => !s.hidden),
     shallowEqual
   );
 

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
@@ -37,7 +37,7 @@ describe('DataFilesSidebar', () => {
       ...initialMockState,
     });
 
-    const { getByText } = renderComponent(
+    const { getByText, queryByText } = renderComponent(
       <Route path="/workbench/data">
         <DataFilesSidebar />
       </Route>,
@@ -58,6 +58,7 @@ describe('DataFilesSidebar', () => {
         .closest('a')
         .getAttribute('href')
     ).toEqual('/workbench/data/tapis/private/longhorn.home.username/');
+    expect(queryByText(/My Data \(Work\)/)).toBeNull();
   });
 
   it('disables creating new shared workspaces in read only shared workspaces', async () => {

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.test.js
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.test.js
@@ -9,29 +9,33 @@ import filesModalFixture from '../fixtures/files.modal.fixture';
 const mockStore = configureStore();
 
 describe('DataFilesSystemSelector', () => {
-  it('contains options for non-private systems', () => {
+  it('does not render excluded systems in selector', () => {
     const history = createMemoryHistory();
     const store = mockStore({
       systems: systemsFixture,
       files: filesModalFixture,
     });
+    const canMakePublic = true;
     const { queryByText } = renderComponent(
       <DataFilesSystemSelector
         section="modal"
         operation="copy"
         excludedSystems={systemsFixture.storage.configuration
-          .filter((s) => s.scheme !== 'private')
+          .filter(
+            (s) => s.hidden || (s.scheme !== 'private' && s.scheme !== 'projects')
+          )
+          .filter((s) => !(s.scheme === 'public' && canMakePublic))
           .map((s) => s.system)}
       />,
       store,
       history
     );
-    expect(queryByText(/My Data \(Work\)/)).toBeDefined();
+    expect(queryByText(/My Data \(Work\)/)).toBeNull();
     expect(queryByText(/My Data \(Frontera\)/)).toBeDefined();
     expect(queryByText(/My Data \(Longhorn\)/)).toBeDefined();
     expect(queryByText(/Google Drive/)).toBeDefined();
     expect(queryByText(/Shared Workspaces/)).toBeDefined();
-    expect(queryByText(/Public Data/)).toBeNull();
+    expect(queryByText(/Public Data/)).toBeDefined();
     expect(queryByText(/Community Data/)).toBeNull();
   });
 });

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.test.js
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.test.js
@@ -22,7 +22,8 @@ describe('DataFilesSystemSelector', () => {
         operation="copy"
         excludedSystems={systemsFixture.storage.configuration
           .filter(
-            (s) => s.hidden || (s.scheme !== 'private' && s.scheme !== 'projects')
+            (s) =>
+              s.hidden || (s.scheme !== 'private' && s.scheme !== 'projects')
           )
           .filter((s) => !(s.scheme === 'public' && canMakePublic))
           .map((s) => s.system)}

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -7,6 +7,7 @@ const systemsFixture = {
         scheme: 'private',
         api: 'tapis',
         icon: null,
+        hidden: true
       },
       {
         name: 'My Data (Frontera)',

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -7,7 +7,7 @@ const systemsFixture = {
         scheme: 'private',
         api: 'tapis',
         icon: null,
-        hidden: true
+        hidden: true,
       },
       {
         name: 'My Data (Frontera)',

--- a/client/src/components/DataFiles/tests/DataFiles.test.js
+++ b/client/src/components/DataFiles/tests/DataFiles.test.js
@@ -39,7 +39,7 @@ describe('DataFiles', () => {
         },
       },
     });
-    const { getByText, getAllByText } = renderComponent(
+    const { getByText, getAllByText, queryByText } = renderComponent(
       <DataFiles />,
       store,
       history
@@ -49,6 +49,7 @@ describe('DataFiles', () => {
     //);
     expect(getAllByText(/My Data \(Frontera\)/)).toBeDefined();
     expect(getByText(/My Data \(Longhorn\)/)).toBeDefined();
+    expect(queryByText(/My Data \(Work\)/)).toBeNull();
   });
 
   it('should not render Data Files with no systems', () => {
@@ -62,11 +63,20 @@ describe('DataFiles', () => {
       },
       systems: {
         storage: {
-          configuration: [],
+          configuration: [
+            {
+              name: 'My Data (Work)',
+              system: 'corral.home.username',
+              scheme: 'private',
+              api: 'tapis',
+              icon: null,
+              hidden: true
+            },
+          ],
           error: false,
           errorMessage: null,
           loading: false,
-          defaultHost: '',
+          defaultHost: 'cloud.corral.tacc.utexas.edu',
         },
         definitions: {
           list: [],

--- a/client/src/components/DataFiles/tests/DataFiles.test.js
+++ b/client/src/components/DataFiles/tests/DataFiles.test.js
@@ -70,7 +70,7 @@ describe('DataFiles', () => {
               scheme: 'private',
               api: 'tapis',
               icon: null,
-              hidden: true
+              hidden: true,
             },
           ],
           error: false,

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -46,7 +46,8 @@ class SystemListingView(BaseApiView):
                             'system':  UserSystemsManager(request.user, system_name=system_name).get_system_id(),
                             'scheme': 'private',
                             'api': 'tapis',
-                            'icon': details['icon']
+                            'icon': details['icon'],
+                            'hidden': details['hidden'] if 'hidden' in details else False
                         }
                     )
                 default_system = user_systems[settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT]

--- a/server/portal/apps/jupyter_mounts/api/views_unit_test.py
+++ b/server/portal/apps/jupyter_mounts/api/views_unit_test.py
@@ -76,6 +76,11 @@ def test_get(authenticated_user, client, service_account, mock_manager, mock_pro
             "pems": "rw"
         },
         {
+            "path": "/12345/username",
+            "mountPath": "/test/mock_name",
+            "pems": "rw"
+        },
+        {
             "path": "/projects/cep.project-1",
             "mountPath": "/test/My Projects/test",
             "pems": "rw"

--- a/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
@@ -97,7 +97,7 @@ def test_process(regular_user, mock_call_reactor, mocker):
         {
             'name': 'My Data (Work)',
             'host': 'cloud.corral.tacc.utexas.edu',
-            'rootDir': '/home/12345/username',
+            'rootDir': '/work/12345/username',
             'port': 2222,
             'systemId': 'cloud.corral.work.username',
             'icon': None,

--- a/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
+++ b/server/portal/apps/onboarding/steps/key_service_creation_unit_test.py
@@ -63,7 +63,8 @@ def test_process(regular_user, mock_call_reactor, mocker):
             'host': 'frontera.tacc.utexas.edu',
             'rootDir': '/home1/12345/username',
             'port': 22,
-            'icon': None
+            'icon': None,
+            'hidden': False
         },
         callback='portal.apps.onboarding.steps.key_service_creation.KeyServiceCreationCallback',
         callback_data={'expected': 'frontera.home.username'},
@@ -81,14 +82,33 @@ def test_process(regular_user, mock_call_reactor, mocker):
             'port': 22,
             'requires_allocation': 'longhorn3',
             'systemId': 'longhorn.home.username',
-            'icon': None
+            'icon': None,
+            'hidden': False
         },
         callback='portal.apps.onboarding.steps.key_service_creation.KeyServiceCreationCallback',
         callback_data={'expected': 'longhorn.home.username'},
         dryrun=False,
         force=True
     )
-    mock_call_reactor.assert_has_calls([frontera_call, longhorn_call], any_order=True)
+    stockyard_call = call(
+        regular_user,
+        'cloud.corral.work.username',
+        'wma-storage',
+        {
+            'name': 'My Data (Work)',
+            'host': 'cloud.corral.tacc.utexas.edu',
+            'rootDir': '/home/12345/username',
+            'port': 2222,
+            'systemId': 'cloud.corral.work.username',
+            'icon': None,
+            'hidden': True
+        },
+        callback='portal.apps.onboarding.steps.key_service_creation.KeyServiceCreationCallback',
+        callback_data={'expected': 'cloud.corral.work.username'},
+        dryrun=False,
+        force=True
+    )
+    mock_call_reactor.assert_has_calls([frontera_call, longhorn_call, stockyard_call], any_order=True)
 
 
 def test_mark_system(regular_user, mock_complete, mock_fail, monkeypatch, mocker):

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -77,6 +77,7 @@ _PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'rootDir': '/work/{tasdir}',
         'port': 2222,
         'icon': None,
+        'hidden': False,
     },
     'frontera': {
         'name': 'My Data (Frontera)',
@@ -87,6 +88,7 @@ _PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'rootDir': '/home1/{tasdir}',
         'port': 22,
         'icon': None,
+        'hidden': False,
     },
     'longhorn': {
         'name': 'My Data (Longhorn)',
@@ -98,6 +100,7 @@ _PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'port': 22,
         'requires_allocation': 'longhorn3',
         'icon': None,
+        'hidden': False,
     }
 }
 

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -466,7 +466,7 @@ PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
     'stockyard': {
         'name': 'My Data (Work)',
         'systemId': 'cloud.corral.work.{username}',
-        'host': 'longhorn.tacc.utexas.edu',
+        'host': 'cloud.corral.tacc.utexas.edu',
         'rootDir': '/work/{tasdir}',
         'port': 2222,
         'icon': None,

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -451,6 +451,7 @@ PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'rootDir': '/home1/{tasdir}',
         'port': 22,
         'icon': None,
+        'hidden': False,
     },
     'longhorn': {
         'name': 'My Data (Longhorn)',
@@ -460,6 +461,16 @@ PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'port': 22,
         'requires_allocation': 'longhorn3',
         'icon': None,
+        'hidden': False,
+    },
+    'stockyard': {
+        'name': 'My Data (Work)',
+        'systemId': 'cloud.corral.work.{username}',
+        'host': 'longhorn.tacc.utexas.edu',
+        'rootDir': '/work/{tasdir}',
+        'port': 2222,
+        'icon': None,
+        'hidden': True,
     }
 }
 
@@ -496,10 +507,21 @@ PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'siteSearchPriority': 1
     },
     {
+        'name': 'Public Data',
+        'system': 'portal.storage.public',
+        'scheme': 'public',
+        'api': 'tapis',
+        'icon': None,
+        'siteSearchPriority': 0
+    },
+    {
         'name': 'Shared Workspaces',
         'scheme': 'projects',
         'api': 'tapis',
-        'icon': 'publications'
+        'icon': 'publications',
+        'privilegeRequired': False,
+        'readOnly': False,
+        'hideSearchBar': False
     },
     {
         'name': 'Google Drive',
@@ -508,14 +530,6 @@ PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         'api': 'googledrive',
         'icon': None,
         'integration': 'portal.apps.googledrive_integration'
-    },
-    {
-        'name': 'Public Data',
-        'system': 'portal.storage.public',
-        'scheme': 'public',
-        'api': 'tapis',
-        'icon': None,
-        'siteSearchPriority': 0
     }
 ]
 


### PR DESCRIPTION
## Overview: ##
A2CPS wants to enable apps, but disable the showing of private storage systems in the data files area. Since a private storage system is needed for apps, we must add a 'hidden' flag to the storage system configuration from the backend portal settings.

## Related Jira tickets: ##

* [FP-1541](https://jira.tacc.utexas.edu/browse/FP-1541)

## Summary of Changes: ##

## Testing Steps: ##
1. Add `"hidden": True` to one of your storage systems in `_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS` in `settings_default.py`
2. Go to https://cep.dev/workbench/data/ and confirm that system is not present in the sidebar
3. Confirm you can still run and clone apps
4. Confirm the hidden system is not present in any file system selector dropdowns
