### PR TITLE
hotfix/FP-1870: ls6 home dir

### DIFF
--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -498,7 +498,7 @@ PORTAL_EXEC_SYSTEMS = {
     },
     'ls6.tacc.utexas.edu': {
         'scratch_dir': '/scratch/{}',
-        'home_dir': '/home/{}'
+        'home_dir': '/home1/{}'
     },
 }
 


### PR DESCRIPTION
## Overview
LS6 has `/home1`, not `/home` as the home dir


## Related

* [FP-1870](https://jira.tacc.utexas.edu/browse/FP-1870)

