### PR TITLE
feat(server): fp-1952 tighter ES network settings

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -43,8 +43,9 @@ services:
       - ../elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - core_portal_es_data:/usr/share/elasticsearch/data
     container_name: core_portal_elasticsearch
-    ports:
-      - 9200:9200
+    # To enable debugging of Elasticsearch outside containers, set ports
+    # ports:
+    #   - 9200:9200
 
   postgres:
     image: postgres:11.5

--- a/server/conf/elasticsearch/elasticsearch.sample.yml
+++ b/server/conf/elasticsearch/elasticsearch.sample.yml
@@ -3,7 +3,7 @@
 #More info: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
 #
 cluster.name: es-dev
-network.host: 0.0.0.0
+network.host: _local_
 #network.publish_host: hostname
 node.name: es01
 discovery.zen.ping.unicast.hosts: ["es02"]

--- a/server/conf/elasticsearch/elasticsearch.yml
+++ b/server/conf/elasticsearch/elasticsearch.yml
@@ -3,7 +3,7 @@
 #More info: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
 #
 cluster.name: es-dev
-network.host: 0.0.0.0
+network.host: _local_
 #network.publish_host: hostname
 node.name: es01
 #minimum_master_nodes need to be explicitly set when bound on a public IP


### PR DESCRIPTION
## Overview

Use Elasticsearch network settings that are less likely to limit exposure of the software on the network.

## Related

* [FP-1952](https://jira.tacc.utexas.edu/browse/FP-1952)

## Changes

- comment out debug settings
- limit network to only localhost

## Testing

1. Run development environment using these new settings.
2. Test that Elasticsearch still works:
    1. Add a CMS page **and** confirm re-index occurs.[^1]
    2. Publish a CMS page **and** confirm re-index occurs.[^1]
    3. Delete a CMS page **and** confirm re-index occurs.[^1]
    4. Add text to a CMS page and verify page appears in a search.

## UI

...

[^1]: You can check container logs for a message saying that re-index has occurred.