### PR TITLE
Task/fp 546  UI tweaks

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -649,7 +649,7 @@ export const AppSchemaForm = ({ app }) => {
                 </Button>
                 &nbsp;&nbsp;&nbsp;&nbsp;
                 <Button onClick={handleReset} type="link">
-                  <h6>Reset Fields to Defaults</h6>
+                  Reset Fields to Defaults
                 </Button>
               </FormGroup>
             </Form>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesManageProject.module.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesManageProject.module.scss
@@ -7,10 +7,6 @@
   margin-bottom: 1em;
 }
 
-.ownership-toggle {
-  font-size: 12px;
-}
-
 .error {
   margin-top: 1em;
 }

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
@@ -134,11 +134,9 @@ const DataFilesManageProjectModal = () => {
           <div className={styles['owner-controls']}>
             {isOwner ? (
               <Button type="link" onClick={toggleTransferMode}>
-                <h6 className={styles['ownership-toggle']}>
-                  {transferMode
-                    ? 'Cancel Change Ownership'
-                    : 'Change Ownership'}
-                </h6>
+                {transferMode
+                  ? 'Cancel Change Ownership'
+                  : 'Change Ownership'}
               </Button>
             ) : null}
           </div>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.jsx
@@ -134,9 +134,7 @@ const DataFilesManageProjectModal = () => {
           <div className={styles['owner-controls']}>
             {isOwner ? (
               <Button type="link" onClick={toggleTransferMode}>
-                {transferMode
-                  ? 'Cancel Change Ownership'
-                  : 'Change Ownership'}
+                {transferMode ? 'Cancel Change Ownership' : 'Change Ownership'}
               </Button>
             ) : null}
           </div>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.module.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.module.scss
@@ -16,10 +16,6 @@
   padding-top: 10px;
   padding-bottom: 10px;
 }
-.link button i {
-  /* margin needed on _common button icon to prevent cutoff */
-  margin-left: 0.5em;
-}
 .link-icon {
   --color: var(--global-color-accent--normal);
 }

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsSearchbar/DataFilesProjectsSearchbar.module.css
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsSearchbar/DataFilesProjectsSearchbar.module.css
@@ -41,9 +41,6 @@
 
 .input {
   composes: form-control from '../../../../styles/components/bootstrap.form.css';
-  height: calc(
-    1.5em + 0.75rem + 2.828px
-  ); /* used to match height of _common button standard height */
 }
 .output {
   /* … */

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.scss
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.scss
@@ -49,9 +49,6 @@
 
 .input {
   composes: form-control from '../../../styles/components/bootstrap.form.css';
-  height: calc(
-    1.5em + 0.75rem + 2.828px
-  ); /* used to match height of _common button standard height */
 }
 .output {
   /* … */

--- a/client/src/components/History/HistoryViews/JobHistoryModal.jsx
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.jsx
@@ -136,9 +136,8 @@ function JobHistoryContent({ jobDetails, jobDisplay, jobName, toggle }) {
 
   return (
     <>
-      <div className={styles['left-panel']}>
+      <div className={`${styles['left-panel']} ${styles['panel-content']}`}>
         <DescriptionList
-          className={styles['panel-content']}
           density="compact"
           data={{
             Output: !hideDataFiles && (
@@ -155,7 +154,6 @@ function JobHistoryContent({ jobDetails, jobDisplay, jobName, toggle }) {
           <Button
             type="primary"
             attr="submit"
-            size="large"
             className={styles['submit-button']}
             onClick={resubmitJob}
           >

--- a/client/src/components/History/HistoryViews/JobHistoryModal.jsx
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.jsx
@@ -152,16 +152,15 @@ function JobHistoryContent({ jobDetails, jobDisplay, jobName, toggle }) {
           }}
         />
         {isTerminalState && (
-          <div className={styles['submit-button-container']}>
-            <Button
-              type="primary"
-              attr="submit"
-              size="large"
-              onClick={resubmitJob}
-            >
-              Resubmit Job
-            </Button>
-          </div>
+          <Button
+            type="primary"
+            attr="submit"
+            size="large"
+            className={styles['submit-button']}
+            onClick={resubmitJob}
+          >
+            Resubmit Job
+          </Button>
         )}
       </div>
       <DescriptionList

--- a/client/src/components/History/HistoryViews/JobHistoryModal.module.scss
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.module.scss
@@ -44,8 +44,8 @@
   margin-bottom: 0; /* overwrite Bootstrap's `_code.scss` */
 }
 
-.submit-button-container {
-  width: 60%;
+.submit-button {
+  display: block;
   margin: auto;
 }
 

--- a/client/src/components/History/HistoryViews/JobHistoryModal.module.scss
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.module.scss
@@ -45,8 +45,10 @@
 }
 
 .submit-button {
+  --max-width: 100%; /* (temporarily) overwrite `.c-button--...` */
+
   display: block;
-  margin: auto;
+  width: 100%;
 }
 
 .left-panel {

--- a/client/src/components/Onboarding/OnboardingAdminSearchbar.module.scss
+++ b/client/src/components/Onboarding/OnboardingAdminSearchbar.module.scss
@@ -40,9 +40,6 @@
 
 .input {
   composes: form-control from '../../styles/components/bootstrap.form.css';
-  height: calc(
-    1.5em + 0.75rem + 2.828px
-  ); /* used to match height of _common button standard height */
 }
 .output {
   /* … */

--- a/client/src/components/_common/Button/Button.jsx
+++ b/client/src/components/_common/Button/Button.jsx
@@ -88,6 +88,7 @@ const Button = ({
         ${TYPE_MAP[type] ? styles[TYPE_MAP[type]] : ''}
         ${SIZE_MAP[size] ? styles[SIZE_MAP[size]] : ''}
         ${isLoading ? styles['loading'] : ''}
+        ${className}
       `}
       disabled={disabled || isLoading}
       type={attr}

--- a/client/src/components/_common/Button/Button.module.css
+++ b/client/src/components/_common/Button/Button.module.css
@@ -39,10 +39,10 @@
   composes: c-button__icon--after from '../../../styles/components/c-button--new.css';
 }
 /* To offer more space between icon and text (especially '-up' and '-down' */
-.icon--before:global([class*="icon-nav-"]) {
+.icon--before:global([class*='icon-nav-']) {
   margin-right: 0.75em;
 }
-.icon--after:global([class*="icon-nav-"]) {
+.icon--after:global([class*='icon-nav-']) {
   margin-left: 0.75em;
 }
 

--- a/client/src/components/_common/Button/Button.module.css
+++ b/client/src/components/_common/Button/Button.module.css
@@ -38,6 +38,13 @@
 .icon--after {
   composes: c-button__icon--after from '../../../styles/components/c-button--new.css';
 }
+/* To offer more space between icon and text (especially '-up' and '-down' */
+.icon--before:global([class*="icon-nav-"]) {
+  margin-right: 0.75em;
+}
+.icon--after:global([class*="icon-nav-"]) {
+  margin-left: 0.75em;
+}
 
 .loading {
   composes: c-button--is-busy from '../../../styles/components/c-button--new.css';

--- a/client/src/components/_common/TextCopyField/TextCopyField.jsx
+++ b/client/src/components/_common/TextCopyField/TextCopyField.jsx
@@ -40,7 +40,8 @@ const TextCopyField = ({ value, placeholder }) => {
             //style={{ '--transition-duration': `${transitionDuration}s` }}
             onClick={onCopy}
             disabled={isEmpty}
-            type="primary"
+            type="secondary"
+            size="medium"
             iconNameBefore={isCopied ? 'approved-reverse' : 'link'}
           >
             Copy

--- a/client/src/styles/components/bootstrap.form.css
+++ b/client/src/styles/components/bootstrap.form.css
@@ -20,3 +20,8 @@ textarea.form-control {
 .input-group-prepend {
   z-index: 1; /* so child button border is above sibling input border */
 }
+
+.form-control-sm {
+  /* To increase height jsut enough to match height of regular _common Button */
+  height: calc(1.5em + .5rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */
+}

--- a/client/src/styles/components/bootstrap.form.css
+++ b/client/src/styles/components/bootstrap.form.css
@@ -23,9 +23,9 @@ textarea.form-control {
 
 .form-control {
   /* To increase height jsut enough to match height of regular _common Button */
-  height: calc(1.5em + .75rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */
+  height: calc(1.5em + 0.75rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */
 }
 .form-control-sm {
   /* To increase height jsut enough to match height of regular _common Button */
-  height: calc(1.5em + .5rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */
+  height: calc(1.5em + 0.5rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */
 }

--- a/client/src/styles/components/bootstrap.form.css
+++ b/client/src/styles/components/bootstrap.form.css
@@ -21,6 +21,10 @@ textarea.form-control {
   z-index: 1; /* so child button border is above sibling input border */
 }
 
+.form-control {
+  /* To increase height jsut enough to match height of regular _common Button */
+  height: calc(1.5em + .75rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */
+}
 .form-control-sm {
   /* To increase height jsut enough to match height of regular _common Button */
   height: calc(1.5em + .5rem + 3px); /* 3px ← 2px from Bootstrap _forms.css */

--- a/client/src/styles/trumps/icon.css
+++ b/client/src/styles/trumps/icon.css
@@ -76,19 +76,28 @@
 [class*='icon-nav-'] {
   border: solid var(--color, var(--global-color-primary--xx-dark));
   border-width: 0 0.25em 0.25em 0;
-  font-size: 8px;
+  font-size: 8px; /* thus 1px = 0.125em */
   /* display: inline-block; */ /* let `.icon`'s `display: inline-flex;` do it */
   /* padding: var(--size); */ /* let `.icon`'s equal `width` & `height` do it */
 }
+/* To rotate icon each direction and move graphic to stay within icon box */
+/* NOTE: For '-up' and '-down':
+         - translate gave (sub-pixel) better horz. align than relative position
+         - relative position gave  easier vertical alignment
+         So 'left' and 'right' (for consistency) use translate for horz. move */
 .icon-nav-up {
-  transform: rotate(-135deg);
+  position: relative;
+  top: 2px;
+  transform: rotate(-135deg) translate(-1px, 1px);
 }
 .icon-nav-left {
-  transform: rotate(135deg);
+  transform: rotate(135deg) translate(-1px, -1px);
 }
 .icon-nav-down {
-  transform: rotate(45deg);
+  position: relative;
+  top: -2px;
+  transform: rotate(45deg) translate(1px, -1px);
 }
 .icon-nav-right {
-  transform: rotate(-45deg);
+  transform: rotate(-45deg) translate(-1px, -1px);
 }


### PR DESCRIPTION
## Overview

Small tweaks to #662. Can be cherry-picked, merged, or delayed.

<details><summary>✓ To Do</summary>

- [x] Test #662. — except onboarding.
- [x] Create PR for testing review.
- [x] Add all screenshots for #675.
- [x] Submit testing review of  #662.

</details>

<details><summary>… Next Up</summary>

- Test #662 — onboarding.
- (as needed) Create PR for testing review.
- Review orphaned styles in #662.
- (as time allows) Create PR for style-cleanup review.
- Submit orphaned styles review of #662.

</details>

## Related

* [FP-546](https://jira.tacc.utexas.edu/browse/FP-546)
* updates https://github.com/TACC/Core-Portal/pull/662

## Changes / Testing / UI

Each commit is an isolated change and has more detail in its full commit message.

| before 369beba | after 369beba |
| - | - |
| ![369beba before](https://user-images.githubusercontent.com/62723358/178860083-8a424f6d-de07-4381-bfc5-60feb83fff71.png) | ![369beba after](https://user-images.githubusercontent.com/62723358/178860084-bdbb4fd2-b3a4-4d6a-a80e-33e2ab70fa66.png) |
| small-size input field too short | |

| before db5ca14 | after db5ca14 |
| - | - |
| ![db5ca14 before](https://user-images.githubusercontent.com/62723358/178860138-1e150f3b-181b-4815-b4c4-925375f182a2.png) | ![db5ca14 after](https://user-images.githubusercontent.com/62723358/178860139-e29a867d-5266-4eb7-b99a-207f217d9a3a.png) |
| reset link/button text too large | |

| initially (i.e. pre-FP-546) | before 038ace6 | after 038ace6 |
| - | - | - | 
| ![038ace6 before FP-546](https://user-images.githubusercontent.com/62723358/178860182-0cebd3e3-d7eb-41e7-8876-745daa73b6ac.png) | ![038ace6 after FP-546, before tweak](https://user-images.githubusercontent.com/62723358/178860181-ca210e51-c274-475d-856c-525acc90db33.png) | ![038ace6 after tweak](https://user-images.githubusercontent.com/62723358/178860184-91025097-80a6-452c-9b8c-05204eacd317.png)
| regular-size input field too short | 1st row text position unchanged | 1st row text position down 1px[^1] |

| state | before 657f8b3 | after 657f8b3 |
| - | - | - |
| no link | ![657f8b3 before - no link](https://user-images.githubusercontent.com/62723358/178860316-84a14f77-5b3c-48e3-b27c-7285d029d138.png) | ![657f8b3 after - no link](https://user-images.githubusercontent.com/62723358/178860317-137866a7-6108-469b-a1fa-ee1513e61491.png) |
| has link | ![657f8b3 before - has link](https://user-images.githubusercontent.com/62723358/178860318-f18c76d8-4420-44da-b9b5-574ee9be5be9.png) | ![657f8b3 after - has link](https://user-images.githubusercontent.com/62723358/178860319-3c19b657-61d7-46db-a818-334c877dc849.png) |
| | copy button text truncated | copy button text legible |

| before 22bf0f7 | after 22bf0f7 |
| - | - |
| ![22bf0f7 before](https://user-images.githubusercontent.com/62723358/178860692-7088871d-e4f0-4ec3-91d8-0e1ee2c6f9ee.png) | ![22bf0f7 after](https://user-images.githubusercontent.com/62723358/178860695-e4482238-a9fa-442c-b0e4-9f414f364be4.png) |
| text different than link/buttons | |

| direction | before 5702ac6 | after 5702ac6 |
| - | - | - |
| left | ![5702ac6 before - left](https://user-images.githubusercontent.com/62723358/179067050-75d43a26-b8b8-46b9-9821-3e90caa048ea.png) | ![5702ac6 after - left](https://user-images.githubusercontent.com/62723358/179067051-575c613f-711d-49b7-96e6-1e0a4866512b.png) |
| right | ![5702ac6 before - right](https://user-images.githubusercontent.com/62723358/179067068-9cec769c-0d1d-47e4-a0f9-5f33a883eb42.png) | ![5702ac6 after - right](https://user-images.githubusercontent.com/62723358/179067070-0dc29cd5-6e25-4d95-acad-5ce6b42789d7.png) |
| up | ![5702ac6 before - up](https://user-images.githubusercontent.com/62723358/179067083-9ffc1f6f-762a-43b5-b1d7-557cfc8e9f1f.png) | ![5702ac6 after - up](https://user-images.githubusercontent.com/62723358/179067082-572a11fd-d35c-4111-b6dc-289a572be88f.png) |
| down | ![5702ac6 before - down](https://user-images.githubusercontent.com/62723358/179067100-7f956931-093c-44f6-aea8-9b07bfffb271.png) | ![5702ac6 after - down](https://user-images.githubusercontent.com/62723358/179067101-229a777e-787d-4ca6-b2c4-1a9596dedbe6.png) |
| ^ + v alignment<br />< + > alignment | vertically different</br>horizontally different  | vertically matched</br>horizontally matched |
| ^ + v + < + ><br/>horz. alignment | < far left; > far right | < far left; > far left[^2] |

| before 8e0a781 | after 8e0a781 \| before 59d3897 | after 59d3897 |
| - | - | - |
| ![8e0a781 before](https://user-images.githubusercontent.com/62723358/179081502-32ca28b0-c940-4cfb-a5d4-4b949706ecae.png) | ![8e0a781 after](https://user-images.githubusercontent.com/62723358/179081510-84976ba8-d82c-4821-8039-3a24acef8358.png) | ![after 59d3897](https://user-images.githubusercontent.com/62723358/179843834-8df06d89-25b1-4df5-bbdb-3222f5ee0730.png) |
| uses extra div | no extra div | button stretched per [FP-1733](https://jira.tacc.utexas.edu/browse/FP-1733) |

[^1]: The text in first table row is down by a pixel—a side-effect. The problem was solved in #662 by using decimal pixel value. The problem is not our units, but some odd issue beyond the height, and should be solved at that source—wherever it is.
[^2]: I dunno whether to have < + > both middle, left, or right. I can ask Design. I'm tired of pixel pushing. Ask me during review when I care again.