### PR TITLE
Task/FP-1635: 737 - Implement final Allocations UI - Organize MUI CSS

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -11,7 +11,6 @@ import AllocationsContactCard from './AllocationsContactCard';
 import { UserSearchbar } from '_common';
 import styles from './AllocationsTeamViewModal.module.scss';
 import manageStyles from '../AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss';
-import '../AllocationsModalTabs.css';
 
 const AllocationsTeamViewModal = ({
   isOpen,
@@ -86,22 +85,10 @@ const AllocationsTeamViewModal = ({
       size="lg"
       onClosed={resetCard}
     >
-      <ModalHeader className="tab-row" toggle={toggle} charCode="&#xe912;">
-        <Tabs
-          value={selectedTab}
-          onChange={handleTabChange}
-          TabIndicatorProps={{ style: { backgroundColor: 'white' } }}
-        >
-          <Tab
-            label="View Team"
-            className={`tab ${selectedTab === 0 ? 'active' : 'inactive'}`}
-          />
-          {isManager && (
-            <Tab
-              label="Manage Team"
-              className={`tab ${selectedTab === 1 ? 'active' : 'inactive'}`}
-            />
-          )}
+      <ModalHeader className="has-MuiTabs" toggle={toggle} charCode="&#xe912;">
+        <Tabs value={selectedTab} onChange={handleTabChange}>
+          <Tab label="View Team" />
+          {isManager && <Tab label="Manage Team" />}
         </Tabs>
       </ModalHeader>
       <ModalBody className={selectedTab === 0 ? 'd-flex p-0' : 'p-2'}>

--- a/client/src/styles/components/bootstrap.modal.css
+++ b/client/src/styles/components/bootstrap.modal.css
@@ -61,3 +61,14 @@ Styleguide Components.Bootstrap.Modal
   font-size: 1.5rem; /* bigger to match header text font height (like design) */
   font-family: Cortal-Icons !important;
 }
+
+.modal-header.has-MuiTabs {
+  flex-direction: row;
+  position: relative;
+  height: 63.5px;
+  border-bottom: 1px solid #afafaf;
+  padding: 5px;
+}
+.modal-header.has-MuiTabs .close {
+  transform: translate(-25%, 25%);
+}

--- a/client/src/styles/components/mui.tabs.css
+++ b/client/src/styles/components/mui.tabs.css
@@ -1,14 +1,4 @@
-.tab-row.modal-header {
-  flex-direction: row;
-  position: relative;
-  height: 63.5px;
-  border-bottom: 1px solid #afafaf;
-  padding: 5px;
-}
-.tab-row.modal-header .close {
-  transform: translate(-25%, 25%);
-}
-.tab {
+.MuiTab-root {
   font-size: 19px;
   text-align: center;
   opacity: 1;
@@ -18,7 +8,7 @@
   height: 60.5px;
 }
 
-.tab.active {
+.MuiTab-root.Mui-selected {
   background: #ffffff 0% 0% no-repeat padding-box;
   border: 1px solid #afafaf;
   border-bottom: none;
@@ -26,7 +16,7 @@
   text-transform: none;
   outline: none;
 }
-.tab.inactive {
+.MuiTab-root:not(.Mui-selected) {
   background: #f4f4f4 0% 0% no-repeat padding-box;
   color: black;
   border: none;
@@ -34,7 +24,11 @@
   text-transform: none;
   height: 58.5px;
 }
-.tab.inactive:hover {
+.MuiTab-root:not(.Mui-selected):hover {
   background: #dbdbdb 0% 0% no-repeat padding-box;
   border: 1px solid #afafaf;
+}
+
+.modal-header.has-MuiTabs .MuiTabs-indicator {
+  background-color: white;
 }

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -27,6 +27,7 @@
 @import url('./components/bootstrap.form.css');
 @import url('./components/bootstrap.modal.css');
 @import url('./components/bootstrap.button.css');
+@import url('./components/mui.tabs.css');
 
 /* TRUMPS */
 /* NOTE: For the most part, allow React components to explicitely import as needed */


### PR DESCRIPTION
## Overview: ##

Make **all** Material UI Tabs styling global, and _clearly_ so (so they can be reused without copying).

<details>

Re-use of code, in the past, for this project, has not been DRY. The solution to create components has been realized too slowly. So, if third-party components have global styles, let's _clearly_ apply our overrides globally. This makes re-use automatic.

</details>

## Related Jira tickets: ##

* [FP-1635](https://jira.tacc.utexas.edu/browse/FP-1635)
* intended for https://github.com/TACC/Core-Portal/pull/636

## Summary of Changes: ##

Move __all__ allocations component styles to global styles.

## Testing Steps: ##
1. Review tabs UI from https://github.com/TACC/Core-Portal/pull/636.
2. Confirm none of it has changed.

## UI Photos:

https://user-images.githubusercontent.com/62723358/170576114-dd25ea16-e5a3-4703-a84d-99c23bd79f37.mov