### PR TITLE
hotfix/FP-1715: Fix `fetchUtil`

### DIFF
--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -251,9 +251,8 @@ export function* getUsernamesManage(action) {
  */
 export const searchUsersUtil = async (term) => {
   const res = await fetchUtil({
-    url: '/api/users/tas-users',
+    url: '/api/users/tas-users/',
     params: { search: term },
-    init: { fetchParams: null },
   });
   const json = res.result;
   return json;

--- a/client/src/utils/fetchUtil.js
+++ b/client/src/utils/fetchUtil.js
@@ -22,10 +22,7 @@ export async function fetchUtil({ url, params, ...options }) {
     'X-CSRFToken': Cookies.get('csrftoken'),
     ...fetchParams.headers,
   };
-  const response = await fetch(request, {
-    fetchParams,
-    ...options.init,
-  });
+  const response = await fetch(request, fetchParams);
   const json = await response.json();
   if (!response.ok) {
     throw new FetchError(json, response);

--- a/client/src/utils/fetchUtil.test.js
+++ b/client/src/utils/fetchUtil.test.js
@@ -25,14 +25,12 @@ describe('fetchUtil', () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(req, {
-      fetchParams: {
-        body: JSON.stringify({}),
-        credentials: 'same-origin',
-        headers: {
-          'X-CSRFToken': Cookies.get('csrf'),
-        },
-        method: 'POST',
+      body: JSON.stringify({}),
+      credentials: 'same-origin',
+      headers: {
+        'X-CSRFToken': Cookies.get('csrf'),
       },
+      method: 'POST',
     });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(json).toEqual({ hello: 'world' });


### PR DESCRIPTION
## Overview

Fix malformed `fetch` parameters, resulting in only `GET` requests.

## Related

* [FP-1715](https://jira.tacc.utexas.edu/browse/FP-1715)

## Changes

- fixed `fetchUtil`
- removed bad params in `searchUsersUtil`


## Testing

1. Go to https://cep.dev/workbench/allocations/approved, click on a project you are a PI/Delegate of, and confirm you can search for and add users
2. Go to https://cep.dev/workbench/applications, submit a job, and confirm you see a `POST` request in the network tab from the client
