### PR TITLE
task/FP-1628: update app values when user changes a new queue

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -24,7 +24,7 @@ import {
   getNodeCountValidation,
   getProcessorsOnEachNodeValidation,
   getQueueValidation,
-  getFixedValuesForUpdatedQueue,
+  updateValuesForQueue,
 } from './AppFormUtils';
 import DataFilesSelectModal from '../../DataFiles/DataFilesModals/DataFilesSelectModal';
 import * as ROUTES from '../../../constants/routes';
@@ -140,7 +140,7 @@ const AdjustValuesWhenQueueChanges = ({ app }) => {
   const { values, setValues } = useFormikContext();
   React.useEffect(() => {
     if (previousValues && previousValues.batchQueue !== values.batchQueue) {
-      setValues(getFixedValuesForUpdatedQueue(app, values));
+      setValues(updateValuesForQueue(app, values));
     }
     setPreviousValues(values);
   }, [app, values, setValues]);

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -137,13 +137,13 @@ const AdjustValuesWhenQueueChanges = ({ app }) => {
   const [previousValues, setPreviousValues] = useState();
 
   // Grab values and update if queue changes
-  const { values, setValues, isValid } = useFormikContext();
+  const { values, setValues } = useFormikContext();
   React.useEffect(() => {
     if (previousValues && previousValues.batchQueue !== values.batchQueue) {
       setValues(getFixedValuesForUpdatedQueue(app, values));
     }
     setPreviousValues(values);
-  }, [app, values, setValues, isValid]);
+  }, [app, values, setValues]);
   return null;
 };
 

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -154,12 +154,16 @@ export const getFixedValuesForUpdatedQueue = (app, values) => {
   }
 
   if (
-    queue.maxProcessorsPerNode !== -1 &&
+    queue.maxProcessorsPerNode !== -1 /* e.g. Frontera rtx/rtx-dev queue */ &&
     values.processorsOnEachNode > maxProcessorsOnEachNode
   ) {
     fixedValues.processorsOnEachNode = maxProcessorsOnEachNode;
   }
 
