### PR TITLE
Bug/FP-1538: Remove hover highlight for DataFilesTable headers.

### DIFF
--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.scss
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.scss
@@ -22,6 +22,9 @@
   padding-bottom: 0;
   font-weight: bold;
 }
+.tr-header:hover {
+  background-color: inherit;
+}
 
 .scroll {
   display: flex;

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.scss
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.scss
@@ -14,16 +14,13 @@
 .tr-background-shading:not(.-status) {
   background: #f4f4f4;
 }
-.tr:hover {
+.tr:not(.tr-header):hover {
   background-color: rgb(0 0 0 / 5%);
 }
 .tr-header {
   border-bottom: 1px solid #000000;
   padding-bottom: 0;
   font-weight: bold;
-}
-.tr-header:hover {
-  background-color: inherit;
 }
 
 .scroll {


### PR DESCRIPTION
## Overview: ##
One-liner pr for fixing header hover behavior in `DataFilesTable`.

## Related Jira tickets: ##

* [FP-1538](https://jira.tacc.utexas.edu/browse/FP-1538)

## Summary of Changes: ##
Fixed css in `DataFilesTable` that caused unwanted highlight for header rows.

## Testing Steps: ##
1. Ensure that there is no highlight on `DataFilesTable` headers (see videos below).

## UI Photos:
Before:
https://user-images.githubusercontent.com/9425579/160892350-50485b55-cdd8-45b0-9d37-1f381f9faec8.mov

After:
https://user-images.githubusercontent.com/9425579/160892392-4b2e8a53-2060-456f-a905-8922b5abea57.mov



## Notes: ##
