### PR TITLE
task/FP 1943 Remove retired Longhorn from system monitor

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsRequestModal/AllocationsRequestModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsRequestModal/AllocationsRequestModal.jsx
@@ -14,7 +14,7 @@ export const AllocationsRequestModal = ({ isOpen, toggle }) => (
     </ModalHeader>
     <ModalBody className={styles['modal-body']}>
       <p>
-        <strong>For Frontera or Longhorn:</strong> You can manage your
+        <strong>For Frontera:</strong> You can manage your
         allocation or request more time on a machine by using your TACC user
         account credentials to access the Resource Allocation System at&nbsp;
         <a

--- a/client/src/components/Allocations/AllocationsModals/AllocationsRequestModal/AllocationsRequestModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsRequestModal/AllocationsRequestModal.jsx
@@ -14,9 +14,9 @@ export const AllocationsRequestModal = ({ isOpen, toggle }) => (
     </ModalHeader>
     <ModalBody className={styles['modal-body']}>
       <p>
-        <strong>For Frontera:</strong> You can manage your
-        allocation or request more time on a machine by using your TACC user
-        account credentials to access the Resource Allocation System at&nbsp;
+        <strong>For Frontera:</strong> You can manage your allocation or request
+        more time on a machine by using your TACC user account credentials to
+        access the Resource Allocation System at&nbsp;
         <a
           href="https://submit-tacc.xras.org/"
           target="_blank"

--- a/server/portal/fixtures/system_monitor/index.json
+++ b/server/portal/fixtures/system_monitor/index.json
@@ -1,20 +1,4 @@
 {
-  "Longhorn": {
-    "display_name": "Longhorn",
-    "tas_name": "longhorn3",
-    "hostname": "longhorn.tacc.utexas.edu",
-    "system_type": "COMPUTE",
-    "timestamp": "2022-11-07T14:30:02.709924+00:00",
-    "online": true,
-    "reachable": true,
-    "queues_down": false,
-    "load": 0.5865,
-    "running": 13,
-    "queued": 6,
-    "in_maintenance": false,
-    "next_maintenance": null,
-    "reservations": []
-  },
   "Stampede2": {
     "display_name": "Stampede2",
     "tas_name": "stampede4",

--- a/server/portal/fixtures/system_monitor/index_frontera_not_running.json
+++ b/server/portal/fixtures/system_monitor/index_frontera_not_running.json
@@ -1,20 +1,4 @@
 {
-  "Longhorn": {
-    "display_name": "Longhorn",
-    "tas_name": "longhorn3",
-    "hostname": "longhorn.tacc.utexas.edu",
-    "system_type": "COMPUTE",
-    "timestamp": "2022-11-07T14:30:02.709924+00:00",
-    "online": true,
-    "reachable": true,
-    "queues_down": false,
-    "load": 0.5865,
-    "running": 13,
-    "queued": 6,
-    "in_maintenance": false,
-    "next_maintenance": null,
-    "reservations": []
-  },
   "Stampede2": {
     "display_name": "Stampede2",
     "tas_name": "stampede4",

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -89,18 +89,6 @@ _PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'icon': None,
         'hidden': False,
     },
-    'longhorn': {
-        'name': 'My Data (Longhorn)',
-        'description': 'My Data on Longhorn for {username}',
-        'site': 'cep',
-        'systemId': 'longhorn.home.{username}',
-        'host': 'longhorn.tacc.utexas.edu',
-        'rootDir': '/home/{tasdir}',
-        'port': 22,
-        'requires_allocation': 'longhorn3',
-        'icon': None,
-        'hidden': False,
-    }
 }
 
 _PORTAL_DATAFILES_STORAGE_SYSTEMS = [

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -21,8 +21,7 @@ _WH_BASE_URL = ''
 _LOGIN_REDIRECT_URL = '/remote/login/'
 _LOGOUT_REDIRECT_URL = '/cms/logout/'
 
-_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Longhorn',
-                                'Lonestar6', 'Frontera', 'Maverick2']
+_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera', 'Maverick2']
 
 ########################
 # DJANGO SETTINGS LOCAL

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -86,17 +86,6 @@ _PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
         'rootDir': '/home1/{tasdir}',
         'port': 22,
         'icon': None,
-    },
-    'longhorn': {
-        'name': 'My Data (Longhorn)',
-        'description': 'My Data on Longhorn for {username}',
-        'site': 'cep',
-        'systemId': 'longhorn.home.{username}',
-        'host': 'longhorn.tacc.utexas.edu',
-        'rootDir': '/home/{tasdir}',
-        'port': 22,
-        'requires_allocation': 'longhorn3',
-        'icon': None,
     }
 }
 

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -21,8 +21,7 @@ _WH_BASE_URL = ''
 _LOGIN_REDIRECT_URL = '/remote/login/'
 _LOGOUT_REDIRECT_URL = '/cms/logout/'
 
-_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Longhorn',
-                                'Lonestar6', 'Frontera', 'Maverick2']
+_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera', 'Maverick2']
 
 ########################
 # DJANGO SETTINGS LOCAL


### PR DESCRIPTION
## Overview

Removed Longhorn from system monitor, data files, and app input

## Related

* [FP-1943](https://jira.tacc.utexas.edu/browse/FP-1943)

## Changes

- Removed Longhorn from system monitor display list in settings 

- Updated system monitor fixtures removing Longhorn


## Testing

1. [Go to cep.test/workbench/dashboard](https://cep.test/workbench/dashboard)
2. Check that the system monitor no longer displays Longhorn
3. Go to Applications
4. Select an app
5. Under Inputs, click the Select button under Input Directory and make sure My Data (Longhorn) is not in the drop down
6. Go to Data Files
7. Make sure My Data (Longhorn) is no longer displayed
8. Go to Allocations
9. Click Request New Allocation
10. Check the the first line says For Frontera: not For Frontera or Longhorn:

## UI
Dashboard
<img width="1777" alt="Screen Shot 2022-11-30 at 9 46 49 AM" src="https://user-images.githubusercontent.com/96220951/204843748-c315cb90-101c-49e2-a865-96c5de58f8c0.png">


Data Files
<img width="1772" alt="Screen Shot 2022-11-30 at 10 26 26 AM" src="https://user-images.githubusercontent.com/96220951/204853377-ddcaa135-c95c-4597-ab83-1c550db3af6b.png">


Applications
<img width="1744" alt="Screen Shot 2022-11-30 at 10 26 00 AM" src="https://user-images.githubusercontent.com/96220951/204853287-44182dd9-711b-4f32-bd14-6568bc5ecb8a.png">

Allocations
<img width="1759" alt="Screen Shot 2022-11-30 at 11 23 28 AM" src="https://user-images.githubusercontent.com/96220951/204865792-c908b569-88c7-4d39-bdc0-6bb41aa0c057.png">


## Notes

