### PR TITLE
Hotfix: Update CMS configurations

### DIFF
--- a/server/conf/cms/secrets.sample.py
+++ b/server/conf/cms/secrets.sample.py
@@ -3,33 +3,7 @@
 ########################
 
 SECRET_KEY = 'replacethiswithareallysecureandcomplexsecretkeystring'
-DEBUG = False
-
-ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']
-
-LDAP_ENABLED = False
-
-########################
-# DATABASE SETTINGS
-########################
-
-DATABASES = {
-   'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'PORT': '5432',
-        'NAME': 'taccsite',
-        'USER': 'postgresadmin',
-        'PASSWORD': 'taccforever',  # Change before live deployment.
-        'HOST': 'core_cms_postgres'
-    }
-}
-
-########################
-# GOOGLE ANALYTICS
-########################
-
-GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-123ABC@%$&-#'
-GOOGLE_ANALYTICS_PRELOAD = True
+LOGIN_REDIRECT_URL = '/workbench/dashboard/'
 
 ########################
 # ELASTICSEARCH
@@ -38,16 +12,32 @@ GOOGLE_ANALYTICS_PRELOAD = True
 ES_AUTH = 'username:password'
 ES_HOSTS = 'http://elasticsearch:9200'
 ES_INDEX_PREFIX = 'cep-dev-{}'
-ES_DOMAIN = 'http://localhost:8000'
+ES_DOMAIN = 'https://cep.test'
 
 es_engine = 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine'
 HAYSTACK_CONNECTIONS = {
-  'default': {
-    'ENGINE': es_engine,
-    'URL': ES_HOSTS,
-    'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
-    'KWARGS': {'http_auth': ES_AUTH}
-  }
+    'default': {
+        'ENGINE': es_engine,
+        'URL': ES_HOSTS,
+        'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
+        'KWARGS': {'http_auth': ES_AUTH}
+    }
 }
 
+########################
+# RECAPTCHA SETTINGS
+########################
+
+RECAPTCHA_PUBLIC_KEY = ''
+RECAPTCHA_PRIVATE_KEY = ''
 SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+
+########################
+# REDMINE TRACKER AUTH
+########################
+
+RT_HOST = ''
+RT_UN = ''
+RT_PW = ''
+RT_QUEUE = ''
+RT_TAG = ''

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   cms:
-    image: taccwma/core-cms:latest
+    image: taccwma/core-cms:ff737a3
     volumes:
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini


### PR DESCRIPTION
## Overview

After #752, the CMS index links no longer routed correctly (or maybe they never did). This PR fixes that issue, as well as updates/simplifies the CMS settings and pins the CMS version.

## Changes
- Pin CMS version to v3.9.1 (latest versioned release), to prevent breaking changes in the `latest` tag from affecting local Core Portal development.
- Fix the `ES_DOMAIN` setting in `secrets.sample.py`
- Simplify local CMS settings in `secrets.sample.py` by leveraging defaults in the Core-CMS `settings.py`

## Testing

1. Make sure all containers are not running
2. Update the `secrets.py` file for local CMS: `cp server/conf/cms/secrets.sample.py server/conf/cms/secrets.py`
3. Run `docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml pull cms`
4. Run migrations in the `core_portal_cms` container
5. Make sure you have at least 1 cms page published with text, e.g. a homepage with the text "Test" on the page
6. Search "Test" in the searchbar and confirm you get a result for a CMS page
7. Click the link in the CMS page and confirm it takes you to the correct page

