### PR TITLE
fix/FP-1823: Update poetry and base docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   Server_Side_Unit_Tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 
@@ -25,7 +25,7 @@ jobs:
       with:
         poetry-version: 1.1.0
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pypoetry/virtualenvs
         key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
@@ -44,7 +44,7 @@ jobs:
         poetry run pytest --cov-config=.coveragerc --cov=portal --cov-report=xml -ra
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./server/coverage.xml
@@ -53,12 +53,12 @@ jobs:
         fail_ci_if_error: true
 
   Server_Side_Linting:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 
@@ -67,7 +67,7 @@ jobs:
       with:
         poetry-version: 1.1.0
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pypoetry/virtualenvs
         key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
@@ -85,15 +85,15 @@ jobs:
         poetry run flake8
 
   Client_Side_Unit_Tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 16
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -113,15 +113,15 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_TOKEN }} -cF javascript
 
   Client_Side_Linting:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 16
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.1.0
+        poetry-version: 1.2.0
 
     - uses: actions/cache@v3
       with:
@@ -65,7 +65,7 @@ jobs:
     - name: Setup Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.1.0
+        poetry-version: 1.2.0
 
     - uses: actions/cache@v3
       with:

--- a/server/conf/docker/Dockerfile
+++ b/server/conf/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-buster as python-base
+FROM python:3.7-bullseye as python-base
 
 LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
 

--- a/server/conf/docker/Dockerfile
+++ b/server/conf/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 EXPOSE 8000
 
 # https://python-poetry.org/docs/configuration/#using-environment-variables
-ENV POETRY_VERSION=1.1.0 \
+ENV POETRY_VERSION=1.2.0 \
     POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     POETRY_NO_INTERACTION=1 \
@@ -38,7 +38,7 @@ RUN apt-get update &&  apt-get install -y --no-install-recommends \
 RUN pip3 install --upgrade pip setuptools wheel
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # copy project requirement files here to ensure they will be cached.
 WORKDIR $PYSETUP_PATH


### PR DESCRIPTION
## Overview

Poetry actions are failing. To fix this, I've updated poetry to 1.2, and bumped base images and actions to latest stable versions.

## Related

* [FP-1823](https://jira.tacc.utexas.edu/browse/FP-1823)

## Changes
- bump base docker image to latest stable debian lts `bullseye`
- bump github action runner images to latest ubuntu lts `focal`
- update github actions
- bump poetry to 1.1.2

## Testing
1. run `make build`
2. run `make start` and `npm run dev` in separate terminal windows
3. go to cep.dev and ensure everything works as expected
4. ensure these github actions are passing

