### PR TITLE
bug/FP-1859: fix upload icon color

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
@@ -79,8 +79,12 @@ const DataFilesSidebar = ({ readOnly }) => {
               + Add
             </DropdownToggle>
             <DropdownMenu>
-              <DropdownItem className={styles[writeItemStyle]} onClick={toggleMkdirModal} disabled={disabled}>
-                  <i className="icon-folder" /> Folder
+              <DropdownItem
+                className={styles[writeItemStyle]}
+                onClick={toggleMkdirModal}
+                disabled={disabled}
+              >
+                <i className="icon-folder" /> Folder
               </DropdownItem>
               {sharedWorkspaces && !sharedWorkspaces.readOnly && (
                 <DropdownItem onClick={toggleAddProjectModal}>
@@ -95,10 +99,7 @@ const DataFilesSidebar = ({ readOnly }) => {
                 <i className={`icon-upload`} />
                 <span className="multiline-menu-item-wrapper">
                   Upload
-                  <small>
-                    {' '}
-                    Up to 500mb{' '}
-                  </small>
+                  <small> Up to 500mb </small>
                 </span>
               </DropdownItem>
             </DropdownMenu>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
@@ -94,7 +94,9 @@ const DataFilesSidebar = ({ readOnly }) => {
                 onClick={toggleUploadModal}
                 disabled={disabled}
               >
-                <i className={`icon-upload ${styles[writeItemStyle]}`} />
+                <span className={`${styles[writeItemStyle]}`}>
+                  <i className={`icon-upload`} />
+                </span>
                 <span className="multiline-menu-item-wrapper">
                   <span className={styles[writeItemStyle]}>Upload</span>
                   <small className={styles[writeItemStyle]}>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
@@ -79,10 +79,8 @@ const DataFilesSidebar = ({ readOnly }) => {
               + Add
             </DropdownToggle>
             <DropdownMenu>
-              <DropdownItem onClick={toggleMkdirModal} disabled={disabled}>
-                <span className={styles[writeItemStyle]}>
+              <DropdownItem className={styles[writeItemStyle]} onClick={toggleMkdirModal} disabled={disabled}>
                   <i className="icon-folder" /> Folder
-                </span>
               </DropdownItem>
               {sharedWorkspaces && !sharedWorkspaces.readOnly && (
                 <DropdownItem onClick={toggleAddProjectModal}>
@@ -90,16 +88,14 @@ const DataFilesSidebar = ({ readOnly }) => {
                 </DropdownItem>
               )}
               <DropdownItem
-                className="complex-dropdown-item"
+                className={`complex-dropdown-item ${styles[writeItemStyle]}`}
                 onClick={toggleUploadModal}
                 disabled={disabled}
               >
-                <span className={`${styles[writeItemStyle]}`}>
-                  <i className={`icon-upload`} />
-                </span>
+                <i className={`icon-upload`} />
                 <span className="multiline-menu-item-wrapper">
-                  <span className={styles[writeItemStyle]}>Upload</span>
-                  <small className={styles[writeItemStyle]}>
+                  Upload
+                  <small>
                     {' '}
                     Up to 500mb{' '}
                   </small>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.module.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.module.scss
@@ -5,9 +5,8 @@
     height: 100%;
   }
 
-  .read-only,
-  button.read-only,
-  button.read-only small {
+  .read-only *,
+  button.read-only {
     color: #afafaf;
   }
 }

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.module.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.module.scss
@@ -5,7 +5,7 @@
     height: 100%;
   }
 
-  .read-only {
+  .read-only, button.read-only, button.read-only small {
     color: #afafaf;
   }
 }

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.module.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.module.scss
@@ -5,7 +5,9 @@
     height: 100%;
   }
 
-  .read-only, button.read-only, button.read-only small {
+  .read-only,
+  button.read-only,
+  button.read-only small {
     color: #afafaf;
   }
 }


### PR DESCRIPTION
## Overview
Upload icon needs to be greyed out, just like the text "Upload", when the upload dropdown item is disabled.

## Related

* [FP-1859](https://jira.tacc.utexas.edu/browse/FP-1859)

## Changes
Wrap the icon in a new span with the appropriate CSS className.

## Testing

1. Go to Data Files
2. Select Shared Workspaces
3. Click the + Add button
4. Ensure that the upload icon is greyed out.

## UI
**Before**
![Screen Shot 2022-10-07 at 8 56 31 AM](https://user-images.githubusercontent.com/79928051/194572455-776b6736-8421-4912-a20c-8ed97d52fe56.png)

**After**
![Screen Shot 2022-10-07 at 9 31 46 AM](https://user-images.githubusercontent.com/79928051/194578728-9be54dea-5fc8-4156-ba5c-31b082d4d585.png)



