### PR TITLE
bug/FP-1629-Allow helper text to display with error message while creating a job

### DIFF
--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -85,7 +85,10 @@ const FormField = ({
   const FieldNote = () => (
     <>
       {meta.touched && meta.error ? (
-        <div className="form-field__validation-error">{meta.error}</div>
+        <FormText className="form-field__help" color="muted">
+          {description}
+          <div className="form-field__validation-error">{meta.error} </div>
+        </FormText>
       ) : (
         description && (
           <FormText className="form-field__help" color="muted">
@@ -94,7 +97,7 @@ const FormField = ({
         )
       )}
     </>
-  );
+);
 
   // Allowing ineffectual prop combinations would lead to confusion
   if (addon && agaveFile) {

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -97,7 +97,7 @@ const FormField = ({
         )
       )}
     </>
-);
+  );
 
   // Allowing ineffectual prop combinations would lead to confusion
   if (addon && agaveFile) {

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -87,7 +87,7 @@ const FormField = ({
       <FormText className="form-field__help" color="muted">
         {description}
         {meta.touched && meta.error && (
-          <div className="form-field__validation-error">{meta.error} </div>
+          <div className="form-field__validation-error">{meta.error}</div>
         )}
       </FormText>
     </>

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -84,18 +84,14 @@ const FormField = ({
   );
   const FieldNote = () => (
     <>
-      {meta.touched && meta.error ? (
-        <FormText className="form-field__help" color="muted">
-          {description}
+      <FormText className="form-field__help" color="muted">
+        {description}
+        {meta.touched && meta.error ? (
           <div className="form-field__validation-error">{meta.error} </div>
-        </FormText>
-      ) : (
-        description && (
-          <FormText className="form-field__help" color="muted">
-            {description}
-          </FormText>
-        )
-      )}
+        ) : (
+          description && null
+        )}
+      </FormText>
     </>
   );
 

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -86,10 +86,8 @@ const FormField = ({
     <>
       <FormText className="form-field__help" color="muted">
         {description}
-        {meta.touched && meta.error ? (
+        {meta.touched && meta.error && (
           <div className="form-field__validation-error">{meta.error} </div>
-        ) : (
-          description && null
         )}
       </FormText>
     </>


### PR DESCRIPTION
## Overview
Allow helper text to display with error message while creating a job if required field is not filled out

## Related

* [[FP-1629]](https://jira.tacc.utexas.edu/browse/FP-1629)

## Changes
Changed conditional so helper text displays in both instances whether the field has been touched or not by the user. 

## Testing

1. Go to CEP.test and go to Dashboard
2. Select Applications
3. Choose an app 
4. In the AppForm to create a job, select any Required field and click off it
5. Make sure the helper text appears first followed by the Required error

## UI

Untouched fields shows only helper text 
<img width="784" alt="Screen Shot 2022-10-13 at 12 10 19 PM" src="https://user-images.githubusercontent.com/96220951/195662107-3b9d13ab-bd0a-4b1e-9cfb-35aaf09271b9.png">

If left blank after user touches the field, displays both helper text first then required warning error. This works for all fields in the form that can be left blank by user.
![Screen Shot 2022-10-13 at 12 12 30 PM](https://user-images.githubusercontent.com/96220951/195662353-64b94328-e3d2-46b7-90bd-f70f5827f1ed.png)



## Notes

