### PR TITLE
Added () to accepted characters and changed error message to reflect

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesRenameModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesRenameModal.jsx
@@ -30,8 +30,8 @@ const DataFilesRenameModal = () => {
     newName: Yup.string()
       .min(1)
       .matches(
-        /^[\d\w\s\-_.]+$/,
-        'Please enter a valid file name (accepted characters are A-Z a-z 0-9 - _ .)'
+        /^[\d\w\s\-_.()]+$/,
+        'Please enter a valid file name (accepted characters are A-Z a-z 0-9 () - _ .)'
       )
       .notOneOf(
         [selected.name],

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesRenameModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesRenameModal.test.js
@@ -105,7 +105,7 @@ describe('DataFilesRenameModal', () => {
 
     expect(
       getByText(
-        'Please enter a valid file name (accepted characters are A-Z a-z 0-9 - _ .)'
+        'Please enter a valid file name (accepted characters are A-Z a-z 0-9 () - _ .)'
       )
     ).toBeDefined();
 

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -498,7 +498,7 @@ PORTAL_EXEC_SYSTEMS = {
     },
     'ls6.tacc.utexas.edu': {
         'scratch_dir': '/scratch/{}',
-        'home_dir': '/home/{}'
+        'home_dir': '/home1/{}'
     },
 }
 


### PR DESCRIPTION
## Overview
Added () to accepted characters and changed error message and tests to reflect changes


## Related

* [FP-1668](https://jira.tacc.utexas.edu/browse/FP-1668)

## Changes

Rename modal now allows the use of parentheses "()" and the error message will include that now as an acceptable character.

## Testing

1. Go to My Dashboard >> Data Files
2. Select a Workspace from the Data Files Nav (Public Data, Shared Workspace, etc)
3. Click checkbox of data file you'd like to edit
4. Click Rename
5. When modal pops up enter a name with a invalid character like &%$ to make sure the error message says () are ok
6. When modal pops up, enter a name that includes parentheses and make sure it successfully saves

## UI



## Notes