### PR TITLE
Quick: Fix datafiles paths in modals

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.jsx
@@ -69,7 +69,7 @@ const DataFilesShowPathModal = React.memo(() => {
             {params.api === 'tapis' && definition && (
               <>
                 <dt>Storage Host</dt>
-                <dd>{definition.storage.host}</dd>
+                <dd>{definition.host}</dd>
                 <dt>Storage Path</dt>
               </>
             )}
@@ -81,7 +81,7 @@ const DataFilesShowPathModal = React.memo(() => {
             )}
             <dd>
               <TextCopyField
-                value={`${definition.storage.rootDir}${file.path}`}
+                value={`${definition.rootDir}/${file.path}`.replace('//', '/')}
               />
             </dd>
           </dl>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.jsx
@@ -130,7 +130,10 @@ const DataFilesUploadModal = ({ className, layout }) => {
         {showListing && (
           <div className={styles.listing}>
             <span className={styles['listing-header']}>
-              Uploading to {systemDisplayName}/{params.path}
+              {`Uploading to ${systemDisplayName}/${params.path}`.replace(
+                '//',
+                '/'
+              )}
             </span>
             <DataFilesUploadModalListingTable
               uploadedFiles={uploadedFiles}

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
@@ -56,7 +56,8 @@ const DataFilesToolbar = ({ scheme, api }) => {
 
   const inTrash = useSelector((state) => {
     // remove leading slash from homeDir value
-    const homeDir = selectedSystem?.homeDir.slice(1);
+    const homeDir = selectedSystem?.homeDir?.slice(1);
+    if (!homeDir) return false;
 
     return state.files.params.FilesListing.path.startsWith(
       `${homeDir}/${state.workbench.config.trashPath}`


### PR DESCRIPTION
## Overview
- Fixes an error where the Google Drive system would fail to render in datafiles
- Fixes paths in the upload and view path modals

## Testing

1. Confirm you can go to https://cep.test/workbench/data/googledrive/private/googledrive/ without the UI breaking
2. Confirm the View Path modals show correct values for all tapis systems
3. Confirm the Upload modal shows the correct paths
