### PR TITLE
Download modal adjustments

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesDownloadMessageModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesDownloadMessageModal.jsx
@@ -95,11 +95,11 @@ const DataFilesDownloadMessageModal = () => {
       onOpened={onOpened}
       onClosed={onClosed}
       toggle={toggle}
-      size="lg"
+      size="md"
       className="dataFilesModal"
     >
       <ModalHeader toggle={toggle} charCode="&#xe912;">
-        Download Folder
+        Download
       </ModalHeader>
       <Formik
         innerRef={formRef}

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -1091,7 +1091,7 @@ export function* compressFiles(action) {
       });
       yield put({
         type: 'DATA_FILES_TOGGLE_MODAL',
-        payload: { operation: 'compress', props: {} },
+        payload: { operation: 'downloadMessage', props: {} },
       });
     } else {
       throw new Error('Unable to compress files');


### PR DESCRIPTION
## Overview

Made adjustments to the download modal

## Related

* [FP-1537](https://jira.tacc.utexas.edu/browse/FP-1537)

## Changes

1. Changed size of download modal to 'md' (previously lg)
2. Renamed heading to Download (previously Download Folder)
3. After the compress job is submitted the modal closes automatically and an additional success modal does not show. 

## Testing

1. Go to Data Files
2. Select some files and click Download
4. Ensure modal size is smaller than before
5. Ensure heading text is Download
6. Click compress and ensure modal closes upon success

## UI

Before: 

![Screen Shot 2022-10-10 at 11 28 51 AM](https://user-images.githubusercontent.com/23081932/194913805-49b03c13-e4e1-4bad-a37f-d14bda89bf39.png)

After: 

![Screen Shot 2022-10-10 at 11 28 16 AM](https://user-images.githubusercontent.com/23081932/194914011-d013ea8f-85e7-4228-bb2a-023bdaaa6897.png)



## Notes

