### PR TITLE
bug/FP-1618, FP-1626, FP-1630, FP-1299: Various bugfixes

### DIFF
--- a/client/src/components/ManageAccount/ManageAccountModals.jsx
+++ b/client/src/components/ManageAccount/ManageAccountModals.jsx
@@ -32,7 +32,7 @@ export const EditRequiredInformationModal = () => {
 
   const closeModal = () => {
     dispatch({ type: 'CLOSE_PROFILE_MODAL' });
-    if (success) dispatch({ type: 'LOAD_PROFILE_DATA' });
+    if (success) dispatch({ type: 'GET_PROFILE_DATA' });
   };
 
   return (
@@ -78,7 +78,7 @@ export const EditOptionalInformationModal = () => {
   const dispatch = useDispatch();
   const closeModal = () => {
     dispatch({ type: 'CLOSE_PROFILE_MODAL' });
-    if (success) dispatch({ type: 'LOAD_PROFILE_DATA' });
+    if (success) dispatch({ type: 'GET_PROFILE_DATA' });
   };
   return (
     <Modal isOpen={open} toggle={closeModal} className="manage-account-modal">
@@ -118,7 +118,7 @@ export const ChangePasswordModal = () => {
   const dispatch = useDispatch();
   const closeModal = () => {
     dispatch({ type: 'CLOSE_PROFILE_MODAL' });
-    if (success) dispatch({ type: 'LOAD_PROFILE_DATA' });
+    if (success) dispatch({ type: 'GET_PROFILE_DATA' });
   };
   return (
     <Modal isOpen={open} toggle={closeModal} className="manage-account-modal">

--- a/client/src/components/ManageAccount/tests/ManageAccountModals.test.js
+++ b/client/src/components/ManageAccount/tests/ManageAccountModals.test.js
@@ -204,7 +204,7 @@ describe('Change Password', () => {
     await waitFor(() => {
       const [close, reload] = successStore.getActions();
       expect(close.type).toEqual('CLOSE_PROFILE_MODAL');
-      expect(reload.type).toEqual('LOAD_PROFILE_DATA');
+      expect(reload.type).toEqual('GET_PROFILE_DATA');
     });
   });
 });
@@ -320,7 +320,7 @@ describe('Edit Optional Information', () => {
     await waitFor(() => {
       const [close, reload] = store.getActions();
       expect(close.type).toEqual('CLOSE_PROFILE_MODAL');
-      expect(reload.type).toEqual('LOAD_PROFILE_DATA');
+      expect(reload.type).toEqual('GET_PROFILE_DATA');
     });
   });
 });
@@ -468,7 +468,7 @@ describe('Edit Required Information', () => {
     await waitFor(() => {
       const [close, reload] = store.getActions();
       expect(close.type).toEqual('CLOSE_PROFILE_MODAL');
-      expect(reload.type).toEqual('LOAD_PROFILE_DATA');
+      expect(reload.type).toEqual('GET_PROFILE_DATA');
     });
   });
 });

--- a/client/src/components/Tickets/TicketsLayout.scss
+++ b/client/src/components/Tickets/TicketsLayout.scss
@@ -35,7 +35,7 @@
       width: 5em;
     }
     /* subject (fills to available width) */
-    tr>*:nth-child(2) {
+    tr > *:nth-child(2) {
       width: 100%;
     }
     /* date */

--- a/client/src/components/Tickets/TicketsLayout.scss
+++ b/client/src/components/Tickets/TicketsLayout.scss
@@ -12,15 +12,15 @@
   .tickets-view {
     /* number */
     tr > *:nth-child(1) {
-      width: 7%;
+      width: 12%;
     }
     /* subject */
     tr > *:nth-child(2) {
-      width: 70%;
+      width: 63%;
     }
     /* date */
     tr > *:nth-child(3) {
-      width: 11%;
+      width: 12%;
     }
     /* status */
     tr > *:nth-child(4) {

--- a/client/src/components/Tickets/TicketsLayout.scss
+++ b/client/src/components/Tickets/TicketsLayout.scss
@@ -14,17 +14,14 @@
     tr > *:nth-child(1) {
       width: 12%;
     }
-    /* subject */
-    tr > *:nth-child(2) {
-      width: 63%;
-    }
+    /* subject (fills to available width) */
     /* date */
     tr > *:nth-child(3) {
       width: 12%;
     }
     /* status */
     tr > *:nth-child(4) {
-      width: 12%;
+      width: 14%;
     }
   }
 }
@@ -32,19 +29,16 @@
   .tickets-view {
     /* number */
     tr > *:nth-child(1) {
-      width: 12.5%;
+      width: 15%;
     }
-    /* subject */
-    tr > *:nth-child(2) {
-      width: 52.5%;
-    }
+    /* subject (fills to available width) */
     /* date */
     tr > *:nth-child(3) {
-      width: 20%;
+      width: 6.5em;
     }
     /* status */
     tr > *:nth-child(4) {
-      width: 15%;
+      width: 7em;
     }
   }
 }

