### PR TITLE
hotfix: use codecov github action instead of deprecated bash script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,11 @@ jobs:
         npm run test
 
     - name: Upload coverage to Codecov
-      run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_TOKEN }} -cF javascript
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: javascript
+        fail_ci_if_error: true
 
   Client_Side_Linting:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Overview

Codecov's uploader is deprecated and not working today.  https://docs.codecov.com/docs/about-the-codecov-bash-uploader.  This brings the uploading using gh action in line with the uploading of the backend coverage.

@edmondsgarrett  and I noticed it wasn't working correctly earlier today and we thought codecov was just down but I just saw the deprecating notice.

