### PR TITLE
docs(ui): less specific primary button use case

### DIFF
--- a/client/src/components/UIPatterns/UIPatternsButton/UIPatternsButton.jsx
+++ b/client/src/components/UIPatterns/UIPatternsButton/UIPatternsButton.jsx
@@ -39,8 +39,7 @@ function UIPatternsButton() {
         <span>No small primary buttons.</span>
         <p>
           <small>
-            Use for regular-height buttons that are alone or are the main action
-            of a pair of buttons.
+            Use for regular-height buttons that are the main actions.
           </small>
         </p>
       </dd>


### PR DESCRIPTION
## Overview

Describe that primary buttons are allowed for any "main" purpose button.

<details>

[One designer and I agree that a pair of primary buttons is okay, because some modals have two equally important actions.](https://tacc-team.slack.com/archives/CQUA4D5KJ/p1657752714192479) (Link expires.)

</details>

## Related

* [FP-546](https://jira.tacc.utexas.edu/browse/FP-546)
* discussed because https://github.com/TACC/Core-Portal/pull/662

## Changes

- change text in dev-facing UI Patterns section

## Testing / UI

Skipped.