### PR TITLE
bug/FP-1694: Fix background icon in FileInputDropdownSelector

### DIFF
--- a/client/src/components/Onboarding/OnboardingStatus.jsx
+++ b/client/src/components/Onboarding/OnboardingStatus.jsx
@@ -43,7 +43,9 @@ const getContents = (step) => {
     case 'processing':
       return (
         <span className={styles.processing}>
-          <Pill type={type}>Processing</Pill>
+          <Pill shouldTruncate={false} type={type}>
+            Processing
+          </Pill>
           <LoadingSpinner
             placement="inline"
             className="onboarding-status__loading"

--- a/client/src/components/_common/Form/FileInputDropZone.jsx
+++ b/client/src/components/_common/Form/FileInputDropZone.jsx
@@ -54,7 +54,7 @@ function FileInputDropZone({
       <input {...getInputProps()} />
       {!showFileList && (
         <div className="no-attachment-view">
-          <i className="icon-upload" />
+          <i className="icon icon-upload" />
           <br />
           <Button outline onClick={open} className="select-files-button">
             Select File(s)

--- a/client/src/components/_common/Form/FileInputDropZone.scss
+++ b/client/src/components/_common/Form/FileInputDropZone.scss
@@ -11,6 +11,7 @@
   align-items: center;
 
   .icon.icon-upload {
+    /* This rule needs the additional '.icon' in order for it to be picked up first both in dev and prod (see Core-Portal PR #667)*/
     color: #70707026;
     display: flex;
     font-size: 12rem;

--- a/client/src/components/_common/Form/FileInputDropZone.scss
+++ b/client/src/components/_common/Form/FileInputDropZone.scss
@@ -10,7 +10,7 @@
   justify-content: center;
   align-items: center;
 
-  .icon-upload {
+  .icon.icon-upload {
     color: #70707026;
     display: flex;
     font-size: 12rem;

--- a/client/src/components/_common/Form/FileInputDropZone.scss
+++ b/client/src/components/_common/Form/FileInputDropZone.scss
@@ -11,7 +11,7 @@
   align-items: center;
 
   .icon.icon-upload {
-    /* This rule needs the additional '.icon' in order for it to be picked up first both in dev and prod (see Core-Portal PR #667)*/
+    /* This rule needs the additional '.icon' in order for it to be picked up first both in dev and prod (see Core-Portal PR #667) */
     color: #70707026;
     display: flex;
     font-size: 12rem;


### PR DESCRIPTION
## Overview

Upload icon in file drop zone too small in production environments.

## Related

* [FP-1694](https://jira.tacc.utexas.edu/browse/FP-1694)

## Changes
- Increased specificity of selector for this icon in this application to take precedence in both environments.


## Testing

1. [Build env for production](https://github.com/TACC/Core-Portal/wiki/Using-Vite-production-build-locally)
2. Open a ticket preview and confirm, in the file drop zone, that the upload icon takes up most of the space of the drop zone (see UI photos).
3. Confirm the same for the upload modal in Data Files.

## UI
<img width="808" alt="image" src="https://user-images.githubusercontent.com/43251554/176288476-197f76c0-60ee-4c68-b481-e40e577ea167.png">
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/43251554/176289292-588d9f75-26e8-4a36-abb9-fe1329da50b2.png">



## Notes

