### PR TITLE
task/FP-1839: Feedback link in portal is configurable

### DIFF
--- a/client/src/components/Sidebar/Sidebar.jsx
+++ b/client/src/components/Sidebar/Sidebar.jsx
@@ -24,7 +24,7 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const hideAllocations = useSelector(
     (state) => state.workbench.config.hideAllocations
   );
-  const hideFeeback = useSelector(
+  const hideFeedback = useSelector(
     (state) => state.workbench.config.hideFeeback
   );
   const sidebarItems = [
@@ -81,7 +81,7 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const addItems = [
     {
       className: styles['feedback-nav-item'],
-      children: !hideFeeback && <FeedbackButton />,
+      children: !hideFeedback && <FeedbackButton />,
     },
   ];
   return (

--- a/client/src/components/Sidebar/Sidebar.jsx
+++ b/client/src/components/Sidebar/Sidebar.jsx
@@ -81,7 +81,7 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const addItems = [
     {
       className: styles['feedback-nav-item'],
-      children:  <FeedbackButton/>,
+      children: <FeedbackButton />,
       hidden: hideFeedback,
     },
   ];

--- a/client/src/components/Sidebar/Sidebar.jsx
+++ b/client/src/components/Sidebar/Sidebar.jsx
@@ -24,6 +24,9 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const hideAllocations = useSelector(
     (state) => state.workbench.config.hideAllocations
   );
+  const hideFeeback = useSelector(
+    (state) => state.workbench.config.hideFeeback
+  );
   const sidebarItems = [
     {
       to: path + ROUTES.DASHBOARD,
@@ -78,7 +81,7 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const addItems = [
     {
       className: styles['feedback-nav-item'],
-      children: <FeedbackButton />,
+      children: !hideFeeback && <FeedbackButton />,
     },
   ];
   return (

--- a/client/src/components/Sidebar/Sidebar.jsx
+++ b/client/src/components/Sidebar/Sidebar.jsx
@@ -25,7 +25,7 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
     (state) => state.workbench.config.hideAllocations
   );
   const hideFeedback = useSelector(
-    (state) => state.workbench.config.hideFeeback
+    (state) => state.workbench.config.hideFeedback
   );
   const sidebarItems = [
     {
@@ -81,7 +81,8 @@ const Sidebar = ({ disabled, showUIPatterns, loading }) => {
   const addItems = [
     {
       className: styles['feedback-nav-item'],
-      children: !hideFeedback && <FeedbackButton />,
+      children:  <FeedbackButton/>,
+      hidden: hideFeedback,
     },
   ];
   return (

--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -136,9 +136,7 @@ function Workbench() {
                   />
                 )}
                 {showUIPatterns && (
-                  <Route path={`${path}${ROUTES.UI}`} 
-                  component={UIPatterns} 
-                  />
+                  <Route path={`${path}${ROUTES.UI}`} component={UIPatterns} />
                 )}
                 <Redirect from={`${path}`} to={`${path}${ROUTES.DASHBOARD}`} />
               </Switch>

--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -136,7 +136,9 @@ function Workbench() {
                   />
                 )}
                 {showUIPatterns && (
-                  <Route path={`${path}${ROUTES.UI}`} component={UIPatterns} />
+                  <Route path={`${path}${ROUTES.UI}`} 
+                  component={UIPatterns} 
+                  />
                 )}
                 <Redirect from={`${path}`} to={`${path}${ROUTES.DASHBOARD}`} />
               </Switch>

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -69,7 +69,11 @@ const Sidebar = ({ sidebarItems, addItems, loading }) => {
         )}
       {addItems
         ? addItems.map((item) => (
-            <NavItem className={item.className} key={item.className} hidden={item.hidden}>
+            <NavItem
+              className={item.className}
+              key={item.className}
+              hidden={item.hidden}
+            >
               {item.children}
             </NavItem>
           ))

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -68,15 +68,14 @@ const Sidebar = ({ sidebarItems, addItems, loading }) => {
             )
         )}
       {addItems
-        ? addItems.map((item) => (
-            <NavItem
-              className={item.className}
-              key={item.className}
-              hidden={item.hidden}
-            >
-              {item.children}
-            </NavItem>
-          ))
+        ? addItems.map(
+            (item) =>
+              !item.hidden && (
+                <NavItem className={item.className} key={item.className}>
+                  {item.children}
+                </NavItem>
+              )
+          )
         : null}
     </Nav>
   );

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -69,7 +69,7 @@ const Sidebar = ({ sidebarItems, addItems, loading }) => {
         )}
       {addItems
         ? addItems.map((item) => (
-            <NavItem className={item.className} key={item.className}>
+            <NavItem className={item.className} key={item.className} hidden={item.hidden}>
               {item.children}
             </NavItem>
           ))

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -67,7 +67,8 @@ const Sidebar = ({ sidebarItems, addItems, loading }) => {
               </SidebarItem>
             )
         )}
-      {addItems
+
+      {!loading && addItems
         ? addItems.map(
             (item) =>
               !item.hidden && (

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -261,6 +261,7 @@ _WORKBENCH_SETTINGS = {
     "showSubmissions": False,
     "hideManageAccount": False,
     "hasUserGuide": True,
+    "hideFeedback": False,
     "onboardingCompleteRedirect": '/workbench/',
     "noPHISystem": "",
     "customDashboardSection": {

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -261,6 +261,6 @@ _WORKBENCH_SETTINGS = {
     "onboardingCompleteRedirect": '/workbench/',
     "noPHISystem": "",
     "customDashboardSection": None,
-    "hideFeeback": False,
+    "hideFeedback": False,
 
 }

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -260,5 +260,7 @@ _WORKBENCH_SETTINGS = {
     "hasUserGuide": True,
     "onboardingCompleteRedirect": '/workbench/',
     "noPHISystem": "",
-    "customDashboardSection": None
+    "customDashboardSection": None,
+    "hideFeeback": False,
+
 }

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -262,5 +262,4 @@ _WORKBENCH_SETTINGS = {
     "noPHISystem": "",
     "customDashboardSection": None,
     "hideFeedback": False,
-
 }


### PR DESCRIPTION
## Overview

Added boolean setting that removes the 'Add Feedback' button from the sidebar 

## Related

* [FP-1839](https://jira.tacc.utexas.edu/browse/FP-1839)

## Changes
Added a `hideFeeback` boolean in `settings_default.py` that removes the Add FeedBack when set to True


## Testing

1. Add `"hideFeeback": True` to `_WORKBENCH_SETTINGS` in `settings_custom.py`
2. Check that the "Leave Feedback" button is hidden at the bottom of the Workbench Sidebar

## UI



## Notes

