### PR TITLE
bug/FP-1772: Allocations Modal bugfixes

### DIFF
--- a/client/src/components/Allocations/AllocationsLayout.jsx
+++ b/client/src/components/Allocations/AllocationsLayout.jsx
@@ -5,6 +5,7 @@ import {
   NavLink as RRNavLink,
   Route,
   useHistory,
+  Switch,
 } from 'react-router-dom';
 import { Nav, NavItem, NavLink } from 'reactstrap';
 import { string } from 'prop-types';
@@ -88,22 +89,24 @@ export const Layout = ({ page }) => {
               <AllocationsTable page={page} />
             </SectionTableWrapper>
           )}
-          <Route exact path={`${root}/manage`}>
-            <AllocationsRequestModal
-              isOpen
-              toggle={() => {
-                history.push(root);
-              }}
-            />
-          </Route>
-          <Route path={`${root}/:projectId`}>
-            <AllocationsTeamViewModal
-              isOpen
-              toggle={() => {
-                history.push(root);
-              }}
-            />
-          </Route>
+          <Switch>
+            <Route exact path={`${root}/manage`}>
+              <AllocationsRequestModal
+                isOpen
+                toggle={() => {
+                  history.push(root);
+                }}
+              />
+            </Route>
+            <Route path={`${root}/:projectId`}>
+              <AllocationsTeamViewModal
+                isOpen
+                toggle={() => {
+                  history.push(root);
+                }}
+              />
+            </Route>
+          </Switch>
         </>
       }
     />

--- a/client/src/components/Allocations/AllocationsLayout.jsx
+++ b/client/src/components/Allocations/AllocationsLayout.jsx
@@ -6,6 +6,7 @@ import {
   Route,
   useHistory,
   Switch,
+  Redirect,
 } from 'react-router-dom';
 import { Nav, NavItem, NavLink } from 'reactstrap';
 import { string } from 'prop-types';
@@ -98,7 +99,7 @@ export const Layout = ({ page }) => {
                 }}
               />
             </Route>
-            <Route path={`${root}/:projectId`}>
+            <Route exact path={`${root}/:projectId(\\d+)`}>
               <AllocationsTeamViewModal
                 isOpen
                 toggle={() => {
@@ -106,6 +107,7 @@ export const Layout = ({ page }) => {
                 }}
               />
             </Route>
+            <Redirect to={`${root}`} />
           </Switch>
         </>
       }

--- a/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.jsx
@@ -69,10 +69,10 @@ const AllocationsManageTeamTable = ({ rawData, projectId }) => {
         Cell: (el) => {
           const deleteOperationOccuring =
             removingUserOperation.loading &&
-            el.row.original.username === removingUserOperation.userName;
+            el.row.original.username === removingUserOperation.username;
           const deleteOperationFailed =
             removingUserOperation.error &&
-            el.row.original.username === removingUserOperation.userName;
+            el.row.original.username === removingUserOperation.username;
           const removable =
             !deleteOperationOccuring && el.row.original.role !== 'PI';
 

--- a/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsManageTeamTable/AllocationsManageTeamTable.jsx
@@ -91,7 +91,7 @@ const AllocationsManageTeamTable = ({ rawData, projectId }) => {
                       type: 'REMOVE_USER_FROM_TAS_PROJECT',
                       payload: {
                         projectId,
-                        id: el.row.original.username,
+                        username: el.row.original.username,
                       },
                     });
                   }}

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -31,7 +31,7 @@ const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
   const isLoading =
     loadingUsernames[projectId] && loadingUsernames[projectId].loading;
   React.useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && projectId in teams) {
       const currentUser = teams[projectId].filter((u) => u.username === user);
       if (currentUser.length !== 1) return;
       if (currentUser[0].role === 'PI' || currentUser[0].role === 'Delegate')

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -160,7 +160,7 @@ const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
             <div className={manageStyles['user-operation-error']}>
               {addUserOperation.error ? (
                 <InlineMessage type="error">
-                  Unable to add user {addUserOperation.userName}.
+                  Unable to add user {addUserOperation.username}.
                 </InlineMessage>
               ) : null}
               {addUserOperation.error && removingUserOperation.error ? (
@@ -168,7 +168,7 @@ const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
               ) : null}
               {removingUserOperation.error ? (
                 <InlineMessage type="error">
-                  Unable to remove user {removingUserOperation.userName}.
+                  Unable to remove user {removingUserOperation.username}.
                 </InlineMessage>
               ) : null}
             </div>

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -59,7 +59,7 @@ const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
         type: 'ADD_USER_TO_TAS_PROJECT',
         payload: {
           projectId,
-          id: newUser.user.username,
+          username: newUser.user.username,
         },
       });
     },

