### PR TITLE
FP-1647: Use Core-Styles via NPM Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/Introdu
 3. Make changes in your [Core Styles] clone as necessary.
 4. Test changes.
     - Changes to imported files during `npm run dev` will trigger livereload.
+5. Commit successful changes to a [Core Styles] branch.
 
-- _Note: If you run `npm install` or `npm ci`, the link is destroyed. Repeat these steps to restore it._
+- _Note: [If you run `npm install` or `npm ci`, the link is destroyed.](https://github.com/npm/cli/issues/2380#issuecomment-1029967927) Repeat the above steps to restore it._
 
 #### Best Practices
 Sign your commits ([see this link](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) for help)

--- a/README.md
+++ b/README.md
@@ -279,16 +279,9 @@ If you need to test file changes with [Core CMS] changes:
 
     _**Do** use `--save`.\* Do **not** commit the changes to `package.json` **nor** `package-lock.json`._
 
-3. Re-install [Core Styles] dependency `postcss-cli`:
-
-    ```bash
-    # cd path-to-Core-Portal/client
-    npm install postcss-cli --no-save
-    ```
-
-4. Make changes in your [Core Styles] clone as necessary.
-5. Test changes.
-6. Undo changes to `package.json` and `package-lock.json`.
+3. Make changes in your [Core Styles] clone as necessary.
+4. Test changes.
+5. Undo changes to `package.json` and `package-lock.json`.
     - _Warning: Do __not__ commit `npm link`'s automatic changes to `package.json` and `package-lock.json`!_
 
 - _Note: If you run `npm install` or `npm ci`, the live-edit link is destroyed. Repeat these steps to restore it._

--- a/README.md
+++ b/README.md
@@ -245,6 +245,68 @@ We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/Introdu
     - `bug/` for bugfixes
     - `fix/` for hotfixes
 
+#### Changing Core Styles
+
+If you need to change files within `node_modules/@tacc/core-styles/source`:
+
+1. Clone [Core Styles].
+2. Make and commit changes.
+3. Open pull request.
+4. After PR is merged.
+5. In [Core CMS], update [Core Styles] module commit:
+
+  ```bash
+  cd client
+  npm install git+https://git@github.com/TACC/Core-Styles.git
+  ```
+
+6. Commit changes.
+
+#### Testing Core Styles Changes Locally
+
+If you need to test file changes with [Core CMS] changes:
+
+1. Clone [Core Styles].
+2. Allow live edit of node module via your [Core Styles] clone:
+
+    ```bash
+    cd path-to-Core-Styles
+    npm link
+    cd path-to-Core-Portal/client
+    npm link @tacc/core-styles --save
+    ```
+
+    _**Do** use `--save`.\* Do **not** commit the changes to `package.json` **nor** `package-lock.json`._
+
+3. Re-install [Core Styles] dependency `postcss-cli`:
+
+    ```bash
+    # cd path-to-Core-Portal/client
+    npm install postcss-cli --no-save
+    ```
+
+4. Make changes in your [Core Styles] clone as necessary.
+5. Test changes.
+6. Do __not__ commit `npm link`'s automatic changes to `package.json` and `package-lock.json`!
+
+<sub>\* Use of `npm link` _without `--save`_ is overwritten by `npm install`. See [details](https://github.com/npm/cli/issues/2380#issuecomment-1029967927).</sub>
+
+#### Testing Core Styles Changes Remotely
+
+If you need to test [Core CMS] and [Core Styles] changes on a server:
+
+1. Push changes onto a [Core Styles] branch (not `main`).
+2. Install [Core Styles] at that branch:
+
+    ```bash
+    # cd path-to-Core-CMS
+    npm install --save-dev git+https://git@github.com/TACC/Core-Styles.git#your-branch-name
+    ```
+
+3. Deploy changes to test server.\*
+
+<sub>\* See [Deployment Steps](#deployment-steps).</sub>
+
 #### Best Practices
 Sign your commits ([see this link](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) for help)
 

--- a/README.md
+++ b/README.md
@@ -245,61 +245,19 @@ We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/Introdu
     - `bug/` for bugfixes
     - `fix/` for hotfixes
 
-#### Changing Core Styles
-
-If you need to change files within `node_modules/@tacc/core-styles/source`:
-
-1. Clone [Core Styles].
-2. Make and commit changes.
-3. Open pull request.
-4. After PR is merged.
-5. In [Core CMS], update [Core Styles] module commit:
-
-  ```bash
-  cd client
-  npm install git+https://git@github.com/TACC/Core-Styles.git
-  ```
-
-6. Commit changes.
-
 #### Testing Core Styles Changes Locally
 
-If you need to test file changes with [Core CMS] changes:
-
-0. You should stash, commit, or revert any changes to `package.json` or `package-lock.json`.
-1. Clone [Core Styles].
-2. Allow live edit of node module via your [Core Styles] clone:
-
+1. Clone [Core Styles] (if you haven't already).
+2. Tell project to temporarily use your [Core Styles] clone:
     ```bash
-    cd path-to-Core-Styles
-    npm link
-    cd path-to-Core-Portal/client
-    npm link @tacc/core-styles
+    npm link path-to/Core-Styles # e.g. npm link ../../Core-Styles
     ```
 
 3. Make changes in your [Core Styles] clone as necessary.
 4. Test changes.
-5. Undo changes to `package.json` and `package-lock.json`.
+    - Changes to imported files during `npm run dev` will trigger livereload.
 
-- _Note: If you run `npm install` or `npm ci`, the live-edit link is destroyed. Repeat these steps to restore it._
-
-<sub>\* Use of `npm link` _without `--save`_ is overwritten by `npm install`. See [details](https://github.com/npm/cli/issues/2380#issuecomment-1029967927).</sub>
-
-#### Testing Core Styles Changes Remotely
-
-If you need to test [Core CMS] and [Core Styles] changes on a server:
-
-1. Push changes onto a [Core Styles] branch (not `main`).
-2. Install [Core Styles] at that branch:
-
-    ```bash
-    # cd path-to-Core-CMS
-    npm install --save-dev git+https://git@github.com/TACC/Core-Styles.git#your-branch-name
-    ```
-
-3. Deploy changes to test server.\*
-
-<sub>\* See [Deployment Steps](#deployment-steps).</sub>
+- _Note: If you run `npm install` or `npm ci`, the link is destroyed. Repeat these steps to restore it._
 
 #### Best Practices
 Sign your commits ([see this link](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) for help)

--- a/README.md
+++ b/README.md
@@ -274,15 +274,12 @@ If you need to test file changes with [Core CMS] changes:
     cd path-to-Core-Styles
     npm link
     cd path-to-Core-Portal/client
-    npm link @tacc/core-styles --save
+    npm link @tacc/core-styles
     ```
-
-    _**Do** use `--save`.\* Do **not** commit the changes to `package.json` **nor** `package-lock.json`._
 
 3. Make changes in your [Core Styles] clone as necessary.
 4. Test changes.
 5. Undo changes to `package.json` and `package-lock.json`.
-    - _Warning: Do __not__ commit `npm link`'s automatic changes to `package.json` and `package-lock.json`!_
 
 - _Note: If you run `npm install` or `npm ci`, the live-edit link is destroyed. Repeat these steps to restore it._
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you need to change files within `node_modules/@tacc/core-styles/source`:
 
 If you need to test file changes with [Core CMS] changes:
 
+0. You should stash, commit, or revert any changes to `package.json` or `package-lock.json`.
 1. Clone [Core Styles].
 2. Allow live edit of node module via your [Core Styles] clone:
 
@@ -287,7 +288,10 @@ If you need to test file changes with [Core CMS] changes:
 
 4. Make changes in your [Core Styles] clone as necessary.
 5. Test changes.
-6. Do __not__ commit `npm link`'s automatic changes to `package.json` and `package-lock.json`!
+6. Undo changes to `package.json` and `package-lock.json`.
+    - _Warning: Do __not__ commit `npm link`'s automatic changes to `package.json` and `package-lock.json`!_
+
+- _Note: If you run `npm install` or `npm ci`, the live-edit link is destroyed. Repeat these steps to restore it._
 
 <sub>\* Use of `npm link` _without `--save`_ is overwritten by `npm install`. See [details](https://github.com/npm/cli/issues/2380#issuecomment-1029967927).</sub>
 


### PR DESCRIPTION
## Overview: ##

Add instructions (to README) for using NPM link to live-edit Core-Styles.

## Related Jira tickets: ##

* [FP-1647](https://jira.tacc.utexas.edu/browse/FP-1647)
* builds off https://github.com/TACC/Core-Portal/pull/639

## Summary of Changes: ##

- add content to README

## Testing Steps: ##
0. Load local server with live reload (`npm run dev`).
1. Follow steps from README under "Testing Core Styles Changes Locally".
2. Find a Core-Styles stylesheet to test edit (e.g. one imported by `global.css`).
3. Open `source/_imports/settings/border.css`.
4. Change its `--global-border-width--normal` from `1px` to `10px`.
5. Save edit.
6. Watch server reload.

## UI Photos:

| 1. follow steps | 2. find stylesheet | 3. open stylesheet | 4. 5. 6. change → reload |
| - | - | - | - |
| <img width="1440" alt="FP-1647 npm link 1" src="https://user-images.githubusercontent.com/62723358/171503916-6bc559a9-c3ef-4c9d-81b3-d13d43a26f96.png"> | <img width="1440" alt="FP-1647 npm link 2" src="https://user-images.githubusercontent.com/62723358/171503924-2b0b4a16-217a-4625-8ef7-3cbf1db41d17.png"> | <img width="1440" alt="FP-1647 npm link 3" src="https://user-images.githubusercontent.com/62723358/171503931-667780e0-12e5-4844-ac65-561563824df5.png"> | <img width="1440" alt="FP-1647 npm link 4" src="https://user-images.githubusercontent.com/62723358/171503937-1ffb5071-7a00-422f-9a1c-7fb8c6d607e8.png"> |
