### PR TITLE
fix(fp-737): make ui closer to design

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Table, Button } from 'reactstrap';
+import { Table } from 'reactstrap';
+import { Button } from '_common';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTable } from 'react-table';
 import { LoadingSpinner, Message, DropdownSelector } from '_common';
@@ -83,7 +84,7 @@ const AllocationsManageTeamTable = ({ rawData, projectId }) => {
               {deleteOperationOccuring && <LoadingSpinner placement="inline" />}
               {removable && (
                 <Button
-                  color="link"
+                  type="link"
                   disabled={removingUserOperation.loading}
                   onClick={(e) => {
                     dispatch({
@@ -115,7 +116,7 @@ const AllocationsManageTeamTable = ({ rawData, projectId }) => {
       hover
       borderless
       size="sm"
-      className={styles['manage-team-table']}
+      className={`${styles['manage-team-table']} o-fixed-header-table`}
       {...getTableProps()}
     >
       <thead>

--- a/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss
@@ -6,36 +6,57 @@
   padding-right: 0;
 }
 .manage-team-table {
-  font-size: 0.875rem;
-  line-height: 2rem;
-  margin: 0 1rem;
-  thead {
-    border-bottom: 1px solid black;
-  }
+  font-size: 12px; /* 10px design * 1.2 design-to-app ratio */
+  margin-bottom: 0; /* overwrite bootstrap */
+  border-collapse: separate; /* keep <th> border-bottom visible on scroll */
+  border-spacing: 0;
+
   td,
   th {
-    padding: 0;
+    padding: 6px 15px;
     vertical-align: middle;
   }
   th {
     font-weight: bold;
+    background-color: var(--global-color-primary--xx-light);
   }
-  td {
-    padding: 0.25rem;
-    font-weight: normal;
+  thead th /* specificity overwrites bootstrap */ {
+    border-bottom: 1px solid var(--global-color-primary--dark);
   }
   tr:nth-child(even) td {
-    background-color: rgb(112 112 112 / 15%);
+    background-color: var(--global-color-primary--x-light);
+  }
+  /* action */
+  tr > *:nth-child(3) {
+    text-align: right;
+    padding-right: 40px;
+
+    button {
+      position: static; /* overwrite <Button> */
+    }
   }
 }
-.search-bar-wrapper {
-  margin: 0 1rem;
+/* wide screen */
+@media (--medium-and-below) {
+  .manage-team-table {
+    /* member */
+    tr > *:nth-child(1) {
+      width: 60%;
+    }
+    /* role */
+    tr > *:nth-child(2) {
+      width: 15%;
+    }
+    /* action */
+    tr > *:nth-child(3) {
+      width: 20%;
+    }
+  }
 }
 .search-bar-header-text {
   font-size: 13px;
 }
 .help-text {
-  font-size: 12px;
-  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
   display: block;
 }

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -90,7 +90,7 @@ const AllocationsTeamViewModal = ({
           {isManager && <Tab label="Manage Team" />}
         </Tabs>
       </ModalHeader>
-      <ModalBody className={selectedTab === 0 ? 'd-flex p-0' : 'p-2'}>
+      <ModalBody className={selectedTab === 0 && 'd-flex p-0'}>
         {selectedTab === 0 && (
           <Container>
             {error ? (
@@ -137,9 +137,9 @@ const AllocationsTeamViewModal = ({
                 searchResults={search.results}
                 placeholder=""
               />
-              <i className={manageStyles['help-text']}>
+              <small className={manageStyles['help-text']}>
                 Search by entering the full username, email, or last name.
-              </i>
+              </small>
             </div>
             <div className={manageStyles['listing-wrapper']}>
               {error ? (
@@ -157,9 +157,9 @@ const AllocationsTeamViewModal = ({
                 />
               )}
             </div>
-            <i className={manageStyles['help-text']}>
+            <small className={manageStyles['help-text']}>
               The PI, Co-PIs, and Allocation Managers can manage the team.
-            </i>
+            </small>
           </>
         )}
       </ModalBody>


### PR DESCRIPTION
## Overview: ##

Make the manage team modal better match the [design].

## Related Jira tickets: ##

* [FP-1635](https://jira.tacc.utexas.edu/browse/FP-1635)
* intended for https://github.com/TACC/Core-Portal/pull/636 or `main`

## Summary of Changes: ##

- use common <Button>
- keep table header still when scrolling
- only show scrollbar if necessary
- change spacing and font size
- avoid table overflow

## Testing Steps: ##

1. Verify Manage Team modal table only has scrollbar when necessary (delete `<tr>`'s to test).
2. Verify Manage Team modal table never has horizontal overflow (no matter how narrow the window).
3. Verify Manage Team modal content looks closer to [design] than before (spacing, colors, font size).
4. Verify View Team modal and Allocations section are unchanged.

## UI Photos:

| 992px | 991px |
| - | - |
| ![992px](https://user-images.githubusercontent.com/62723358/171767378-e57aabf9-b310-4d0b-864a-b266c682adbb.png) | ![991px](https://user-images.githubusercontent.com/62723358/171767380-a3c32e1a-c6c3-4d11-a432-5496a53cf818.png) |

[design]: https://xd.adobe.com/view/db2660cc-1011-4f26-5d31-019ce87c1fe8-ad17/screen/82d25240-6e20-491e-9f90-f7c9d534965a/specs/