### PR TITLE
FP-1584 Populating source portal name in ticket data

### DIFF
--- a/server/portal/apps/tickets/utils.py
+++ b/server/portal/apps/tickets/utils.py
@@ -16,7 +16,7 @@ def create_ticket(username, first_name, last_name, email, cc, subject,
     metadata = "{}\n\n".format(METADATA_HEADER)
     metadata += "Client info:\n{}\n\n".format(info)
 
-    for key in ['HTTP_REFERER', 'HTTP_USER_AGENT', 'SERVER_NAME']:
+    for key in ['HTTP_REFERER', 'HTTP_USER_AGENT', 'HTTP_HOST']:
         metadata += "{}:\n{}\n\n".format(key, meta.get(key, "None"))
 
     if username:


### PR DESCRIPTION
## Overview

The SERVER_NAME field is not getting populated in the ticket data. This field is used to quickly identify the source portal the ticket is coming from without logging into RT directly. 

## Related

* [FP-1584](https://jira.tacc.utexas.edu/browse/FP-1584)

## Changes

Instead of using the SERVER_NAME header in the request (which is coming in as blank), the HTTP_HOST header is used instead which contains the name of the source portal


## Testing

1. In the Portal click on Leave Feedback then click on Submit a Ticket
2. Fill out the information and submit a test ticket 
3. Go to [Request Tracker](https://consult.tacc.utexas.edu/) and find the created ticket
4. Ensure the ticket data contains the HTTP_HOST field with the correct source portal name

## UI

Before: 

![Screen Shot 2022-10-12 at 11 53 45 AM](https://user-images.githubusercontent.com/23081932/195403279-d56a7673-1cdd-4ed4-9dde-898892c5f519.png)

After: 

![Screen Shot 2022-10-12 at 11 55 44 AM](https://user-images.githubusercontent.com/23081932/195403310-0332fb28-d6e4-4221-8913-571181537a01.png)


## Notes

The SERVER_NAME header is a field that contains the name of the server the instance is running on. Likely due to the shift to using docker containers the SERVER_NAME field does not contain the name of the portal the request is coming from. Running the application locally, the SERVER_NAME field gets populated with the local docker container id which is not the information we need. Therefore it is best to use the value in the HTTP_HOST header to display the source portal information. 