--- a/client/src/components/Tickets/TicketsLayout.scss
+++ b/client/src/components/Tickets/TicketsLayout.scss
@@ -14,10 +14,13 @@
     tr > *:nth-child(1) {
       width: 12%;
     }
-    /* subject (fills to available width) */
+    /* subject */
+    tr > *:nth-child(2) {
+      width: 61%;
+    }
     /* date */
     tr > *:nth-child(3) {
-      width: 12%;
+      width: 13%;
     }
     /* status */
     tr > *:nth-child(4) {
@@ -29,9 +32,12 @@
   .tickets-view {
     /* number */
     tr > *:nth-child(1) {
-      width: 15%;
+      width: 5em;
     }
     /* subject (fills to available width) */
+    tr>*:nth-child(2) {
+      width: 100%;
+    }
     /* date */
     tr > *:nth-child(3) {
       width: 6.5em;

--- a/client/src/components/_common/AppIcon/AppIcon.jsx
+++ b/client/src/components/_common/AppIcon/AppIcon.jsx
@@ -11,8 +11,14 @@ const AppIcon = ({ appId }) => {
     Object.keys(appIcons).forEach((appName) => {
       if (id.includes(appName)) {
         appIcon = appIcons[appName].toLowerCase();
+        return appIcon;
       }
     });
+    if (id.includes('compress') || id.includes('zippy')) {
+      appIcon = 'compress';
+    } else if (id.includes('extract')) {
+      appIcon = 'extract';
+    }
     return appIcon;
   };
   const iconName = findAppIcon(appId);

--- a/client/src/components/_common/AppIcon/AppIcon.test.js
+++ b/client/src/components/_common/AppIcon/AppIcon.test.js
@@ -42,4 +42,16 @@ describe('AppIcon', () => {
     );
     expect(getByRole('img')).toHaveAttribute('class', 'icon icon-jupyter');
   });
+  it('should render icon for zippy toolbar app', () => {
+    const { getByRole } = renderAppIcon(
+      'prtl.clone.username.FORK.zippy-0.2u2-2.0'
+    );
+    expect(getByRole('img')).toHaveAttribute('class', 'icon icon-compress');
+  });
+  it('should render icon for extract toolbar app', () => {
+    const { getByRole } = renderAppIcon(
+      'prtl.clone.username.FORK.extract-0.1u7-7.0'
+    );
+    expect(getByRole('img')).toHaveAttribute('class', 'icon icon-extract');
+  });
 });

