### PR TITLE
bug/FP-1696: Manage Team modal bugfixes

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
@@ -106,7 +106,7 @@ const DataFilesManageProjectModal = () => {
   return (
     <div className={styles.root}>
       <Modal
-        size="lg"
+        size="xl"
         isOpen={isOpen}
         toggle={toggle}
         className="dataFilesModal"
@@ -132,7 +132,7 @@ const DataFilesManageProjectModal = () => {
             </div>
           ) : null}
           <div className={styles['owner-controls']}>
-            {isOwner ? (
+            {isOwner && members.length > 1 ? (
               <Button color="link" onClick={toggleTransferMode}>
                 <h6 className={styles['ownership-toggle']}>
                   {transferMode

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
@@ -52,6 +52,9 @@ const DataFilesManageProjectModal = () => {
     [projectId, dispatch]
   );
 
+  const onOpen = () =>
+    dispatch({ type: 'PROJECTS_SET_MEMBER_RESET', payload: {} });
+
   const onRemove = useCallback(
     (removedUser) => {
       dispatch({
@@ -108,6 +111,7 @@ const DataFilesManageProjectModal = () => {
       <Modal
         size="xl"
         isOpen={isOpen}
+        onOpened={onOpen}
         toggle={toggle}
         className="dataFilesModal"
       >

--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.jsx
@@ -23,9 +23,10 @@ const DataFilesProjectMembers = ({
   const authenticatedUser = useSelector(
     (state) => state.authenticatedUser.user.username
   );
-  const { query: authenticatedUserQuery } = !projectId
-    ? {}
-    : useSystemRole(projectId, authenticatedUser);
+  const { query: authenticatedUserQuery } = useSystemRole(
+    projectId ?? null,
+    authenticatedUser ?? null
+  );
 
   const [selectedUser, setSelectedUser] = useState('');
 
@@ -144,7 +145,9 @@ const DataFilesProjectMembers = ({
       className: 'project-members__cell',
       Cell: (el) => (
         <>
-          {mode === 'addremove' && el.row.original.access !== 'owner' ? (
+          {mode === 'addremove' &&
+          el.row.original.access !== 'owner' &&
+          ['OWNER', 'ADMIN'].includes(authenticatedUserQuery?.data?.role) ? (
             <Button
               onClick={(e) => onRemove(el.row.original)}
               color="link"
@@ -211,51 +214,56 @@ const DataFilesProjectMembers = ({
 
   return (
     <div className={styles.root}>
-      <Label className="form-field__label" size="sm">
-        Add Member
-      </Label>
-      <div className={styles['user-search']}>
-        <div className={`input-group ${styles['member-search-group']}`}>
-          <div className="input-group-prepend">
-            <Button
-              className={styles['add-button member-search']}
-              onClick={() =>
-                onAddCallback({ user: selectedUser, access: 'edit' })
-              }
-              disabled={
-                !selectedUser ||
-                loading ||
-                alreadyMember(selectedUser) ||
-                mode === 'transfer'
-              }
-            >
-              Add
-            </Button>
+      {['OWNER', 'ADMIN'].includes(authenticatedUserQuery?.data?.role) && (
+        <>
+          <Label className="form-field__label" size="sm">
+            Add Member
+          </Label>
+
+          <div className={styles['user-search']}>
+            <div className={`input-group ${styles['member-search-group']}`}>
+              <div className="input-group-prepend">
+                <Button
+                  className={styles['add-button member-search']}
+                  onClick={() =>
+                    onAddCallback({ user: selectedUser, access: 'edit' })
+                  }
+                  disabled={
+                    !selectedUser ||
+                    loading ||
+                    alreadyMember(selectedUser) ||
+                    mode === 'transfer'
+                  }
+                >
+                  Add
+                </Button>
+              </div>
+              <Input
+                list="user-search-list"
+                type="text"
+                onChange={(e) => userSearch(e)}
+                placeholder="Search by name"
+                className={styles['member-search']}
+                disabled={loading || mode === 'transfer'}
+                autoComplete="false"
+                value={inputUser}
+              />
+              <datalist id="user-search-list">
+                {
+                  /* eslint-disable */
+                  // Need to replace this component with a generalized solution from FP-743
+                  userSearchResults
+                    .filter((user) => !alreadyMember(user))
+                    .map((user) => (
+                      <option value={formatUser(user)} key={user.username} />
+                    ))
+                  /* eslint-enable */
+                }
+              </datalist>
+            </div>
           </div>
-          <Input
-            list="user-search-list"
-            type="text"
-            onChange={(e) => userSearch(e)}
-            placeholder="Search by name"
-            className={styles['member-search']}
-            disabled={loading || mode === 'transfer'}
-            autoComplete="false"
-            value={inputUser}
-          />
-          <datalist id="user-search-list">
-            {
-              /* eslint-disable */
-              // Need to replace this component with a generalized solution from FP-743
-              userSearchResults
-                .filter((user) => !alreadyMember(user))
-                .map((user) => (
-                  <option value={formatUser(user)} key={user.username} />
-                ))
-              /* eslint-enable */
-            }
-          </datalist>
-        </div>
-      </div>
+        </>
+      )}
       <InfiniteScrollTable
         tableColumns={isTransferring ? transferColumns : columns}
         tableData={existingMembers}

--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.module.scss
@@ -38,12 +38,12 @@
   /* title */
   th:nth-child(1),
   td:nth-child(1) {
-    width: 60%;
+    width: 50%;
   }
   /* owner */
   th:nth-child(2),
   td:nth-child(2) {
-    width: 20%;
+    width: 30%;
   } /* owner */
   th:nth-child(3),
   td:nth-child(3) {

--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
@@ -51,7 +51,7 @@ const SystemRoleSelector = ({ projectId, username }) => {
     OWNER: 'Owner',
     ADMIN: 'Administrator',
     USER: 'User (read/write)',
-    GUEST: 'Guest (read-only',
+    GUEST: 'Guest (read-only)',
   };
   const authenticatedUser = useSelector(
     (state) => state.authenticatedUser.user.username

--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
@@ -91,7 +91,7 @@ const SystemRoleSelector = ({ projectId, username }) => {
           <option value="ADMIN">Administrator</option>
         )}
         <option value="USER">User (read/write)</option>
-        <option value="GUEST">Guest (read-only)</option>
+        <option value="GUEST">Guest (read only)</option>
       </DropdownSelector>
       {data.role !== selectedRole && !isFetching && (
         <Button

--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
@@ -91,7 +91,7 @@ const SystemRoleSelector = ({ projectId, username }) => {
           <option value="ADMIN">Administrator</option>
         )}
         <option value="USER">User (read/write)</option>
-        <option value="GUEST">GUEST</option>
+        <option value="GUEST">Guest (read-only)</option>
       </DropdownSelector>
       {data.role !== selectedRole && !isFetching && (
         <Button

--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
@@ -9,6 +9,7 @@ import styles from '../DataFilesProjectMembers.module.scss';
 import LoadingSpinner from '_common/LoadingSpinner';
 
 const getSystemRole = async (projectId, username) => {
+  if (!projectId || !username) return {};
   const url = `/api/projects/${projectId}/system-role/${username}/`;
   const request = await fetch(url, {
     headers: { 'X-CSRFToken': Cookies.get('csrftoken') },
@@ -46,6 +47,12 @@ export const useSystemRole = (projectId, username) => {
 };
 
 const SystemRoleSelector = ({ projectId, username }) => {
+  const roleMap = {
+    OWNER: 'Owner',
+    ADMIN: 'Administrator',
+    USER: 'User (read/write)',
+    GUEST: 'Guest (read-only',
+  };
   const authenticatedUser = useSelector(
     (state) => state.authenticatedUser.user.username
   );
@@ -73,15 +80,17 @@ const SystemRoleSelector = ({ projectId, username }) => {
     username === authenticatedUser ||
     !['OWNER', 'ADMIN'].includes(currentUserRole)
   )
-    return <span>{data.role}</span>;
+    return <span>{roleMap[data.role]}</span>;
   return (
     <div style={{ display: 'inline-flex' }}>
       <DropdownSelector
         value={selectedRole}
         onChange={(e) => setSelectedRole(e.target.value)}
       >
-        {username !== authenticatedUser && <option value="ADMIN">ADMIN</option>}
-        <option value="USER">USER</option>
+        {username !== authenticatedUser && (
+          <option value="ADMIN">Administrator</option>
+        )}
+        <option value="USER">User (read/write)</option>
         <option value="GUEST">GUEST</option>
       </DropdownSelector>
       {data.role !== selectedRole && !isFetching && (

--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
@@ -51,7 +51,7 @@ const SystemRoleSelector = ({ projectId, username }) => {
     OWNER: 'Owner',
     ADMIN: 'Administrator',
     USER: 'User (read/write)',
-    GUEST: 'Guest (read-only)',
+    GUEST: 'Guest (read only)',
   };
   const authenticatedUser = useSelector(
     (state) => state.authenticatedUser.user.username

--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/_tests/SystemRoleSelector.test.js
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/_tests/SystemRoleSelector.test.js
@@ -26,7 +26,7 @@ describe('SystemRoleSelector', () => {
     );
     expect(await screen.findByTestId('loading-spinner')).toBeDefined();
     await waitFor(async () => {
-      const query = await screen.findByText('GUEST');
+      const query = await screen.findByText(/Guest/);
       expect(query).toBeDefined();
     });
   });

--- a/client/src/redux/reducers/projects.reducers.js
+++ b/client/src/redux/reducers/projects.reducers.js
@@ -186,6 +186,16 @@ export default function projects(state = initialState, action) {
           result: null,
         },
       };
+    case 'PROJECTS_SET_MEMBER_RESET':
+      return {
+        ...state,
+        operation: {
+          name: 'member',
+          loading: false,
+          error: null,
+          result: null,
+        },
+      };
     case 'PROJECTS_SET_TITLE_DESCRIPTION_STARTED':
       return {
         ...state,


### PR DESCRIPTION
## Overview
Bugfixes for Manage Team Modal


## Related

* [FP-1696](https://jira.tacc.utexas.edu/browse/FP-1696)

## Changes
- Reset the error state of the modal when it is opened.
- Lowercase role names and add explanations for USER/GUEST.
- Selector dropdown no longer cuts off role names.
- Disable adding/removing members for user/guest roles.
- Disable "Transfer Ownership" when there is no one to transfer to.

## UI
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/12601812/178043082-79fad56d-2f3f-45d8-926e-ac4389ff7a48.png">
Non-admin view:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/12601812/178043157-e4d379b6-2d52-496e-961a-60c7ea0c1a9d.png">




## Notes

