### PR TITLE
bug/FP -1431 add success message to feedback modal

### DIFF
--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -59,7 +59,7 @@ const FeedbackForm = () => {
             <div className="ticket-create-button-row">
               {creating && (
                   <Alert color="success" className="ticket-create-info-alert">
-                    "Message successfully sent. Thank you for your feedback!"
+                    Message successfully sent. Thank you for your feedback!
                   </Alert>
               )}
               {submitCount > 0 && creatingError && (

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -57,8 +57,7 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
-              {creating  
-              }
+              {creating}
               {submitCount > 0 && creatingError && (
                 <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { Alert, FormGroup } from 'reactstrap';
+import { FormGroup } from 'reactstrap';
 import { Button, FormField, InlineMessage } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -57,11 +57,8 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
-              {creating && (
-                <InlineMessage type="success">
-                  Message successfully sent. 
-                </InlineMessage>
-              )}
+              {creating  
+              }
               {submitCount > 0 && creatingError && (
                 <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { Alert, FormGroup} from 'reactstrap';
+import { Alert, FormGroup } from 'reactstrap';
 import { Button, FormField } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { Alert, FormGroup } from 'reactstrap';
+import { Alert, FormGroup} from 'reactstrap';
 import { Button, FormField } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';
@@ -57,6 +57,11 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
+              {creating && (
+                  <Alert color="success" className="ticket-create-info-alert">
+                    "Message successfully sent. Thank you for your feedback!"
+                  </Alert>
+              )}
               {submitCount > 0 && creatingError && (
                 <Alert color="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -58,9 +58,9 @@ const FeedbackForm = () => {
             </FormGroup>
             <div className="ticket-create-button-row">
               {creating && (
-                  <Alert color="success" className="ticket-create-info-alert">
-                    Message successfully sent. Thank you for your feedback!
-                  </Alert>
+                <Alert color="success" className="ticket-create-info-alert">
+                  Message successfully sent. Thank you for your feedback!
+                </Alert>
               )}
               {submitCount > 0 && creatingError && (
                 <Alert color="warning">

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
 import { Alert, FormGroup } from 'reactstrap';
-import { Button, FormField } from '_common';
+import { Button, FormField, InlineMessage } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';
 
@@ -58,14 +58,14 @@ const FeedbackForm = () => {
             </FormGroup>
             <div className="ticket-create-button-row">
               {creating && (
-                <Alert color="success" className="ticket-create-info-alert">
-                  Message successfully sent. Thank you for your feedback!
-                </Alert>
+                <InlineMessage type="success">
+                  Message successfully sent. 
+                </InlineMessage>
               )}
               {submitCount > 0 && creatingError && (
-                <Alert color="warning">
+                <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}
-                </Alert>
+                </InlineMessage>
               )}
               <Button
                 attr="submit"


### PR DESCRIPTION
## Overview

 Add success message in the feedback modal and info alert to bottom of page

## Related

* [FP-1431](https://jira.tacc.utexas.edu/browse/FP-1431)

## Changes

Modal now displays a message at the bottom of the modal that says "Message successfully sent. Thank you for your feedback!" Also included a Message successfully sent info alert to the bottom of the page in case the user misses the message in the modal before it closes. 

## Testing

1. Go to any page of the portal
2. On the bottom left corner, click the "Leave Feedback" link
3. Enter a message and click submit
4. Ensure you see a message in the modal before it closes and that there is a purple info alert that pops up at the bottom of the page notifying the user the message was successfully sent.

## UI



## Notes
Should feedback be saved in the Ticket Dashboard? This is how it's currently behaving before my changes.

