### PR TITLE
Quick: Set poetry to 1.1.0 since we use 1.1.0

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -54,5 +54,5 @@ coverage = "^5.1"
 requests-mock = "^1.8.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.1.0"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
## Overview: ##

- Completion(?) of Poetry from https://github.com/TACC/Core-Portal/pull/356.
- Match [Core-CMS#468](https://github.com/TACC/Core-CMS/pull/468/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R119-R120) (which is trying to match Portal).

<details>

> Poetry 1.0 adds the poetry.core (a pep compliant build for use in deployments) to projects now. https://github.com/python-poetry/poetry-core
> — @taoteg 

</details>

## Related Jira tickets: ##

* [FP-1461](https://jira.tacc.utexas.edu/browse/FP-1461)

## Summary of Changes: ##

Dependency bump to match version actually used.

## Testing Steps: ##

I dunno. This is more of a proposal, and an inquiry as to whether this is a noop or not. If more consideration is necessary, I'll create a ticket.
