### PR TITLE
fix(fp-737): remove bkgd color from disabled link

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss
@@ -34,12 +34,6 @@
   }
   tr:nth-child(even) td {
     background-color: var(--global-color-primary--x-light);
-
-    button:disabled {
-      background-color: var(
-        --global-color-primary--x-light
-      ); /* button's disabled state background will match row background color */
-    }
   }
 }
 /* wide screen */

--- a/client/src/components/UIPatterns/UIPatternsButton/UIPatternsButton.jsx
+++ b/client/src/components/UIPatterns/UIPatternsButton/UIPatternsButton.jsx
@@ -177,6 +177,7 @@ function UIPatternsButton() {
       </dd>
       <dd>
         <Button type="link">Link</Button>
+        <Button type="link" disabled>Disabled</Button>
         <p>
           <small>To “clear” or “cancel” a UI state.</small>
         </p>

--- a/client/src/components/UIPatterns/UIPatternsButton/UIPatternsButton.jsx
+++ b/client/src/components/UIPatterns/UIPatternsButton/UIPatternsButton.jsx
@@ -177,7 +177,9 @@ function UIPatternsButton() {
       </dd>
       <dd>
         <Button type="link">Link</Button>
-        <Button type="link" disabled>Disabled</Button>
+        <Button type="link" disabled>
+          Disabled
+        </Button>
         <p>
           <small>To “clear” or “cancel” a UI state.</small>
         </p>

--- a/client/src/styles/components/c-button--new.css
+++ b/client/src/styles/components/c-button--new.css
@@ -75,10 +75,12 @@ Styleguide Components.Button
 }
 .c-button:disabled:not(.c-button--is-busy) {
   color: var(--global-color-primary--dark);
-  background-color: var(--global-color-primary--xx-light);
   border-color: var(--global-color-primary--dark);
 
   pointer-events: none;
+}
+.c-button:disabled:not(.c-button--is-busy, .c-button--as-link) {
+  background-color: var(--global-color-primary--xx-light);
 }
 
 /* MODIFIERS */


### PR DESCRIPTION
## Overview

Fix disabled link erroneous background everywhere, not just allocations.

## Related

* [FP-737](https://jira.tacc.utexas.edu/browse/FP-737)
* for https://github.com/TACC/Core-Portal/pull/568/
* mimicked by https://github.com/TACC/tup-ui/pull/11

## Changes

- remove fix from d60ff3e
- add disabled link to UI patterns
- fix in `c-buton--new.css` instead

## Testing

1. Load allocations.
2. Make a "Remove" link/button disabled.
    - I did this by adding `disabled` attribute to link/button.
4. Confirm the link/button does not have its own background.
    - The result will look the same, but Developer Tools CSS will show no allocations-specific CSS for this link/button background.

## UI

| UI Pattern | Alt. Button Fix |
| - | - |
| ![UI Pattern](https://user-images.githubusercontent.com/62723358/173941261-703f0818-2d3a-4b00-99b7-80699f78c774.png) | ![Bug Fixed](https://user-images.githubusercontent.com/62723358/173941260-20d9b138-cac3-4362-8454-0b1eeca51248.png) |