### PR TITLE
Task/fp 1499 cms pattern library - serve at /ui url

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -10,6 +10,7 @@ services:
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini
       - ../../cms/static:/code/static
       - ../../cms/media:/code/media
+      - ../../cms/ui:/code/taccsite_ui
     command: python manage.py runserver 0.0.0.0:8000
     container_name: core_portal_cms
     depends_on:

--- a/server/conf/nginx/nginx.conf
+++ b/server/conf/nginx/nginx.conf
@@ -127,6 +127,10 @@ http {
            alias /srv/www/portal/server/cms/static;
         }
 
+        location /ui  {
+            alias /srv/www/portal/server/cms/ui;
+        }
+
         location /favicon.ico {
             alias /srv/www/portal/server/static/favicon.ico;
         }


### PR DESCRIPTION
## Overview

Serve https://github.com/TACC/Core-CMS/pull/512's `taccsite_ui/` at `/ui`.

## Related

* [FP-1499](https://jira.tacc.utexas.edu/browse/FP-1499)
* supports https://github.com/TACC/Core-CMS/pull/512

## Changes

- (docker-compose) mount `taccsite_ui/` at `cms/ui`
- (nginx) serve `cms/ui` at `/ui`

## Testing / UI

See https://github.com/TACC/Core-CMS/pull/512 for remote servers.