### PR TITLE
bug/FP-1722: Fix Shared Workspaces id and accept any amount of hyphens in `PORTAL_PROJECTS_ID_PREFIX`

### DIFF
--- a/server/portal/apps/projects/models/unit_test.py
+++ b/server/portal/apps/projects/models/unit_test.py
@@ -6,6 +6,7 @@
 
 from portal.apps.projects.models.metadata import ProjectMetadata
 from portal.apps.projects.models.base import Project
+from portal.apps.projects.models.utils import get_latest_project_storage
 from portal.libs.agave.models.systems.storage import StorageSystem
 import pytest
 
@@ -120,3 +121,20 @@ def test_project_change_project_role(agave_client, mock_owner, mock_project_save
     prj.change_project_role(mock_owner, 'co_pi', 'member')
     mock_remove.assert_called_with(mock_owner)
     mock_add.assert_called_with(mock_owner)
+
+
+def test_get_latest_project_storage(mock_owner, portal_project, agave_client, mock_project_save_signal, service_account, mocker):
+    sys = StorageSystem(agave_client, 'cep.test.SOME-PRJ-5678')
+    sys.last_modified = '1234'
+    sys.name = 'SOME-PRJ-5678'
+
+    mock_search = mocker.patch('portal.apps.projects.models.base.StorageSystem.search')
+    mock_search.return_value = [sys]
+
+    Project(
+        agave_client,
+        'SOME-PRJ-5678',
+        storage=sys
+    )
+    latest = get_latest_project_storage()
+    assert latest == 5678

--- a/server/portal/apps/projects/models/utils.py
+++ b/server/portal/apps/projects/models/utils.py
@@ -32,7 +32,7 @@ def get_latest_project_storage(max_project_id=None):
         )
         if '-' not in prj_id:
             continue
-        _, prj_id = prj_id.rsplit('-')
+        prj_id = prj_id.rsplit('-')[-1]
         prj_id = int(prj_id)
 
         if prj_id > latest and (max_project_id is None or prj_id < max_project_id):


### PR DESCRIPTION
## Overview
Fixes an issue where, for project ids with multiple hyphens, the `get_latest_project_storage` function will fail.


## Related

* [FP-1722](https://jira.tacc.utexas.edu/browse/FP-1722)

## Testing

1. Change `PORTAL_PROJECTS_ID_PREFIX` to `LOCAL-CEP`
2. Create a shared workspace, and note the ID number
3. In the `core_portal_django` container, run `./manage.py projects_id --update $ID`, replacing `$ID` with the ID from step 2
4. Create another shared workspace, and confirm that it properly handles the collision
