### PR TITLE
bug/FP-1539: Fix Undesired `<Pill>` truncation

### DIFF
--- a/client/src/components/Onboarding/OnboardingStatus.jsx
+++ b/client/src/components/Onboarding/OnboardingStatus.jsx
@@ -43,7 +43,9 @@ const getContents = (step) => {
     case 'processing':
       return (
         <span className={styles.processing}>
-          <Pill shouldTruncate={false} type={type}>Processing</Pill>
+          <Pill shouldTruncate={false} type={type}>
+            Processing
+          </Pill>
           <LoadingSpinner
             placement="inline"
             className="onboarding-status__loading"

--- a/client/src/components/Onboarding/OnboardingStatus.jsx
+++ b/client/src/components/Onboarding/OnboardingStatus.jsx
@@ -43,7 +43,7 @@ const getContents = (step) => {
     case 'processing':
       return (
         <span className={styles.processing}>
-          <Pill type={type}>Processing</Pill>
+          <Pill shouldTruncate={false} type={type}>Processing</Pill>
           <LoadingSpinner
             placement="inline"
             className="onboarding-status__loading"


### PR DESCRIPTION
## Overview
Somewhere in the Vite build for production, styles are ordered differently causing the `Processing` pill to be truncated when a `<LoadingSpinner>` is present. This removes that possibility by setting `shouldTruncate={false}`.


## Related

* [FP-1539](https://jira.tacc.utexas.edu/browse/FP-1539)


## Testing

1. On line `9` of `client/src/components/Onboarding/OnboardingStatus.jsx`, add `step.state = 'processing';`
2. [Build vite for production](https://github.com/TACC/Core-Portal/wiki/Using-Vite-production-build-locally)
3. Go to https://cep.dev/workbench/onboarding/setup/ and confirm `Processing` is not truncated.

## UI

<img width="768" alt="Screen Shot 2022-06-24 at 2 44 46 PM" src="https://user-images.githubusercontent.com/20326896/175657000-88b6fe55-c6b4-4549-935f-750109937c9d.png">
