### PR TITLE
task/FP-1855: fix allocation usage dialog

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -14,7 +14,8 @@ import styles from './AllocationsTeamViewModal.module.scss';
 import manageStyles from '../AllocationsManageTeamTable/AllocationsManageTeamTable.module.scss';
 
 const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
-  const { projectId } = useParams();
+  const { projectId: projectIdString } = useParams();
+  const projectId = Number(projectIdString);
   const {
     teams,
     loadingUsernames,

--- a/client/src/redux/sagas/allocations.sagas.js
+++ b/client/src/redux/sagas/allocations.sagas.js
@@ -36,7 +36,7 @@ export const getAllocationsUtil = async () => {
 
 /**
  * Fetch user data for a project
- * @param {String} projectId - project id
+ * @param {Number} projectId - project id
  */
 export const getProjectUsersUtil = async (projectId) => {
   const res = await fetchUtil({ url: `/api/users/team/${projectId}` });


### PR DESCRIPTION
## Overview

Fix allocation usage dialog.  `projectId` needed to be converted to an int (as later processing/data-handling was dependent on that)

## Related

* [FP-1855](https://jira.tacc.utexas.edu/browse/FP-1855)

## Testing

1. Navigate to a project and view team and ensure you can see usage information for team members
2. Go directly to a project ( ) ensure you can see usage information for team members