### PR TITLE
feat: install core-styles via npm

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -45,7 +45,7 @@
         "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
         "@rollup/plugin-eslint": "^8.0.1",
-        "@tacc/core-styles": "git+https://git@github.com/TACC/Core-Styles.git#v0.5.1",
+        "@tacc/core-styles": "^0.5.1",
         "@testing-library/jest-dom": "^5.0.2",
         "@testing-library/react": "^12.1.1",
         "@types/react": "^17.0.26",
@@ -3252,9 +3252,9 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.5.1",
-      "resolved": "git+https://git@github.com/TACC/Core-Styles.git#c7d9fec7560aea4266378958bd05dcf91d7c0ced",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.5.1.tgz",
+      "integrity": "sha512-RZNNfgzydXhsAtLANiKOEkLXYcI2saoKKawOscRdvn98y27of0yFOnLOsLroHJTUy/x5kaAduUr3/5tQPLQH6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -19512,9 +19512,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+https://git@github.com/TACC/Core-Styles.git#c7d9fec7560aea4266378958bd05dcf91d7c0ced",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.5.1.tgz",
+      "integrity": "sha512-RZNNfgzydXhsAtLANiKOEkLXYcI2saoKKawOscRdvn98y27of0yFOnLOsLroHJTUy/x5kaAduUr3/5tQPLQH6Q==",
       "dev": true,
-      "from": "@tacc/core-styles@git+https://git@github.com/TACC/Core-Styles.git#v0.5.1",
       "requires": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",

--- a/client/package.json
+++ b/client/package.json
@@ -67,7 +67,7 @@
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
     "@rollup/plugin-eslint": "^8.0.1",
-    "@tacc/core-styles": "git+https://git@github.com/TACC/Core-Styles.git#v0.5.1",
+    "@tacc/core-styles": "^0.5.1",
     "@testing-library/jest-dom": "^5.0.2",
     "@testing-library/react": "^12.1.1",
     "@types/react": "^17.0.26",


### PR DESCRIPTION
## Overview: ##

Install `@tacc/core-styles` from NPM.

## Related: ##

* [FP-1647](https://jira.tacc.utexas.edu/browse/FP-1647)
* based off https://github.com/TACC/Core-Portal/pull/651

## Summary of Changes: ##

- re-install (core-styles) same version, but via npm)

## Testing Steps: ##

Nope.

## UI Photos:

Nope.