### PR TITLE
bug/FP-1702: CSS Load Order Differs on Dev vs Local

### DIFF
--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -17,6 +17,7 @@ import * as ROUTES from '../../constants/routes';
 import NotificationToast from '../Toasts';
 import OnboardingAdmin from '../Onboarding/OnboardingAdmin';
 import './Workbench.scss';
+import '../../index.css'
 
 function Workbench() {
   const { path } = useRouteMatch();

--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -17,7 +17,8 @@ import * as ROUTES from '../../constants/routes';
 import NotificationToast from '../Toasts';
 import OnboardingAdmin from '../Onboarding/OnboardingAdmin';
 import './Workbench.scss';
-import '../../index.css'
+// Core Styles needs to be imported last for Rollup to compile the CSS correctly.
+import '../../index.css';
 
 function Workbench() {
   const { path } = useRouteMatch();

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import LoadingSpinner from '_common/LoadingSpinner';
 import { QueryClient, QueryClientProvider } from 'react-query';
 const AppRouter = React.lazy(() => import('./components/Workbench'));
-import './index.css';
 import store from './redux/store';
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
## Overview
Fix a bug where Core Styles was clobbering Material UI and causing tabs to disappear in the Allocations area.

## Related

* [FP-1702](https://jira.tacc.utexas.edu/browse/FP-1702)

## Testing

1. Stop all running containers.
2. `npm ci && npm run build`
3. set `_DEBUG = False` in `settings_custom.py`
4. Tweak the nginx conf to prevent Django from trying to serve static files. In `server/conf/nginx/nginx.conf` line 83 should read:
> location ~ ^/(auth|workbench|tickets|googledrive-privacy-policy|public-data|accounts|api|login|webhooks|search) {
5. Restart all containers.
5. Shell into the Django container (`docker exec -it core_portal_django /bin/bash`) and run `python manage.py collectstatic`
6. Navigate to the the dev portal and check that the UI renders correctly. In your network tab, the index and vendor bundle hashes should match the ones in `client/dist/`: 
![image](https://user-images.githubusercontent.com/12601812/138536825-191b9050-cfc7-45e5-ae71-fca836ba5b46.png)

