### PR TITLE
docs(README): do not mention webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ OR
     docker-compose -f ./server/conf/docker/docker-compose-dev.all.debug.yml up
 
 
-#### Install client-side dependencies and bundle code with webpack:
+#### Install client-side dependencies and bundle code:
 
     cd client
     npm ci


### PR DESCRIPTION
## Overview

We don't use Webpack now, right? We use Vite. So, don't mention Webpack. Thoughts?

## Related

N/A

## Changes

- remove some words from Readme so we are not wrong now nor in the future

## Testing / UI

N/A