--- a/client/src/redux/reducers/allocations.reducers.js
+++ b/client/src/redux/reducers/allocations.reducers.js
@@ -55,7 +55,7 @@ export function allocations(state = initialState, action) {
         ...state,
         loadingUsernames: {
           ...state.loadingUsernames,
-          ...action.payload.loading,
+          ...action.payload.loadingUsernames,
         },
         errors: {
           ...state.errors,

--- a/client/src/redux/reducers/allocations.reducers.js
+++ b/client/src/redux/reducers/allocations.reducers.js
@@ -14,12 +14,12 @@ export const initialState = {
     loading: false,
   },
   removingUserOperation: {
-    userName: '',
+    username: '',
     error: false,
     loading: false,
   },
   addUserOperation: {
-    userName: '',
+    username: '',
     error: false,
     loading: false,
   },
@@ -115,7 +115,7 @@ export function allocations(state = initialState, action) {
       return {
         ...state,
         removingUserOperation: {
-          userName: '',
+          username: '',
           error: false,
           loading: false,
         },
@@ -131,7 +131,7 @@ export function allocations(state = initialState, action) {
       return {
         ...state,
         addUserOperation: {
-          userName: '',
+          username: '',
           error: false,
           loading: true,
         },
@@ -141,7 +141,7 @@ export function allocations(state = initialState, action) {
       return {
         ...state,
         addUserOperation: {
-          userName: '',
+          username: '',
           error: false,
           loading: false,
         },

--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -248,7 +248,9 @@ export function* getUsernamesManage(action) {
       type: 'ADD_USERNAMES_TO_TEAM',
       payload,
     });
-  } catch (error) {}
+  } catch (error) {
+
+  }
 }
 /**
  * Search for users in TAS
@@ -276,8 +278,8 @@ export function* searchUsers(action) {
   }
 }
 
-export const manageUtil = async (pid, uid, add = true) => {
-  const r = await fetch(`/api/users/team/manage/${pid}/${uid}`, {
+export const manageUtil = async (projectId, username, add = true) => {
+  const r = await fetch(`/api/users/team/manage/${projectId}/${username}`, {
     headers: { 'X-CSRFToken': Cookies.get('csrftoken') },
     method: add ? 'POST' : 'DELETE',
   });
@@ -288,7 +290,7 @@ export const manageUtil = async (pid, uid, add = true) => {
 export function* addUser(action) {
   try {
     yield put({ type: 'ALLOCATION_OPERATION_ADD_USER_INIT' });
-    yield call(manageUtil, action.payload.projectId, action.payload.id);
+    yield call(manageUtil, action.payload.projectId, action.payload.username);
     yield put({ type: 'ALLOCATION_OPERATION_ADD_USER_COMPLETE' });
     const { projectId } = action.payload;
     yield put({
@@ -304,7 +306,7 @@ export function* addUser(action) {
         addUserOperation: {
           loading: false,
           error: true,
-          userName: action.payload.id,
+          userName: action.payload.username,
         },
       },
     });

--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -231,7 +231,6 @@ export const teamPayloadUtil = (
   return { data, loadingUsernames };
 };
 
-
 /**
  * Search for users in TAS
  * @async
@@ -305,7 +304,12 @@ export function* removeUser(action) {
         },
       },
     });
-    yield call(manageUtil, action.payload.projectId, action.payload.username, false);
+    yield call(
+      manageUtil,
+      action.payload.projectId,
+      action.payload.username,
+      false
+    );
     // remove user from team state
     const teams = yield select(allocationsTeamSelector);
     const updatedTeams = { ...teams };

--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -231,27 +231,7 @@ export const teamPayloadUtil = (
   return { data, loadingUsernames };
 };
 
-export function* getUsernamesManage(action) {
-  try {
-    yield put({
-      type: 'GET_PROJECT_USERS_INIT',
-      payload: {
-        loadingUsernames: { [action.payload.projectId]: { loading: true } },
-      },
-    });
-    const json = yield call(getProjectUsersUtil, action.payload.projectId);
-    const payload = {
-      data: { [action.payload.projectId]: json },
-      loadingUsernames: { [action.payload.projectId]: { loading: false } },
-    };
-    yield put({
-      type: 'ADD_USERNAMES_TO_TEAM',
-      payload,
-    });
-  } catch (error) {
 
-  }
-}
 /**
  * Search for users in TAS
  * @async
@@ -292,11 +272,10 @@ export function* addUser(action) {
     yield put({ type: 'ALLOCATION_OPERATION_ADD_USER_INIT' });
     yield call(manageUtil, action.payload.projectId, action.payload.username);
     yield put({ type: 'ALLOCATION_OPERATION_ADD_USER_COMPLETE' });
-    const { projectId } = action.payload;
     yield put({
-      type: 'GET_MANAGE_TEAMS',
+      type: 'GET_PROJECT_USERS',
       payload: {
-        projectId,
+        projectId: action.payload.projectId,
       },
     });
   } catch (error) {
@@ -322,17 +301,17 @@ export function* removeUser(action) {
         removingUserOperation: {
           loading: true,
           error: false,
-          username: action.payload.id,
+          username: action.payload.username,
         },
       },
     });
-    yield call(manageUtil, action.payload.projectId, action.payload.id, false);
+    yield call(manageUtil, action.payload.projectId, action.payload.username, false);
     // remove user from team state
     const teams = yield select(allocationsTeamSelector);
     const updatedTeams = { ...teams };
     updatedTeams[action.payload.projectId] = teams[
       action.payload.projectId
-    ].filter((i) => i.username !== action.payload.id);
+    ].filter((i) => i.username !== action.payload.username);
     yield put({
       type: 'ALLOCATION_OPERATION_REMOVE_USER_STATUS',
       payload: {
@@ -347,7 +326,7 @@ export function* removeUser(action) {
         removingUserOperation: {
           loading: false,
           error: true,
-          username: action.payload.id,
+          username: action.payload.username,
         },
       },
     });
@@ -369,13 +348,10 @@ export function* watchAllocationData() {
 export function* watchTeams() {
   yield takeLatest('GET_PROJECT_USERS', getUsernames);
 }
-export function* watchManageTeams() {
-  yield takeLatest('GET_MANAGE_TEAMS', getUsernamesManage);
-}
+
 export default [
   watchAllocationData(),
   watchTeams(),
-  watchManageTeams(),
   watchUserSearch(),
   watchAddUser(),
   watchRemoveUser(),

--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -306,7 +306,7 @@ export function* addUser(action) {
         addUserOperation: {
           loading: false,
           error: true,
-          userName: action.payload.username,
+          username: action.payload.username,
         },
       },
     });
@@ -322,7 +322,7 @@ export function* removeUser(action) {
         removingUserOperation: {
           loading: true,
           error: false,
-          userName: action.payload.id,
+          username: action.payload.id,
         },
       },
     });
@@ -337,7 +337,7 @@ export function* removeUser(action) {
       type: 'ALLOCATION_OPERATION_REMOVE_USER_STATUS',
       payload: {
         teams: updatedTeams,
-        removingUserOperation: { loading: false, error: false, userName: '' },
+        removingUserOperation: { loading: false, error: false, username: '' },
       },
     });
   } catch (error) {
@@ -347,7 +347,7 @@ export function* removeUser(action) {
         removingUserOperation: {
           loading: false,
           error: true,
-          userName: action.payload.id,
+          username: action.payload.id,
         },
       },
     });

--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -17,10 +17,6 @@ export function* getAllocations() {
   try {
     const json = yield call(getAllocationsUtil);
     yield put({ type: 'ADD_ALLOCATIONS', payload: json });
-    yield put({
-      type: 'POPULATE_TEAMS',
-      payload: populateTeamsUtil(json),
-    });
   } catch (error) {
     yield put({ type: 'ADD_ALLOCATIONS_ERROR', payload: error });
   }
@@ -46,24 +42,6 @@ export const getProjectUsersUtil = async (projectId) => {
   const res = await fetchUtil({ url: `/api/users/team/${projectId}` });
   const json = res.response;
   return json;
-};
-
-/**
- * Generate an empty dictionary to look up users from project ID and map loading state
- * to each project
- * @param {{portal_alloc: String, active: Array, inactive: Array, hosts: Object}} data -
- * Allocations data
- * @returns {{teams: Object, loadingTeams: {}}}
- */
-export const populateTeamsUtil = (data) => {
-  const teams = data.active
-    .concat(data.inactive)
-    .reduce((obj, item) => ({ ...obj, [item.projectId]: {} }), {});
-  const loadingTeams = Object.keys(teams).reduce(
-    (obj, teamID) => ({ ...obj, [teamID]: { loading: true } }),
-    {}
-  );
-  return { teams, loadingTeams };
 };
 
 export const allocationsSelector = (state) => [

--- a/client/src/redux/sagas/tests/allocations.sagas.test.js
+++ b/client/src/redux/sagas/tests/allocations.sagas.test.js
@@ -213,7 +213,9 @@ describe('Allocations Sagas', () => {
     const expectedTeam = {
       1234: teamFixture.filter((i) => i.username !== 'chicken'),
     };
-    expectSaga(removeUser, { payload: { projectId: 1234, username: 'chicken' } })
+    expectSaga(removeUser, {
+      payload: { projectId: 1234, username: 'chicken' },
+    })
       .withReducer(allocationsReducer, { ...initialState })
       .provide([
         [matchers.call.fn(manageUtil), { response: 'ok' }],
@@ -255,7 +257,9 @@ describe('Allocations Sagas', () => {
       teams: { 1234: teamFixture },
     };
     const fakeError = new Error('Unable to remove user');
-    expectSaga(removeUser, { payload: { projectId: 1234, username: 'chicken' } })
+    expectSaga(removeUser, {
+      payload: { projectId: 1234, username: 'chicken' },
+    })
       .withReducer(allocationsReducer, { ...initialState })
       .provide([[matchers.call.fn(manageUtil), throwError(fakeError)]])
       .put({

--- a/client/src/redux/sagas/tests/allocations.sagas.test.js
+++ b/client/src/redux/sagas/tests/allocations.sagas.test.js
@@ -225,7 +225,7 @@ describe('Allocations Sagas', () => {
           removingUserOperation: {
             loading: true,
             error: false,
-            userName: 'chicken',
+            username: 'chicken',
           },
         },
       })
@@ -234,14 +234,14 @@ describe('Allocations Sagas', () => {
         type: 'ALLOCATION_OPERATION_REMOVE_USER_STATUS',
         payload: {
           teams: { 1234: teamFixture.filter((i) => i.username !== 'chicken') },
-          removingUserOperation: { loading: false, error: false, userName: '' },
+          removingUserOperation: { loading: false, error: false, username: '' },
         },
       })
       .hasFinalState({
         ...initialState,
         teams: expectedTeam,
         removingUserOperation: {
-          userName: '',
+          username: '',
           error: false,
           loading: false,
         },
@@ -264,7 +264,7 @@ describe('Allocations Sagas', () => {
           removingUserOperation: {
             loading: true,
             error: false,
-            userName: 'chicken',
+            username: 'chicken',
           },
         },
       })
@@ -275,14 +275,14 @@ describe('Allocations Sagas', () => {
           removingUserOperation: {
             loading: false,
             error: true,
-            userName: 'chicken',
+            username: 'chicken',
           },
         },
       })
       .hasFinalState({
         ...initialState,
         removingUserOperation: {
-          userName: 'chicken',
+          username: 'chicken',
           error: true,
           loading: false,
         },

--- a/client/src/redux/sagas/tests/allocations.sagas.test.js
+++ b/client/src/redux/sagas/tests/allocations.sagas.test.js
@@ -213,7 +213,7 @@ describe('Allocations Sagas', () => {
     const expectedTeam = {
       1234: teamFixture.filter((i) => i.username !== 'chicken'),
     };
-    expectSaga(removeUser, { payload: { projectId: 1234, id: 'chicken' } })
+    expectSaga(removeUser, { payload: { projectId: 1234, username: 'chicken' } })
       .withReducer(allocationsReducer, { ...initialState })
       .provide([
         [matchers.call.fn(manageUtil), { response: 'ok' }],
@@ -255,7 +255,7 @@ describe('Allocations Sagas', () => {
       teams: { 1234: teamFixture },
     };
     const fakeError = new Error('Unable to remove user');
-    expectSaga(removeUser, { payload: { projectId: 1234, id: 'chicken' } })
+    expectSaga(removeUser, { payload: { projectId: 1234, username: 'chicken' } })
       .withReducer(allocationsReducer, { ...initialState })
       .provide([[matchers.call.fn(manageUtil), throwError(fakeError)]])
       .put({

--- a/client/src/redux/sagas/tests/allocations.sagas.test.js
+++ b/client/src/redux/sagas/tests/allocations.sagas.test.js
@@ -6,7 +6,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import {
   getAllocationsUtil,
   getProjectUsersUtil,
-  populateTeamsUtil,
   getUsageUtil,
   teamPayloadUtil,
   allocationsSelector,
@@ -76,7 +75,6 @@ describe('Allocations Sagas', () => {
     active: [],
     inactive: [],
   };
-  const teamsFixture = populateTeamsUtil(emptyAllocationsFixture);
   test('GET Allocations', () => {
     // Success
     expectSaga(getAllocations)
@@ -92,7 +90,6 @@ describe('Allocations Sagas', () => {
       .put({ type: 'START_ADD_ALLOCATIONS' })
       .call(getAllocationsUtil)
       .put({ type: 'ADD_ALLOCATIONS', payload: emptyAllocationsFixture })
-      .put({ type: 'POPULATE_TEAMS', payload: teamsFixture })
       .run();
     // Error
     const testError = new Error('Test Error');


### PR DESCRIPTION
## Overview

- Fixes an issue where the allocations manage modal was unreachable.
- Fixes an issue where a race condition would cause an infinite spinner when going to a url that pointed straight to an allocations team modal


## Related

* [FP-1772](https://jira.tacc.utexas.edu/browse/FP-1772)

## Testing

1. Go to https://cep.dev/workbench/allocations/approved/manage and confirm it brings up the modal
2. Open a allocations team view modal, refresh the page, and confirm there is no infinite spinner.
  a. You can simulate the race condition happening by setting `force=True` in `get_allocations` in `server/portal/apps/users/utils.py`

## Notes
I've also deployed this branch to dev. You can test this out here: https://dev.cep.tacc.utexas.edu/workbench/allocations/approved/59024