### PR TITLE
bug/FP-1638: Add fixed widths for icon and date in Jobs table

### DIFF
--- a/client/src/components/Jobs/Jobs.scss
+++ b/client/src/components/Jobs/Jobs.scss
@@ -5,7 +5,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 3%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -21,7 +21,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 15%;
+      width: 125px;
     }
   }
 }
@@ -29,7 +29,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 3%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -45,7 +45,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 15%;
+      width: 125px;
     }
   }
 }
@@ -53,7 +53,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 4%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -69,7 +69,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 15%;
+      width: 125px;
     }
   }
 }
@@ -77,7 +77,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 5%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -93,7 +93,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 19%;
+      width: 125px;
     }
   }
 }
@@ -103,7 +103,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -123,7 +123,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 12%;
+      width: 125px;
     }
   }
 }
@@ -131,7 +131,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 3%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -151,7 +151,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 11%;
+      width: 125px;
     }
   }
 }
@@ -159,7 +159,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 3%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -179,7 +179,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 14%;
+      width: 125px;
     }
   }
 }
@@ -187,7 +187,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 4%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -207,7 +207,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 14%;
+      width: 125px;
     }
   }
 }
@@ -215,7 +215,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 5%;
+      width: 23px;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -235,7 +235,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 14%;
+      width: 125px;
     }
   }
 }

--- a/client/src/components/Jobs/Jobs.scss
+++ b/client/src/components/Jobs/Jobs.scss
@@ -5,7 +5,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -21,7 +21,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -29,7 +29,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -45,7 +45,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -53,7 +53,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -69,7 +69,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -77,7 +77,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -93,7 +93,7 @@
     }
     /* date */
     tr > *:nth-child(5) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -103,7 +103,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -123,7 +123,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -131,7 +131,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -151,7 +151,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -159,7 +159,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -179,7 +179,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -187,7 +187,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -207,7 +207,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 125px;
+      width: 9em;
     }
   }
 }
@@ -215,7 +215,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 23px;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -235,7 +235,7 @@
     }
     /* date */
     tr > *:nth-child(6) {
-      width: 125px;
+      width: 9em;
     }
   }
 }

--- a/client/src/components/Jobs/Jobs.scss
+++ b/client/src/components/Jobs/Jobs.scss
@@ -5,7 +5,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -29,7 +29,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -53,7 +53,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -77,7 +77,7 @@
   .jobs-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -103,7 +103,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -131,7 +131,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {
@@ -159,7 +159,7 @@
   .jobs-detailed-view {
     /* icon */
     tr > *:nth-child(1) {
-      width: 2em;;
+      width: 2em;
     }
     /* name */
     tr > *:nth-child(2) {


### PR DESCRIPTION
## Overview: ##

Adds fixed widths to icon and date columns in the Jobs table views. These seem like the most jarring fields to be cut off.

## Related Jira tickets: ##

* [FP-1638](https://jira.tacc.utexas.edu/browse/FP-1638)

## Testing Steps: ##
1. Go to https://cep.dev/workbench/dashboard
2. Change screen width and confirm icons and date are shown at full width
3. Repeat for https://cep.dev/workbench/history/jobs

## UI Photos:
![Screen Shot 2022-05-09 at 3 59 12 PM](https://user-images.githubusercontent.com/20326896/167497712-e1ce5597-1829-44b2-8a89-eeb63f686677.png)
![Screen Shot 2022-05-09 at 3 58 53 PM](https://user-images.githubusercontent.com/20326896/167497715-a977ef8f-9328-4fb5-8124-026ff21bda76.png)


## Notes: ##
Are these appropriate column fields (important enough) to apply fixed widths to all screen sizes?
