### PR TITLE
fix(FP-1670): button text overflow (workspaces)

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.module.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/tools/mixins.scss';
+
 .root {
   display: block;
   margin-bottom: 1em;
@@ -77,6 +79,8 @@
 }
 
 .ownership-button {
+  @include truncate-with-ellipsis;
+
   height: 18.88px;
   border-radius: 0;
   background-color: #f4f4f4;


### PR DESCRIPTION
## Overview: ##

Fix gnarly text overflow on narrow screen for Shared Workspaces modal.

## Related Jira tickets: ##

* [FP-1670](https://jira.tacc.utexas.edu/browse/FP-1670)

## Summary of Changes: ##

* Use SASS mixin.﹡

<sub>﹡ I try to steer us away from SASS, but this makes instances easier to find, thus quicker to replace. Replacements of these instances begins in https://github.com/TACC/Core-Portal/pull/639.</sub>

## Testing Steps: ##
1. Have a shared workspace with members you can manage.
2. Open that workspace.
3. Click "Change Ownership" button (looks like link).
4. Make window size narrow.

For details, see J.R.'s description in https://github.com/TACC/Core-Portal/pull/597#discussion_r877526170.

## UI Photos:

None. I do not have a workspace with members I can manage. I do not know how to create one.[^1]

[^1]: This is a courtesy PR. I don't have bandwidth to learn how to reproduce the bug.

## Notes: ##

Inspired by https://github.com/TACC/Core-Portal/pull/597#discussion_r870662354.