--- a/client/src/components/_common/SectionHeader/SectionHeader.module.css
+++ b/client/src/components/_common/SectionHeader/SectionHeader.module.css
@@ -41,8 +41,6 @@
 /* Do not allow external margin styles */
 .heading {
   margin-bottom: 0; /* Overwrite Bootstrap `h1`–`h6` styles */
-
-  text-transform: capitalize;
 }
 /* Header actions are always after heading text */
 .heading ~ * {

--- a/client/src/redux/reducers/profile.reducers.js
+++ b/client/src/redux/reducers/profile.reducers.js
@@ -20,11 +20,7 @@ export const initialState = {
 export default function profile(state = initialState, action) {
   switch (action.type) {
     case 'LOAD_PROFILE_DATA':
-      return {
-        ...state,
-        isLoading: true,
-        errors: { ...state.errors, data: undefined },
-      };
+      return initialState;
     case 'ADD_DATA':
       return {
         ...state,

--- a/client/src/redux/reducers/tests/profile.reducers.test.js
+++ b/client/src/redux/reducers/tests/profile.reducers.test.js
@@ -10,11 +10,9 @@ describe('Profile/Manage Account Reducer', () => {
     const loadingProfileData = {
       type: 'LOAD_PROFILE_DATA',
     };
-    expect(profileReducer(initialState, loadingProfileData)).toEqual({
-      ...initialState,
-      isLoading: true,
-      errors: { data: undefined },
-    });
+    expect(profileReducer(initialState, loadingProfileData)).toEqual(
+      initialState
+    );
 
     const editingInformation = {
       type: 'EDITING_INFORMATION',

--- a/client/src/redux/sagas/profile.sagas.js
+++ b/client/src/redux/sagas/profile.sagas.js
@@ -15,6 +15,7 @@ export const getPasswordStatus = (h) => {
 };
 
 export function* getProfileData(action) {
+  yield put({ type: 'LOAD_PROFILE_DATA' });
   yield put({ type: 'GET_FORM_FIELDS' });
   try {
     const response = yield call(fetchUtil, {

--- a/client/src/redux/sagas/profile.sagas.test.js
+++ b/client/src/redux/sagas/profile.sagas.test.js
@@ -78,6 +78,7 @@ describe('getProfileData Saga', () => {
           },
         ],
       ])
+      .put({ type: 'LOAD_PROFILE_DATA' })
       .put({ type: 'GET_FORM_FIELDS' })
       .call(fetchUtil, { url: '/accounts/api/profile/data/' })
       .put({


### PR DESCRIPTION
## Overview: ##

- FP-1618: Fix perpetual spinner after updating profile
- FP-1626: Fix username casing on Onboarding page
- FP-1630: Fix column spacing for "My Tickets"
- FP-1299: Add compress/extract icons for zippy and extract toolbar apps

## Related Jira tickets: ##

* [FP-1618](https://jira.tacc.utexas.edu/browse/FP-1618)
* [FP-1626](https://jira.tacc.utexas.edu/browse/FP-1626)
* [FP-1630](https://jira.tacc.utexas.edu/browse/FP-1630)
* [FP-1299](https://jira.tacc.utexas.edu/browse/FP-1299)

## Testing Steps: ##
- FP-1618: Fix perpetual spinner after updating profile
  1. Go to https://cep.dev/workbench/account
  2. Click "Update Profile", change something and click "save", and close modal
  3. Confirm profile reloads and new changes are visible
- FP-1626: Fix username casing on Onboarding page
  1. Go to https://cep.dev/workbench/onboarding/setup
  2. Confirm username is correctly cased
- FP-1630: Fix column spacing for "My Tickets"
  1. Go to https://cep.dev/workbench/dashboard
  2. Confirm "Number" column in Tickets table is fully sized at medium and large screen widths
- FP-1299: Add compress/extract icons for zippy and extract toolbar apps
  1. Go to https://cep.dev/workbench/data
  2. Submit a "Compress" and "Extract" job via the toolbar buttons
  3. Confirm jobs show icons in https://cep.dev/workbench/history/jobs and https://cep.dev/workbench/dashboard

## UI Photos:
![Screen Shot 2022-04-29 at 4 01 21 PM](https://user-images.githubusercontent.com/20326896/166069589-85b8b0fa-c315-430b-a92e-97e7bb120487.png)
![Screen Shot 2022-04-29 at 4 01 07 PM](https://user-images.githubusercontent.com/20326896/166069590-a73ff7f4-9a56-4988-800f-24eb20a8c105.png)
![Screen Shot 2022-04-29 at 11 28 38 AM](https://user-images.githubusercontent.com/20326896/166069591-b509656a-48f2-48a8-a92b-d10aa60783d3.png)
![Screen Shot 2022-04-29 at 11 28 27 AM](https://user-images.githubusercontent.com/20326896/166069592-f03500e5-11c7-414d-b657-b692d2c9ff8b.png)
