### PR TITLE
Bug: Allocations Table Cell Content Alignment

### DIFF
--- a/client/src/components/Allocations/Allocations.scss
+++ b/client/src/components/Allocations/Allocations.scss
@@ -106,6 +106,11 @@
     font-size: 0.875rem; /* 14px (approved deviation from design) */
   }
 }
+/* Selector is long so it is specific enough to override without !important */
+/* NOTE: The length of selector helps devs find the source of the overwrite */
+.allocations-table.InfiniteScrollTable tbody tr:not(.-status) td {
+  vertical-align: top;
+}
 
 /* HACK: The loading icon should not need height set, but it fixes Safari here */
 /* FP-426: Do not use `height: 100%` or isolate usage pending solution to bigger problem */


### PR DESCRIPTION
## Overview: ##

The alignment in [the design](https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/209a0ee5-8add-4931-955e-e33f20bdc9e5/specs/) is top, not middle.

## Related Jira tickets: ##

* [FP-1635](https://jira.tacc.utexas.edu/browse/FP-1635), maybe[^1]

[^1]: I don't know if the related UI ticket [FP-1594](https://jira.tacc.utexas.edu/browse/FP-1594) introduced this as a change, or if its a long-standing bug.

## Summary of Changes: ##

- add vertical alignment to table cell with super specific selector[^2]

[^2] Super specific selector because we avoid reactive `!important` __and__ Allocations and InfiniteScrollTable CSS is not optimized.

## Testing Steps: ##
1. Load allocations table.
2. Verify table content is vertically aligned to top of each cell.

## UI Photos:

![Screen Shot 2022-05-26 at 17 12 30](https://user-images.githubusercontent.com/62723358/170588390-9afb2d73-71a1-4223-8f85-305de3507c02.png)