+  /* if user has entered a time and it's somewhat reasonable (i.e. less than max time
+  for all the queues, then we should check if the time works for the new queue and update
+  it if it doesn't.
+   */
   if (values.maxRunTime) {
     const longestMaxRequestedTime = app.exec_sys.queues
       .map((queue) => queue.maxRequestedTime)

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -138,7 +138,7 @@ export const getQueueValidation = (queue, app) => {
  * @param {Object} values
  * @returns {Object} updated/fixed values
  */
-export const getFixedValuesForUpdatedQueue = (app, values) => {
+export const updateValuesForQueue = (app, values) => {
   const fixedValues = { ...values };
   const queue = app.exec_sys.queues.find((q) => q.name === values.batchQueue);
   const minNode = getMinNodeCount(queue, app);

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -153,7 +153,10 @@ export const getFixedValuesForUpdatedQueue = (app, values) => {
     fixedValues.nodeCount = queue.maxNodes;
   }
 
-  if (values.processorsOnEachNode > maxProcessorsOnEachNode) {
+  if (
+    queue.maxProcessorsPerNode !== -1 &&
+    values.processorsOnEachNode > maxProcessorsOnEachNode
+  ) {
     fixedValues.processorsOnEachNode = maxProcessorsOnEachNode;
   }
 

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -55,7 +55,7 @@ export const createMaxRunTimeRegex = (maxRunTime) => {
  * Get min node count for queue
  */
 const getMinNodeCount = (queue, app) => {
-  // all queues have a min node count of 1 except for the normal queue on Frontera which has a min node of 3
+  // all queues have a min node count of 1 except for the normal queue on Frontera which has a min node count of 3
   return getSystemName(app.exec_sys.login.host) === 'Frontera' &&
     queue.name === 'normal'
     ? 3
@@ -70,7 +70,6 @@ const getMinNodeCount = (queue, app) => {
  * @returns {Yup.number()} min/max validation of node count
  */
 export const getNodeCountValidation = (queue, app) => {
-  // all queues have a min node count of 1 except for the normal queue on Frontera which has a min node of 3
   const min = getMinNodeCount(queue, app);
   return Yup.number()
     .min(

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -139,24 +139,24 @@ export const getQueueValidation = (queue, app) => {
  * @returns {Object} updated/fixed values
  */
 export const updateValuesForQueue = (app, values) => {
-  const fixedValues = { ...values };
+  const updatedValues = { ...values };
   const queue = app.exec_sys.queues.find((q) => q.name === values.batchQueue);
   const minNode = getMinNodeCount(queue, app);
   const maxProcessorsOnEachNode = getMaxProcessorsOnEachNode(queue);
 
   if (values.nodeCount < minNode) {
-    fixedValues.nodeCount = minNode;
+    updatedValues.nodeCount = minNode;
   }
 
   if (values.nodeCount > queue.maxNodes) {
-    fixedValues.nodeCount = queue.maxNodes;
+    updatedValues.nodeCount = queue.maxNodes;
   }
 
   if (
     queue.maxProcessorsPerNode !== -1 /* e.g. Frontera rtx/rtx-dev queue */ &&
     values.processorsOnEachNode > maxProcessorsOnEachNode
   ) {
-    fixedValues.processorsOnEachNode = maxProcessorsOnEachNode;
+    updatedValues.processorsOnEachNode = maxProcessorsOnEachNode;
   }
 
   /* if user has entered a time and it's somewhat reasonable (i.e. less than max time
@@ -175,9 +175,9 @@ export const updateValuesForQueue = (app, values) => {
       runtimeRegExp.test(values.maxRunTime) &&
       values.maxRunTime > queue.maxRequestedTime
     ) {
-      fixedValues.maxRunTime = queue.maxRequestedTime;
+      updatedValues.maxRunTime = queue.maxRequestedTime;
     }
   }
 
-  return fixedValues;
+  return updatedValues;
 };

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -160,5 +160,21 @@ export const getFixedValuesForUpdatedQueue = (app, values) => {
     fixedValues.processorsOnEachNode = maxProcessorsOnEachNode;
   }
 
+  if (values.maxRunTime) {
+    const longestMaxRequestedTime = app.exec_sys.queues
+      .map((queue) => queue.maxRequestedTime)
+      .sort()
+      .at(-1);
+    const runtimeRegExp = new RegExp(
+      createMaxRunTimeRegex(longestMaxRequestedTime)
+    );
+    if (
+      runtimeRegExp.test(values.maxRunTime) &&
+      values.maxRunTime > queue.maxRequestedTime
+    ) {
+      fixedValues.maxRunTime = queue.maxRequestedTime;
+    }
+  }
+
   return fixedValues;
 };

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -84,6 +84,12 @@ export const getNodeCountValidation = (queue, app) => {
 };
 
 /**
+ * Get min node count for queue
+ */
+const getMaxProcessorsOnEachNode = (queue) =>
+  Math.ceil(queue.maxProcessorsPerNode / queue.maxNodes);
+
+/**
  * Get validator for processors on each node
  *
  * @function
@@ -94,9 +100,7 @@ export const getProcessorsOnEachNodeValidation = (queue) => {
   if (queue.maxProcessorsPerNode === -1) {
     return Yup.number();
   }
-  return Yup.number()
-    .min(1)
-    .max(Math.ceil(queue.maxProcessorsPerNode / queue.maxNodes));
+  return Yup.number().min(1).max(getMaxProcessorsOnEachNode(queue));
 };
 
 /**
@@ -139,6 +143,7 @@ export const getFixedValuesForUpdatedQueue = (app, values) => {
   const fixedValues = { ...values };
   const queue = app.exec_sys.queues.find((q) => q.name === values.batchQueue);
   const minNode = getMinNodeCount(queue, app);
+  const maxProcessorsOnEachNode = getMaxProcessorsOnEachNode(queue);
 
   if (values.nodeCount < minNode) {
     fixedValues.nodeCount = minNode;
@@ -146,6 +151,10 @@ export const getFixedValuesForUpdatedQueue = (app, values) => {
 
   if (values.nodeCount > queue.maxNodes) {
     fixedValues.nodeCount = queue.maxNodes;
+  }
+
+  if (values.processorsOnEachNode > maxProcessorsOnEachNode) {
+    fixedValues.processorsOnEachNode = maxProcessorsOnEachNode;
   }
 
   return fixedValues;

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -71,7 +71,7 @@ describe('AppFormUtils', () => {
     ).toEqual(true);
   });
 
-  it('getFixedValuesForUpdatedQueue properly fixes node count when using small queue', () => {
+  it('getFixedValuesForUpdatedQueue fixes node count when using small queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'small';
@@ -80,7 +80,7 @@ describe('AppFormUtils', () => {
     expect(updatedValues.nodeCount).toEqual(2);
   });
 
-  it('getFixedValuesForUpdatedQueue properly fixes node count when using normal queue', () => {
+  it('getFixedValuesForUpdatedQueue fixes node count when using normal queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'normal';
@@ -89,7 +89,7 @@ describe('AppFormUtils', () => {
     expect(updatedValues.nodeCount).toEqual(3);
   });
 
-  it('getFixedValuesForUpdatedQueue properly fixes processorsOnEachNode when using dev queue', () => {
+  it('getFixedValuesForUpdatedQueue fixes processorsOnEachNode', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'development';

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -71,7 +71,7 @@ describe('AppFormUtils', () => {
     ).toEqual(true);
   });
 
-  it('updateValuesForQueue fixes node count when using small queue', () => {
+  it('updateValuesForQueue updates node count when using small queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'small';
@@ -80,7 +80,7 @@ describe('AppFormUtils', () => {
     expect(updatedValues.nodeCount).toEqual(2);
   });
 
-  it('updateValuesForQueue fixes node count when using normal queue', () => {
+  it('updateValuesForQueue updates node count when using normal queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'normal';
@@ -89,7 +89,7 @@ describe('AppFormUtils', () => {
     expect(updatedValues.nodeCount).toEqual(3);
   });
 
-  it('updateValuesForQueue fixes processorsOnEachNode', () => {
+  it('updateValuesForQueue updates processorsOnEachNode', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'development';
@@ -109,7 +109,7 @@ describe('AppFormUtils', () => {
     expect(updatedValues.processorsOnEachNode).toEqual(2);
   });
 
-  it('updateValuesForQueue fixes maxRunTime', () => {
+  it('updateValuesForQueue updates maxRunTime', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'development';
@@ -118,7 +118,7 @@ describe('AppFormUtils', () => {
     expect(updatedValues.maxRunTime).toEqual('02:00:00');
   });
 
-  it('updateValuesForQueue avoids fixing runtime if not valid or empty', () => {
+  it('updateValuesForQueue avoids updating runtime if not valid or empty', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.maxRunTime = '99:00:00';

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -1,6 +1,13 @@
 import { cloneDeep } from 'lodash';
-import { namdAppFixture } from './fixtures/AppForm.app.fixture';
-import { getNodeCountValidation, getQueueValidation } from './AppFormUtils';
+import {
+  namdAppFixture,
+  namdDefaultFormValues,
+} from './fixtures/AppForm.app.fixture';
+import {
+  getNodeCountValidation,
+  getQueueValidation,
+  getFixedValuesForUpdatedQueue,
+} from './AppFormUtils';
 
 describe('AppFormUtils', () => {
   const normalQueue = namdAppFixture.exec_sys.queues.find(
@@ -62,5 +69,23 @@ describe('AppFormUtils', () => {
     expect(
       getQueueValidation(normalQueue, stampede2SerialApp).isValidSync('normal')
     ).toEqual(true);
+  });
+
+  it('getFixedValuesForUpdatedQueue properly fixes node count when using small queue', () => {
+    const appFrontera = cloneDeep(namdAppFixture);
+    const values = cloneDeep(namdDefaultFormValues);
+    values.batchQueue = 'small';
+    values.nodeCount = 3;
+    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    expect(updatedValues.nodeCount).toEqual(2);
+  });
+
+  it('getFixedValuesForUpdatedQueue properly fixes node count when using normal queue', () => {
+    const appFrontera = cloneDeep(namdAppFixture);
+    const values = cloneDeep(namdDefaultFormValues);
+    values.batchQueue = 'normal';
+    values.nodeCount = 2;
+    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    expect(updatedValues.nodeCount).toEqual(3);
   });
 });

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -98,4 +98,13 @@ describe('AppFormUtils', () => {
     /* should to be 56 (i.e. 2240/40) on development queue */
     expect(updatedValues.processorsOnEachNode).toEqual(56);
   });
-});
+
+  it('getFixedValuesForUpdatedQueue handles processorsOnEachNode for rtx queue', () => {
+    const appFrontera = cloneDeep(namdAppFixture);
+    const values = cloneDeep(namdDefaultFormValues);
+    values.batchQueue = 'rtx';
+    values.processorsOnEachNode = 2;
+    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    /* shouldn't change for rtx or rtx-dev queues as maxProcessorsPerNode is -1  */
+    expect(updatedValues.processorsOnEachNode).toEqual(2);
+  });

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -6,7 +6,7 @@ import {
 import {
   getNodeCountValidation,
   getQueueValidation,
-  getFixedValuesForUpdatedQueue,
+  updateValuesForQueue,
 } from './AppFormUtils';
 
 describe('AppFormUtils', () => {
@@ -71,65 +71,62 @@ describe('AppFormUtils', () => {
     ).toEqual(true);
   });
 
-  it('getFixedValuesForUpdatedQueue fixes node count when using small queue', () => {
+  it('updateValuesForQueue fixes node count when using small queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'small';
     values.nodeCount = 3;
-    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    const updatedValues = updateValuesForQueue(appFrontera, values);
     expect(updatedValues.nodeCount).toEqual(2);
   });
 
-  it('getFixedValuesForUpdatedQueue fixes node count when using normal queue', () => {
+  it('updateValuesForQueue fixes node count when using normal queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'normal';
     values.nodeCount = 2;
-    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    const updatedValues = updateValuesForQueue(appFrontera, values);
     expect(updatedValues.nodeCount).toEqual(3);
   });
 
-  it('getFixedValuesForUpdatedQueue fixes processorsOnEachNode', () => {
+  it('updateValuesForQueue fixes processorsOnEachNode', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'development';
     values.processorsOnEachNode = 64;
-    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    const updatedValues = updateValuesForQueue(appFrontera, values);
     /* should to be 56 (i.e. 2240/40) on development queue */
     expect(updatedValues.processorsOnEachNode).toEqual(56);
   });
 
-  it('getFixedValuesForUpdatedQueue handles processorsOnEachNode for rtx queue', () => {
+  it('updateValuesForQueue handles processorsOnEachNode for rtx queue', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'rtx';
     values.processorsOnEachNode = 2;
-    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    const updatedValues = updateValuesForQueue(appFrontera, values);
     /* shouldn't change for rtx or rtx-dev queues as maxProcessorsPerNode is -1  */
     expect(updatedValues.processorsOnEachNode).toEqual(2);
   });
 
-  it('getFixedValuesForUpdatedQueue fixes maxRunTime', () => {
+  it('updateValuesForQueue fixes maxRunTime', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.batchQueue = 'development';
     values.maxRunTime = '48:00:00';
-    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    const updatedValues = updateValuesForQueue(appFrontera, values);
     expect(updatedValues.maxRunTime).toEqual('02:00:00');
   });
 
-  it('getFixedValuesForUpdatedQueue avoids fixing runtime if not valid or empty', () => {
+  it('updateValuesForQueue avoids fixing runtime if not valid or empty', () => {
     const appFrontera = cloneDeep(namdAppFixture);
     const values = cloneDeep(namdDefaultFormValues);
     values.maxRunTime = '99:00:00';
-    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    const updatedValues = updateValuesForQueue(appFrontera, values);
     expect(updatedValues.maxRunTime).toEqual('99:00:00');
 
     values.maxRunTime = '';
-    const moreUpdatedValues = getFixedValuesForUpdatedQueue(
-      appFrontera,
-      values
-    );
+    const moreUpdatedValues = updateValuesForQueue(appFrontera, values);
     expect(moreUpdatedValues.maxRunTime).toEqual('');
   });
 });

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -108,3 +108,28 @@ describe('AppFormUtils', () => {
     /* shouldn't change for rtx or rtx-dev queues as maxProcessorsPerNode is -1  */
     expect(updatedValues.processorsOnEachNode).toEqual(2);
   });
+
+  it('getFixedValuesForUpdatedQueue fixes maxRunTime', () => {
+    const appFrontera = cloneDeep(namdAppFixture);
+    const values = cloneDeep(namdDefaultFormValues);
+    values.batchQueue = 'development';
+    values.maxRunTime = '48:00:00';
+    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    expect(updatedValues.maxRunTime).toEqual('02:00:00');
+  });
+
+  it('getFixedValuesForUpdatedQueue avoids fixing runtime if not valid or empty', () => {
+    const appFrontera = cloneDeep(namdAppFixture);
+    const values = cloneDeep(namdDefaultFormValues);
+    values.maxRunTime = '99:00:00';
+    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    expect(updatedValues.maxRunTime).toEqual('99:00:00');
+
+    values.maxRunTime = '';
+    const moreUpdatedValues = getFixedValuesForUpdatedQueue(
+      appFrontera,
+      values
+    );
+    expect(moreUpdatedValues.maxRunTime).toEqual('');
+  });
+});

--- a/client/src/components/Applications/AppForm/AppFormUtils.test.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.test.js
@@ -88,4 +88,14 @@ describe('AppFormUtils', () => {
     const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
     expect(updatedValues.nodeCount).toEqual(3);
   });
+
+  it('getFixedValuesForUpdatedQueue properly fixes processorsOnEachNode when using dev queue', () => {
+    const appFrontera = cloneDeep(namdAppFixture);
+    const values = cloneDeep(namdDefaultFormValues);
+    values.batchQueue = 'development';
+    values.processorsOnEachNode = 64;
+    const updatedValues = getFixedValuesForUpdatedQueue(appFrontera, values);
+    /* should to be 56 (i.e. 2240/40) on development queue */
+    expect(updatedValues.processorsOnEachNode).toEqual(56);
+  });
 });

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
@@ -583,3 +583,24 @@ export const namdAppMissingKeysFixture = {
     absolutePath: null,
   },
 };
+
+export const namdDefaultFormValues = {
+  inputs: {
+    inputDirectory: '',
+  },
+  parameters: {
+    confFile: '',
+    namdCommandLineOptions:
+      '+ppn 13 +pemap 2-26:2,30-54:2,3-27:2,31-55:2 +commap 0,28,1,29',
+  },
+  name: 'namd-frontera-2.1.3u2_2022-05-11T02:03:16',
+  batchQueue: 'normal',
+  nodeCount: 1,
+  processorsOnEachNode: 1,
+  maxRunTime: '',
+  archivePath: '',
+  archive: true,
+  archiveOnAppError: true,
+  appId: 'namd-frontera-2.1.3u2',
+  allocation: 'TACC-ACI',
+};


### PR DESCRIPTION
## Overview: ##

In [FP-1628](https://jira.tacc.utexas.edu/browse/FP-1628), it was noted that we do not update some values when switching queues and that it would be helpful to update them.  This pr refactors things so that when a queue changes, we potentially alter the values of `nodeCount`, `maxRunTime`, and `processorsOnEachNode` to match the constraints of the new queue.

## Related Jira tickets: ##

* [FP-1628](https://jira.tacc.utexas.edu/browse/FP-1628)

## Summary of Changes: ##

## Testing Steps: ##
1. Setup testing app locally:  Add an entry for (`matlab-frontera-9.9u4`) in https://cep.dev/core/admin/workspace/apptrayentry/.  **Note**:  frontera jupyter hub app could also be useful to test but its is SERIAL so the matlab frontera app is a good one to use for testing.
2. Setup testing app locally:   Add Matlab license for yourself: https://cep.dev/core/admin/portal_licenses/matlablicense/.   Any random text will do.
3. Switch between `normal` and `small` queue and note node count change.
4. Switch between `normal` and `nvdim` queue and note processors-on-each-node changes (i.e. nvdimm->28 and normal->56)
5. Switch between `normal` and `rtx` queue and note processors-on-each-node shouldn't change
6. Set time of job to be 48 hours in `normal` queue and then switch to `dev` where max is 2 hrs

## UI Photos:

None

## Notes: ##
- [x] add a ticket for sidebar issue regarding prop type. (https://jira.tacc.utexas.edu/browse/FP-1649)
- [x] ~add a ticket for systems error when going directly to the app~. (I can't create this today so avoiding the ticket but felt I saw this multiple times. 
- [x] Determine if we want to also update max run time (if they entered a value) and processors on each node (@rstijerina , @duckonomy )