### PR TITLE
Task/TV3-55: Job (re)submission backend

### DIFF
--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -157,7 +157,7 @@ class JobsView(BaseApiView):
 
                 job = JobSubmission.objects.create(
                     user=request.user,
-                    jobId=data["uuid"]
+                    jobId=data.uuid
                 )
                 job.save()
             elif job_action == 'cancel':

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -145,30 +145,28 @@ class JobsView(BaseApiView):
         )
 
     def post(self, request, *args, **kwargs):
-        agave = request.user.tapis_oauth.client
+        tapis = request.user.tapis_oauth.client
         job_post = json.loads(request.body)
-        job_id = job_post.get('job_id')
+        job_uuid = job_post.get('job_uuid')
         job_action = job_post.get('action')
 
-        if job_id and job_action:
+        if job_uuid and job_action:
             # resubmit job
             if job_action == 'resubmit':
-                METRICS.info("user:{} is resubmitting job id:{}".format(request.user.username, job_id))
+                METRICS.info("user:{} is resubmitting job id:{}".format(request.user.username, job_uuid))
+                data = tapis.jobs.resubmitJob(jobUuid=job_uuid)
             # cancel job / stop job
             else:
-                METRICS.info("user:{} is canceling/stopping job id:{}".format(request.user.username, job_id))
+                METRICS.info("user:{} is canceling/stopping job id:{}".format(request.user.username, job_uuid))
+                data = tapis.jobs.cancelJob(jobUuid=job_uuid)
 
-            data = agave.jobs.manage(jobId=job_id, body={"action": job_action})
-
-            if job_action == 'resubmit':
-                if "id" in data:
-                    job = JobSubmission.objects.create(
-                        user=request.user,
-                        jobId=data["id"]
-                    )
-                    job.save()
-
-            return JsonResponse({"response": data})
+            return JsonResponse(
+                {
+                    'status': 200,
+                    'response': data,
+                },
+                encoder=BaseTapisResultSerializer
+            )
         # submit job
         elif job_post:
             METRICS.info("user:{} is submitting job:{}".format(request.user.username, job_post))
@@ -249,7 +247,7 @@ class JobsView(BaseApiView):
                                       for param in job_post['parameters']
                                       if param in [p['id'] for p in app.parameters]}
 
