### PR TITLE
Task/fp 1877  replace alert with inline

### DIFF
--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -57,7 +57,7 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
-              {creating}
+
               {submitCount > 0 && creatingError && (
                 <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -59,7 +59,7 @@ const FeedbackForm = () => {
             <div className="ticket-create-button-row">
               {creating && (
                   <Alert color="success" className="ticket-create-info-alert">
-                    "Message successfully sent. Thank you for your feedback!"
+                    Message successfully sent. Thank you for your feedback!
                   </Alert>
               )}
               {submitCount > 0 && creatingError && (

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -57,8 +57,7 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
-              {creating  
-              }
+              {creating}
               {submitCount > 0 && creatingError && (
                 <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { Alert, FormGroup } from 'reactstrap';
+import { FormGroup } from 'reactstrap';
 import { Button, FormField, InlineMessage } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -57,11 +57,8 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
-              {creating && (
-                <InlineMessage type="success">
-                  Message successfully sent. 
-                </InlineMessage>
-              )}
+              {creating  
+              }
               {submitCount > 0 && creatingError && (
                 <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { FormGroup } from 'reactstrap';
+import { FormGroup, ModalFooter } from 'reactstrap';
 import { Button, FormField, InlineMessage } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';
@@ -56,8 +56,7 @@ const FeedbackForm = () => {
                 required
               />
             </FormGroup>
-            <div className="ticket-create-button-row">
-
+            <ModalFooter>
               {submitCount > 0 && creatingError && (
                 <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}
@@ -72,7 +71,7 @@ const FeedbackForm = () => {
               >
                 Submit
               </Button>
-            </div>
+            </ModalFooter>
           </Form>
         );
       }}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { Alert, FormGroup} from 'reactstrap';
+import { Alert, FormGroup } from 'reactstrap';
 import { Button, FormField } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -58,7 +58,7 @@ const FeedbackForm = () => {
             </FormGroup>
             <ModalFooter>
               {submitCount > 0 && creatingError && (
-                <InlineMessage type="warning">
+                <InlineMessage type="error">
                   Error submitting feedback: {creatingErrorMessage}
                 </InlineMessage>
               )}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { Alert, FormGroup } from 'reactstrap';
+import { Alert, FormGroup} from 'reactstrap';
 import { Button, FormField } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';
@@ -57,6 +57,11 @@ const FeedbackForm = () => {
               />
             </FormGroup>
             <div className="ticket-create-button-row">
+              {creating && (
+                  <Alert color="success" className="ticket-create-info-alert">
+                    "Message successfully sent. Thank you for your feedback!"
+                  </Alert>
+              )}
               {submitCount > 0 && creatingError && (
                 <Alert color="warning">
                   Error submitting feedback: {creatingErrorMessage}

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -58,9 +58,9 @@ const FeedbackForm = () => {
             </FormGroup>
             <div className="ticket-create-button-row">
               {creating && (
-                  <Alert color="success" className="ticket-create-info-alert">
-                    Message successfully sent. Thank you for your feedback!
-                  </Alert>
+                <Alert color="success" className="ticket-create-info-alert">
+                  Message successfully sent. Thank you for your feedback!
+                </Alert>
               )}
               {submitCount > 0 && creatingError && (
                 <Alert color="warning">

--- a/client/src/components/FeedbackForm/FeedbackForm.jsx
+++ b/client/src/components/FeedbackForm/FeedbackForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
 import { Alert, FormGroup } from 'reactstrap';
-import { Button, FormField } from '_common';
+import { Button, FormField, InlineMessage } from '_common';
 import * as Yup from 'yup';
 import styles from './FeedbackForm.module.scss';
 
@@ -58,14 +58,14 @@ const FeedbackForm = () => {
             </FormGroup>
             <div className="ticket-create-button-row">
               {creating && (
-                <Alert color="success" className="ticket-create-info-alert">
-                  Message successfully sent. Thank you for your feedback!
-                </Alert>
+                <InlineMessage type="success">
+                  Message successfully sent. 
+                </InlineMessage>
               )}
               {submitCount > 0 && creatingError && (
-                <Alert color="warning">
+                <InlineMessage type="warning">
                   Error submitting feedback: {creatingErrorMessage}
-                </Alert>
+                </InlineMessage>
               )}
               <Button
                 attr="submit"


### PR DESCRIPTION
## Overview

To make FeedbackForm adhere to UI Behavior Specifications with no in-modal success message and change the error to an InlineMessage rather than a Bootstrap Alert

## Related

* [[FP-1877](https://jira.tacc.utexas.edu/browse/FP-1877)]

## Changes
Updated Feedback Form modal to no longer display a success message in the modal upon submission like the Confluence specifications [here](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=120455500#UIBehavior/UXModals-AfterSubmit,NoError
)

It still displays a toast with 'Message sent' upon successful submission as it did previously.

Changed React Alert for the in modal error message for the FeedbackForm to an InlineMessage to follow UI guidelines specified [here](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=120455500#UIBehavior/UXModals-AfterSubmit,HasError) 

Not left justified (see notes, some conflicting documentation and implementation on Core)

## Testing

1. Login to CEP.test
2. Click Leave Feedback from any page in the portal. It's located in the bottom left hand corner
3. Make sure no success message appears in the modal
4. Change [line 60](https://github.com/TACC/Core-Portal/blob/ddd27eef2840bb5b18b0a60ae68bb2d1e6b1a9cf/client/src/components/FeedbackForm/FeedbackForm.jsx#L60) FeedbackForm.jsx in PR branch to      `{true && (`
5. Go to cep.test and make sure the error message renders correctly. 
6. If you want to test how the state variable will wrap and render if anything is passed to it, (see second photo) change [line 24-25](https://github.com/TACC/Core-Portal/blob/ddd27eef2840bb5b18b0a60ae68bb2d1e6b1a9cf/client/src/components/FeedbackForm/FeedbackForm.jsx#L24-L25) to   `const creatingErrorMessage = "testing";`

## UI
Modal closes on success with a Message sent. toast.


Error rending without state variable
<img width="610" alt="Screen Shot 2022-10-13 at 9 55 12 AM" src="https://user-images.githubusercontent.com/96220951/195648908-a7641870-e723-438a-af2b-f9d65b65a80f.png">


Error rending with state variable
<img width="631" alt="Screen Shot 2022-10-13 at 9 56 24 AM" src="https://user-images.githubusercontent.com/96220951/195648822-66a2865f-bd72-4535-8545-0d9ea5f32264.png">


Error rending with state variable example 2
<img width="607" alt="Screen Shot 2022-10-13 at 9 50 36 AM" src="https://user-images.githubusercontent.com/96220951/195649047-95b0d345-76e9-4f9d-8864-b8a03e2946e6.png">


See Notes: I used this example of a different Modal that uses InlineMessage in a ModalFooter to model in the FeedbackForm modal
<img width="768" alt="Screen Shot 2022-10-12 at 4 31 54 PM" src="https://user-images.githubusercontent.com/96220951/195453621-b10ebf9e-f234-462d-8eb5-6498b2985ea8.png">




## Notes
Add on for previous PR that no longer adhered to Portal UI behavior. This PR reflects changes in accordance with UI expectations for Success messages
https://github.com/TACC/Core-Portal/pull/712#issuecomment-1275304682

Some conflicting things I have questions about

The UI Behavior for Modals doc [here](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=120455500#UIBehavior/UXModals-AfterSubmit,HasError ) says the FeedbackForm should have the text to the left. When I looked up the code for other modals that should have InlineMessages to the left I ran into a few things.
1. Some of these modals do not have error messages at all (trash for example) so that couldn't be used as an example to model this modal after. May need to make another ticket to update these one day.
2.  Some are using a Yup object passed to a variable called validationSchema, which I'm just assuming they haven't been updated yet as well datafilesrename modal
3. Modals that have been updated to use InlineMessages for errors rather than alerts are using them within a ModalFooter which _**does not**_align them to the left but rather wraps them around the submit button (see UI pictures for examples)
