### PR TITLE
fix(docker): remove test entires in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,6 @@ After you clone the repository locally, there are several configuration steps re
 
 ##### CMS
 
-A shortcut for the CMS steps is:
-
-```
-cp server/conf/cms/secrets.sample.py server/conf/cms/secrets.py
-touch server/conf/cms/settings_local.py
-touch server/conf/cms/settings_custom.py
-```
-
-Otherwise:
-
 - Copy `server/conf/cms/secrets.sample.py` to `server/conf/cms/secrets.py`
 
 - To emulate a specific CMS project, copy https://github.com/TACC/Core-CMS-Resources/blob/main/__PROJECT_TO_EMULATE__/settings_custom.py to `server/conf/cms/settings_custom.py`

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -6,8 +6,6 @@ services:
   cms:
     image: taccwma/core-cms:latest
     volumes:
-      - ../cms/settings_custom.py:/code/taccsite_cms/settings_custom.py
-      - ../cms/settings_local.py:/code/taccsite_cms/settings_local.py
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini
       - ../../cms/static:/code/static


### PR DESCRIPTION
## Overview: ##

Remove lines ~~I think~~ I accidentally added in #522 ([code](https://github.com/TACC/Core-Portal/pull/522/files#diff-67ee10ce7fc260521e9912a611ab1003a513c09ec83ddf5c5ed2c74ab198d82a])).

## Related Jira tickets: ##

* [FP-1194](https://jira.tacc.utexas.edu/browse/FP-1194)

## Summary of Changes: ##

- remove two lines from docker compose (dev) file
- remove README instructions that were only for those lines

## Testing Steps: ##
1. Run/Deploy Portal.
2. Open CMS.
3. Above steps succeed.

## UI Photos:

N/A

## Notes: ##

The CMS worked on Portal before the docker compose file change I now revert. Nothing I remember suggests this change I revert was necessary. The change I revert causes an unexpected and unnecessary dependency for Portal (and a docker mount error). I think it was an accident by me to add these (I was probably testing custom CMS project via Portal in local env).

_**Update**: This change does not break local environment CMS testing via Portal. That process requires manual tweaking and was never fully-supported. I had only first tried custom CMS settings—via Portal CMS directly—during #522. With #522, I accidentally committed my mucking about. I normally work on CMS customization via [different solutions](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes)._