-            response = agave.jobs.submit(body=job_post)
+            response = tapis.jobs.submit(body=job_post)
 
             if "id" in response:
                 job = JobSubmission.objects.create(

--- a/server/portal/apps/workspace/api/views_unit_test.py
+++ b/server/portal/apps/workspace/api/views_unit_test.py
@@ -86,6 +86,17 @@ def test_job_post_resubmit(client, authenticated_user, get_user_data, mock_tapis
     assert response.json() == {"status": 200, "response": {"uuid": "1234"}}
 
 
+def test_job_post_invalid(client, authenticated_user, get_user_data, mock_tapis_client,
+                          apps_manager, job_submmission_definition):
+    response = client.post(
+        "/api/workspace/jobs",
+        data=json.dumps({"action": "invalid action", "job_uuid": "1234"}),
+        content_type="application/json"
+    )
+    assert response.status_code == 400
+    assert response.json() == {"message": "user:username is trying to run an unsupported job action: invalid action for job uuid: 1234"}
+
+
 def test_job_post_is_logged_for_metrics(client, authenticated_user, get_user_data, mock_tapis_client,
                                         apps_manager, job_submmission_definition, logging_metric_mock):
     mock_tapis_client.jobs.submit.return_value = {"id": "1234"}

--- a/server/portal/apps/workspace/api/views_unit_test.py
+++ b/server/portal/apps/workspace/api/views_unit_test.py
@@ -49,7 +49,7 @@ def logging_metric_mock(mocker):
 @pytest.mark.skip(reason="job post not implemented yet")
 def test_job_post(client, authenticated_user, get_user_data, mock_tapis_client,
                   apps_manager, job_submmission_definition):
-    mock_tapis_client.jobs.submit.return_value = {"id": "1234"}
+    mock_tapis_client.jobs.resubmitJob.return_value = {"uuid": "1234"}
 
     response = client.post(
         "/api/workspace/jobs",
@@ -57,11 +57,33 @@ def test_job_post(client, authenticated_user, get_user_data, mock_tapis_client,
         content_type="application/json"
     )
     assert response.status_code == 200
-    assert response.json() == {"response": {"id": "1234"}}
+    assert response.json() == {"response": {"uuid": "1234"}}
 
-    # The job submission request
-    job = JobSubmission.objects.all()[0]
-    assert job.jobId == "1234"
+
+def test_job_post_cancel(client, authenticated_user, get_user_data, mock_tapis_client,
+                         apps_manager, job_submmission_definition):
+    mock_tapis_client.jobs.cancelJob.return_value = {"uuid": "1234"}
+
+    response = client.post(
+        "/api/workspace/jobs",
+        data=json.dumps({"action": "cancel", "job_uuid": "1234"}),
+        content_type="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": 200, "response": {"uuid": "1234"}}
+
+
+def test_job_post_resubmit(client, authenticated_user, get_user_data, mock_tapis_client,
+                           apps_manager, job_submmission_definition):
+    mock_tapis_client.jobs.resubmitJob.return_value = {"uuid": "1234"}
+
+    response = client.post(
+        "/api/workspace/jobs",
+        data=json.dumps({"action": "resubmit", "job_uuid": "1234"}),
+        content_type="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": 200, "response": {"uuid": "1234"}}
 
 
 def test_job_post_is_logged_for_metrics(client, authenticated_user, get_user_data, mock_tapis_client,

--- a/server/portal/apps/workspace/api/views_unit_test.py
+++ b/server/portal/apps/workspace/api/views_unit_test.py
@@ -49,7 +49,9 @@ def logging_metric_mock(mocker):
 @pytest.mark.skip(reason="job post not implemented yet")
 def test_job_post(client, authenticated_user, get_user_data, mock_tapis_client,
                   apps_manager, job_submmission_definition):
-    mock_tapis_client.jobs.resubmitJob.return_value = {"uuid": "1234"}
+    mock_tapis_client.jobs.resubmitJob.return_value = TapisResult(**{
+        'uuid': '1234',
+    })
 
     response = client.post(
         "/api/workspace/jobs",
@@ -62,7 +64,9 @@ def test_job_post(client, authenticated_user, get_user_data, mock_tapis_client,
 
 def test_job_post_cancel(client, authenticated_user, get_user_data, mock_tapis_client,
                          apps_manager, job_submmission_definition):
-    mock_tapis_client.jobs.cancelJob.return_value = {"uuid": "1234"}
+    mock_tapis_client.jobs.cancelJob.return_value = TapisResult(**{
+        'uuid': '1234',
+    })
 
     response = client.post(
         "/api/workspace/jobs",
@@ -75,7 +79,9 @@ def test_job_post_cancel(client, authenticated_user, get_user_data, mock_tapis_c
 
 def test_job_post_resubmit(client, authenticated_user, get_user_data, mock_tapis_client,
                            apps_manager, job_submmission_definition):
-    mock_tapis_client.jobs.resubmitJob.return_value = {"uuid": "1234"}
+    mock_tapis_client.jobs.resubmitJob.return_value = TapisResult(**{
+        'uuid': '1234',
+    })
 
     response = client.post(
         "/api/workspace/jobs",


### PR DESCRIPTION
## Overview
Implements job re-submission/cancel behavior in backend ([which was implemented in the frontend with the job listing PR](https://github.com/TACC/Core-Portal/blob/21dbf74c976dfa3eff61f690ffe10c6961f0955d/client/src/components/History/HistoryViews/JobHistoryModal.jsx#L92)).
Job submission through the app form is related to #730 I think, which is what Nathan is working on.

## Related

* [TV3-55](https://jira.tacc.utexas.edu/browse/TV3-55)

## Changes
Modify job resubmit/cancel in the backend.

## Testing
1. Go to history section (https://cep.test/workbench/history/jobs).
2. Click on "View Details" for a job. (assuming that there are jobs run previously)
3. Click on "Resubmit Job".
4. Ensure that the job resubmits correctly.

## Notes
I've removed the use of `JobSubmission` when resubmitting a job assuming that the tag information (including portal information) is copied over in Tapis V3 when resubmitting a job.