### PR TITLE
Bug/fp 1861 remove app icon underline on hover

### DIFF
--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -47,14 +47,10 @@
 .workbench-content .wb-link {
   color: var(--global-color-accent--normal);
 }
-.workbench-content .wb-link:has(.icon):hover {
-  text-decoration: unset;
-}
-
+.workbench-content .wb-link:has(.icon):hover,
 .workbench-content .wb-link:has(.icon) > span {
   text-decoration: unset;
 }
-
 .workbench-content .wb-link:has(.icon):hover > span {
   text-decoration: underline;
 }

--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -51,13 +51,13 @@
   text-decoration: unset;
 }
 
-.workbench-content .wb-link:has(.icon):hover > span{
-  text-decoration: underline;
-}
 .workbench-content .wb-link:has(.icon) > span {
   text-decoration: unset;
 }
-  
+
+.workbench-content .wb-link:has(.icon):hover > span {
+  text-decoration: underline;
+}
 
 .workbench-content .btn-secondary {
   background-color: #f4f4f4;

--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -47,8 +47,7 @@
 .workbench-content .wb-link {
   color: var(--global-color-accent--normal);
 }
-.workbench-content .wb-link:has(.icon):hover,
-.workbench-content .wb-link:has(.icon) > span {
+.workbench-content .wb-link:has(.icon):hover {
   text-decoration: unset;
 }
 .workbench-content .wb-link:has(.icon):hover > span {

--- a/client/src/components/Workbench/Workbench.scss
+++ b/client/src/components/Workbench/Workbench.scss
@@ -47,6 +47,17 @@
 .workbench-content .wb-link {
   color: var(--global-color-accent--normal);
 }
+.workbench-content .wb-link:has(.icon):hover {
+  text-decoration: unset;
+}
+
+.workbench-content .wb-link:has(.icon):hover > span{
+  text-decoration: underline;
+}
+.workbench-content .wb-link:has(.icon) > span {
+  text-decoration: unset;
+}
+  
 
 .workbench-content .btn-secondary {
   background-color: #f4f4f4;


### PR DESCRIPTION
## Overview
Remove app underline when hovering over an App's documentation link to create a job

## Related

* [FP-1861](https://jira.tacc.utexas.edu/browse/FP-1861)

## Changes

Created new modifiers for class wb-link in Workbench styles to stop the icon underline on hover and keep the app documentation link underline on hover. 


## Testing

1. Go to CEP.test and select Applications from the Dashboard
2. Select an app from the App Browser such as NAMD, MATLAB, and/or Frontera HPC Jupyter
3. When the App Form comes up, hover over the app name + documentation link to ensure the icon no longer has a navigation link underline under it. 
4. Also ensure the Documentation text still has underlines on hover.

## UI
Without hover
<img width="1792" alt="Screen Shot 2022-10-14 at 4 09 59 PM" src="https://user-images.githubusercontent.com/96220951/195944736-a19ce0c9-ffd4-4514-8bab-55092bb92181.png">


While hovering over app documentation link
<img width="1079" alt="Screen Shot 2022-10-14 at 4 11 47 PM" src="https://user-images.githubusercontent.com/96220951/195944669-d4d159eb-9a1c-44b6-a6c0-8e605186fe4e.png">

## Notes
Possible issue is that it seems there is a Bootstrap style that is overriding any styles placed on the icon element more immediately to the element in the AppForm component located [here](https://github.com/TACC/Core-Portal/blob/29fe6c667691b87ab82de88845728b78e0608a21/client/src/components/Applications/AppForm/AppForm.jsx#L164) . Tried and failed to make more immediate style changes to the App Icon in the App Form module styles. Debugging in the console, I saw the icon was being passed its style from the wb-link in the Workbench style sheet. Created a new class to alter the icon behavior on hover so it no longer has an underline. Also changed the behavior of the text to ensure it keeps its underline despite the icon style change. 

