### PR TITLE
bug/FP1860: match css text color for 'Up to 500mb' text

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -90,7 +90,7 @@
 
   .dropdown-item {
     padding: 10px 6px;
-    color: #707070;
+    color: var(--global-color-primary--x-dark);
     font-size: 14px;
     i {
       padding-right: 19px;
@@ -98,7 +98,7 @@
       vertical-align: middle;
     }
     &:hover {
-      color: #707070;
+      color: var(--global-color-primary--x-dark);
     }
   }
   .dropdown-item:focus,
@@ -121,6 +121,6 @@
   line-height: 1.1em;
   small {
     display: block;
-    color: var(--global-color-primary--dark);
+    color: var(--global-color-primary--x-dark);
   }
 }

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -121,6 +121,6 @@
   line-height: 1.1em;
   small {
     display: block;
-    color: var(--global-color-primary--xx-dark);
+    color: var(--global-color-primary--dark);
   }
 }


### PR DESCRIPTION
## Overview
Set text color for 'Up to 500mb' to match the text color of the other text in the +Add dropdown menu.


## Related

* [FP-1860](https://jira.tacc.utexas.edu/browse/FP-1860)
* [FP-1082](https://jira.tacc.utexas.edu/browse/FP-1082)
* [FP-1083](https://jira.tacc.utexas.edu/browse/FP-1083)
* [FP-134](https://jira.tacc.utexas.edu/browse/FP-134)


## Changes
Set text color to `var(--global-color-primary--dark)` from `var(--global-color-primary--xx-dark)`


## Testing
1. Click on Data Files, then click on the +Add button.
2. Ensure the text color of 'Up to 500mb' matches the color of the other text in the dropdown menu.

## UI
**Before**
![Screen Shot 2022-10-31 at 9 46 59 AM](https://user-images.githubusercontent.com/79928051/199036459-f873c36a-4129-4d44-aeff-7a41d8a94af5.png)


**After Feedback from Wes & Design on 11/2/22**
![Screen Shot 2022-11-02 at 10 32 09 AM](https://user-images.githubusercontent.com/79928051/199532294-bab4a46c-1add-4e00-8212-dbe6cf32513e.png)


## Notes
**Current state:**
The colors of the button text in the "+ Add" dropdown are specified in `DataFilesSidebar.scss`.

The color of the text "Up to 500mb" is specified in the css class named `.multiline-menu-item-wrapper`. Prior to the change in this PR, the color was set to `var(--global-color-primary--xx-dark)` which is equivalent to `#222222`, as defined in the file color.css.

The color of the remaining button text is specified by the class `.data-files-sidebar .dropdown-item`. Its color is set to `#707070` which is equivalent to `var(--global-color-primary--dark)`.

**History:**
The color attribute in `.multiline-menu-item-wrapper`, which specifies the color of the text "Up to 500mb",  was last modified in PR: [FP-1082/FP-1083: Fix Color Contrast of Accent Color & Body Text](https://github.com/TACC/Core-Portal/pull/452), merged into main on 9/20/21, with the intent of improving color contrast for link and body text. The color was made darker, with the color attribute being changed from `#484848` to `var(--global-color-primary--xx-dark)` which is equivalent to `#222222`. Prior to this PR, the color had remained as `#484848` since 5/1/20, when `.multiline-menu-item-wrapper` was first defined along with the text "Up to 500mb" in PR: [Task/fp 134 Data Files +Add Dropdown Styling Changes](https://github.com/TACC/Core-Portal/pull/8/files)

The color attribute in `.data-files-sidebar .dropdown-item`, which specifies the color of the remaining button text has remained unchanged since at least 5/1/20 when PR: [Task/fp 134 Data Files +Add Dropdown Styling Changes](https://github.com/TACC/Core-Portal/pull/8/files)] was merged into main. It has consistently been set to `#707070` or the equivalent: `var(--global--color-primary--dark)`.

**Summary:**
The text "Up to 500mb" has always been darker than the other text in the dropdown buttons since that text was first written in May of 2020. It was initially set to `#484848`, but was made darker (`#222222`) in a subsequent PR in September of 2021.

The button text in the "+Add" pulldown has always been `#707070`, before and after PR: [FP-1082/FP-1083: Fix Color Contrast of Accent Color & Body Text](https://github.com/TACC/Core-Portal/pull/452). My point is that any color changes beyond what's in the first commit of this PR would be in addition to the review that was done in that PR.
