### PR TITLE
task/FP-1986: Restrict APCD submissions access

### DIFF
--- a/client/src/components/Submissions/Submissions.jsx
+++ b/client/src/components/Submissions/Submissions.jsx
@@ -11,7 +11,7 @@ import styles from './Submissions.module.scss';
 import { fetchUtil } from 'utils/fetchUtil';
 import * as ROUTES from '../../constants/routes';
 
-const SubmissionsUpload = () => {
+export const SubmissionsUpload = () => {
   const history = useHistory();
   const location = useLocation();
   const reloadCallback = () => {

--- a/client/src/components/Submissions/Submissions.jsx
+++ b/client/src/components/Submissions/Submissions.jsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { useHistory, useLocation, Link } from 'react-router-dom';
+import { useQuery } from 'react-query';
 import { v4 as uuidv4 } from 'uuid';
 import { Button } from '_common';
-import { FileInputDropZone, Section } from '_common';
+import { FileInputDropZone, Section, LoadingSpinner } from '_common';
 import { useSystems } from 'hooks/datafiles';
 import { useUpload } from 'hooks/datafiles/mutations';
 import DataFilesUploadModalListingTable from '../DataFiles/DataFilesModals/DataFilesUploadModalListing/DataFilesUploadModalListingTable.jsx';
 import styles from './Submissions.module.scss';
+import { fetchUtil } from 'utils/fetchUtil';
+import * as ROUTES from '../../constants/routes';
 
 const SubmissionsUpload = () => {
   const history = useHistory();
@@ -120,6 +123,43 @@ const SubmissionsUpload = () => {
 };
 
 const Submissions = () => {
+  const getSubmitterRole = async () => {
+    const response = await fetchUtil({
+      url: '/submissions/check-submitter-role/',
+    });
+    return response;
+  };
+
+  const useSubmitterRole = () => {
+    const query = useQuery('submitter-role', getSubmitterRole);
+    return query;
+  };
+
+  const {
+    data: { is_submitter },
+    isLoading,
+  } = useSubmitterRole();
+
+  const Unauthorized = () => (
+    <>
+      <h2>
+        You are not currently authorized for uploads. Please contact the UT
+        Health office or{' '}
+        <Link
+          className="wb-link"
+          to={`${ROUTES.WORKBENCH}${ROUTES.DASHBOARD}${ROUTES.TICKETS}/create`}
+        >
+          submit a ticket.
+        </Link>
+      </h2>
+    </>
+  );
+
+  let contentClassName = '';
+  if (!is_submitter) {
+    contentClassName = styles['center'];
+  }
+
   return (
     <Section
       bodyClassName="has-loaded-dashboard"
@@ -127,7 +167,16 @@ const Submissions = () => {
       header="Data Submission"
       contentLayoutName="oneColumn"
       contentShouldScroll
-      content={<SubmissionsUpload />}
+      contentClassName={contentClassName}
+      content={
+        isLoading ? (
+          <LoadingSpinner />
+        ) : is_submitter ? (
+          <SubmissionsUpload />
+        ) : (
+          <Unauthorized />
+        )
+      }
     />
   );
 };

--- a/client/src/components/Submissions/Submissions.jsx
+++ b/client/src/components/Submissions/Submissions.jsx
@@ -135,10 +135,9 @@ const Submissions = () => {
     return query;
   };
 
-  const {
-    data: { is_submitter },
-    isLoading,
-  } = useSubmitterRole();
+  const { data, isLoading } = useSubmitterRole();
+
+  const is_submitter = data?.is_submitter;
 
   const Unauthorized = () => (
     <>

--- a/client/src/components/Submissions/Submissions.module.scss
+++ b/client/src/components/Submissions/Submissions.module.scss
@@ -22,3 +22,8 @@
   margin-top: 10px;
   font-size: 20px;
 }
+
+.center {
+  align-items: center;
+  justify-content: center;
+}

--- a/client/src/components/Submissions/Submissions.test.js
+++ b/client/src/components/Submissions/Submissions.test.js
@@ -1,12 +1,34 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
+import fetchMock from 'fetch-mock';
 import renderComponent from 'utils/testing';
 import systemsFixture from '../DataFiles/fixtures/DataFiles.systems.fixture';
-import Submissions from './Submissions';
+import Submissions, { SubmissionsUpload } from './Submissions';
 
 const mockStore = configureStore();
 
 describe('Submissions', () => {
+  it('prevent SubmissionsUpload component from rendering', () => {
+    fetchMock.mock('http://localhost/submissions/check-submitter-role/', {
+      is_submitter: false,
+    });
+    const store = mockStore({
+      systems: systemsFixture,
+      files: {
+        operationStatus: { upload: true },
+      },
+    });
+    const { getAllByText, queryByText } = renderComponent(
+      <Submissions />,
+      store
+    );
+    expect(getAllByText(/Data Submission/)).toBeDefined();
+    expect(queryByText(/Max File Size: 2GB/)).toBeNull();
+    fetchMock.restore();
+  });
+});
+
+describe('SubmissionsUpload', () => {
   it('renders the submissions page and displays the max file size', () => {
     const store = mockStore({
       systems: systemsFixture,
@@ -14,8 +36,10 @@ describe('Submissions', () => {
         operationStatus: { upload: true },
       },
     });
-    const { getAllByText } = renderComponent(<Submissions />, store);
-    expect(getAllByText(/Data Submission/)).toBeDefined();
-    expect(getAllByText(/Max File Size: 2GB/)).toBeDefined();
+    const { getAllByText, queryByText } = renderComponent(
+      <SubmissionsUpload />,
+      store
+    );
+    expect(queryByText(/Max File Size: 2GB/)).toBeDefined();
   });
 });

--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -115,9 +115,10 @@ function Workbench() {
                   />
                 )}
                 {showSubmissions && (
-                  <Route path={`${path}${ROUTES.SUBMISSIONS}`}>
-                    <Submissions />
-                  </Route>
+                  <Route
+                    path={`${path}${ROUTES.SUBMISSIONS}`}
+                    component={Submissions}
+                  />
                 )}
                 {!hideApps && (
                   <Route

--- a/client/src/components/Workbench/WorkbenchSidebar/WorkbenchSidebar.jsx
+++ b/client/src/components/Workbench/WorkbenchSidebar/WorkbenchSidebar.jsx
@@ -18,9 +18,6 @@ const WorkbenchSidebar = ({ disabled, showUIPatterns, loading }) => {
   const hideDataFiles = useSelector(
     (state) => state.workbench.config.hideDataFiles
   );
-  const showSubmissions = useSelector(
-    (state) => state.workbench.config.showSubmissions
-  );
   const hideAllocations = useSelector(
     (state) => state.workbench.config.hideAllocations
   );


### PR DESCRIPTION
## Overview

Call the `/submissions/check-submitter-role/` endpoint to determine if active user has permissions to view the Submissions component.

## Related

* [FP-1986](https://jira.tacc.utexas.edu/browse/FP-1986)
* https://github.com/TACC/Core-CMS-Custom/pull/118

## Testing

1. Go to https://apcd-qa.tacc.utexas.edu/workbench/data-submission/
  a. If you have a role in `['APCD_ADMIN', 'SUBMITTER_ADMIN', 'SUBMITTER_USER']`, you should be able to access the Submissions component and submit a file.
  b. If you don't have a role in `['APCD_ADMIN', 'SUBMITTER_ADMIN', 'SUBMITTER_USER']`, then you should not be able to access the Submissions component, and instead see the screenshot below.

## UI
![Screen Shot 2023-02-22 at 10 35 18 PM](https://user-images.githubusercontent.com/20326896/221024630-c8b458c6-8716-4687-a357-1d8dca5f8009.png)

