### PR TITLE
Task/FP-1635: 737 - Implement final Allocations UI - Remove Unused CSS

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss
@@ -1,30 +1,9 @@
-.root {
-  max-width: 700px;
-  .modal-body {
-    overflow-y: initial !important;
-  }
-  .update-button {
-    display: flex;
-    width: fit-content;
-    border-radius: 0;
-    font: bold 12px Roboto, sans-serif;
-    padding: 0.5rem 1rem;
-    border: 0 !important; /* override `.workbench-content .btn-secondary` */
-    background-color: #9d85ef !important; /* override `.workbench-content .btn-secondary` */
-    color: white !important; /* override `.workbench-content .btn-secondary` */
-  }
-}
 .listing-wrapper {
   height: 31.125vh;
   overflow-y: scroll;
   padding-left: 0;
   padding-right: 0;
   border-right: 1px solid rgb(112 112 112 / 25%);
-}
-.information-wrapper {
-  display: flex;
-  padding: 1em;
-  overflow: auto;
 }
 .manage-team-table {
   overflow-x: hidden;

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -81,7 +81,6 @@ const AllocationsTeamViewModal = ({
     <Modal
       isOpen={isOpen}
       toggle={toggle}
-      className={styles.root}
       size="lg"
       onClosed={resetCard}
     >

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.module.scss
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.module.scss
@@ -1,8 +1,3 @@
-.root {
-  .modal-body {
-    overflow-y: initial !important;
-  }
-}
 .listing-wrapper {
   height: 50vh;
   max-width: 230px;


### PR DESCRIPTION
## Overview: ##

Remove unused CSS (so I can fix inaccuracies of Allocations Modal UI without being confused).

<details>

Some of this unused CSS may be from before FP-1635, but its distracting me from grok-ing and re-using styles on this complex modal.

</details>

## Related Jira tickets: ##

* [FP-1635](https://jira.tacc.utexas.edu/browse/FP-1635)
* intended for https://github.com/TACC/Core-Portal/pull/636

## Summary of Changes: ##

Remove unused CSS.

## Testing Steps: ##

1. Review tabs UI from https://github.com/TACC/Core-Portal/pull/636.
2. Confirm none of it has changed.

## UI Photos:

https://user-images.githubusercontent.com/62723358/170734862-091c5d45-ba5d-4e0a-8aea-3edb2c92123c.mov

https://user-images.githubusercontent.com/62723358/170734872-2ea13107-ce66-41ae-8c30-489acc1ac7e1.mov