### PR TITLE
Task/fp 1788  apcd manage account  support tall panels

### DIFF
--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -11,11 +11,21 @@ import './Dashboard.global.css';
 import styles from './Dashboard.module.css';
 import CustomDashboardSection from './CustomDashboardSection';
 
+function getPanelCount(standardApps = [], optionalApps = [], customApps = []) {
+  return standardApps.length + optionalApps.length + customApps.length;
+}
+
 function Dashboard() {
   const { hideApps, hideManageAccount, customDashboardSection } = useSelector(
     (state) => state.workbench.config
   );
   const { hideSystemMonitor } = useSelector((state) => state.systemMonitor);
+  const panelCount = getPanelCount(
+    ['DashboardTickets'],
+    [hideApps, hideSystemMonitor].filter((isHidden) => !isHidden),
+    ...(Boolean(customDashboardSection) ? [['customDashboardSection']] : [])
+  );
+
   return (
     <Section
       bodyClassName="has-loaded-dashboard"
@@ -29,7 +39,7 @@ function Dashboard() {
           </Link>
         )
       }
-      contentClassName={styles['panels']}
+      contentClassName={`${styles['panels']} count--${panelCount}`}
       contentLayoutName={hideApps ? 'balance' : 'twoColumn'}
       contentShouldScroll
       content={

--- a/client/src/components/Dashboard/Dashboard.module.css
+++ b/client/src/components/Dashboard/Dashboard.module.css
@@ -86,7 +86,6 @@
   .panels:global(:is(.count--1, .count--2)) > * {
     height: 100%;
     /* So bottom border of table is not flush with bottom of app */
-    /* HELP: …--section-left is used for top spacing which this mirrors */
-    padding-bottom: var(--global-space--section-left);
+    padding-bottom: var(--vertical-buffer);
   }
 }

--- a/client/src/components/Dashboard/Dashboard.module.css
+++ b/client/src/components/Dashboard/Dashboard.module.css
@@ -82,4 +82,8 @@
     width: var(--column-width--small);
     height: auto;
   }
+  /* FAQ: Uses `:global` to avoid error on missing (i.e. unused) classes */
+  .panels:global(:is(.count--1, .count--2)) > * {
+    height: 100%;
+  }
 }

--- a/client/src/components/Dashboard/Dashboard.module.css
+++ b/client/src/components/Dashboard/Dashboard.module.css
@@ -85,5 +85,8 @@
   /* FAQ: Uses `:global` to avoid error on missing (i.e. unused) classes */
   .panels:global(:is(.count--1, .count--2)) > * {
     height: 100%;
+    /* So bottom border of table is not flush with bottom of app */
+    /* HELP: …--section-left is used for top spacing which this mirrors */
+    padding-bottom: var(--global-space--section-left);
   }
 }


### PR DESCRIPTION
## Overview

Stretch column panels and adding padding-bottom if there are no rows.

## Related

* [FP-1788](https://jira.tacc.utexas.edu/browse/FP-1788)

## Changes

- get panel count
- add panel count as global class (so we need not define all possible counts)
- stretch height and add space

## Testing

1. Use the settings from https://github.com/TACC/Core-Portal/pull/688.
2. Verify "My Tickets" column takes up **almost** full column height. — Remember the extra space below.
3. Do not use the settings from https://github.com/TACC/Core-Portal/pull/688.
4. Verify bottom panels have the same extra space as before this branch and as in step 2.

## UI

| Sans FP-1788 Settings | With FP-1788 Settings |
| - | - |
| ![Sans FP-1788 Settings](https://user-images.githubusercontent.com/62723358/186784292-48b708d3-9356-4783-b9d6-b7fc5eb8e82b.png) | ![With FP-1788 Settings](https://user-images.githubusercontent.com/62723358/186784295-9d10b109-4cad-418f-9510-68647f8eaf10.png) |

ℹ️ If the height of the window is shorter than 635px, expect a vertical scrollbar. This is _not_ a new development.

## Notes

Resolves the #2 layout request at https://github.com/TACC/Core-Portal/pull/688#issuecomment-1227381599.