### PR TITLE
bug/FP-1669: fix back button in copy modal

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
@@ -145,7 +145,7 @@ const DataFilesModalListingTable = ({
   disabled,
 }) => {
   const { loading, error, params, fetchMore } = useFileListing('modal');
-  const isNotRoot = (params.path !== '' && params.path !== '/')
+  const isNotRoot = params.path !== '' && params.path !== '/';
 
   const displayName = useSystemDisplayName(params);
 

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
@@ -145,7 +145,7 @@ const DataFilesModalListingTable = ({
   disabled,
 }) => {
   const { loading, error, params, fetchMore } = useFileListing('modal');
-  const isNotRoot = params.path.length > 0;
+  const isNotRoot = (params.path !== '' && params.path !== '/')
 
   const displayName = useSystemDisplayName(params);
 

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
@@ -212,7 +212,7 @@ const DataFilesModalListingTable = ({
     [params, operationName, operationCallback, disabled]
   );
 
-  const hasBackButton = params.path.length > 0;
+  const hasBackButton = isNotRoot;
 
   const BackHeader = useCallback(
     () => (


### PR DESCRIPTION
## Overview
Correct undesired behavior: "Back" button appears at the top of the right panel list in the Copy Modal when trying to copy a file/folder from a top level directory. The name of the top level directory also does not appear in the list.  


## Related

* [FP-1669](https://jira.tacc.utexas.edu/browse/FP-1669)

## Changes
Modify how the `isNotRoot` and `hasBackButton` variables are set in the DataFilesModalListingTable component.
`isNotRoot` is set to `false` if `params.path` is either an empty string or `'/'`.
`hasBackButton` set to `isNotRoot` to follow DRY.


## Testing

1. Go to Data Files.
2. From a top level directory (e.g. My Data (Frontera)) select a file or directory using the checkbox.
3. Click on the Copy button at the top right.
4. Ensure that the "Back" button does NOT appear and that the top level directory name does appear in the modal. See screenshots below.

## UI
**Before:**
![Screen Shot 2022-10-06 at 9 44 19 AM](https://user-images.githubusercontent.com/79928051/194351066-1c481146-65a4-450e-a5f6-74c9f52fc079.png)

**After:**
![Screen Shot 2022-10-06 at 9 45 45 AM](https://user-images.githubusercontent.com/79928051/194351156-26c5ea15-51cb-4073-88c1-1ad449fba63e.png)

## Notes
