### PR TITLE
bug/TV3-154: Treat `500` errors from file listings as need for keys

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
@@ -191,14 +191,14 @@ describe('DataFilesListing', () => {
   });
 
   it.each([
-    ['500', /There was a problem accessing this file system./, 'private'],
+    ['503', /There was a problem accessing this file system./, 'private'],
     [
-      '502',
+      '500',
       /An error occurred loading this directory. For help, please submit/,
       'public',
     ],
     [
-      '502',
+      '500',
       /There was a problem accessing this file system. If this is your/,
       'private',
     ],

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -94,7 +94,7 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
         .
       </>
     );
-    if (err === '502') {
+    if (err === '500') {
       if (downSystems.includes(currSystemHost)) {
         return (
           <div className="h-100 listing-placeholder">

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -11,7 +11,7 @@ import { useTable, useBlockLayout } from 'react-table';
 import { FixedSizeList, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Link } from 'react-router-dom';
-import { useSelectedFiles, useFileListing } from 'hooks/datafiles';
+import { useFileListing } from 'hooks/datafiles';
 import { LoadingSpinner, SectionMessage } from '_common';
 import './DataFilesTable.scss';
 import styles from './DataFilesTable.module.scss';

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.js
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.js
@@ -89,13 +89,13 @@ describe('DataFilesTable', () => {
     expect(getByText(/^Path/)).toBeDefined();
   });
 
-  it('should display an error for 502', async () => {
+  it('should display an error for 500', async () => {
     const storeWithError = mockStore({
       ...initialMockState,
       files: {
         ...initialMockState.files,
         error: {
-          FilesListing: '502',
+          FilesListing: '500',
         },
         params: {
           FilesListing: {
@@ -278,7 +278,7 @@ describe('DataFilesTable', () => {
       files: {
         ...initialMockState.files,
         error: {
-          FilesListing: '502',
+          FilesListing: '500',
         },
         params: {
           FilesListing: {

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -167,8 +167,8 @@ export function* fetchFiles(action) {
         code: e.status ? e.status.toString() : '503',
       },
     });
-    // If listing returns 502, body should contain a system def for key pushing.
-    yield e.status === 502 &&
+    // If listing returns 500, body should contain a system def for key pushing.
+    yield e.status === 500 &&
       put({
         type: 'SET_SYSTEM',
         payload: {

--- a/server/portal/apps/accounts/managers/accounts.py
+++ b/server/portal/apps/accounts/managers/accounts.py
@@ -192,6 +192,6 @@ def add_pub_key_to_resource(
         ) as exc:
             # cannot ssh to system
             message = str(type(exc))  # paramiko exceptions do not contain a string message?
-            status = 502  # Bad gateway
+            status = 500  # Bad gateway
 
     return success, message, status

--- a/server/portal/apps/accounts/managers/unit_test.py
+++ b/server/portal/apps/accounts/managers/unit_test.py
@@ -56,7 +56,7 @@ def test_channel_exception(user_with_keys, mock_lookup_keys_manager):
     mock_lookup_keys_manager.return_value.add_public_key = MagicMock(side_effect=ChannelException(999, "Mock Channel Exception"))
     result, message, status = _run_add_pub_key_to_resource(user_with_keys)
     assert result is False
-    assert status == 502
+    assert status == 500
 
 
 # SSHException occurs when paramiko is unable to open SSH connection to server
@@ -64,7 +64,7 @@ def test_ssh_exception(user_with_keys, mock_lookup_keys_manager):
     mock_lookup_keys_manager.return_value.add_public_key = MagicMock(side_effect=SSHException())
     result, message, status = _run_add_pub_key_to_resource(user_with_keys)
     assert result is False
-    assert status == 502
+    assert status == 500
 
 
 # KeyCannotBeAdded exception occurs when authorized_keys file cannot be modified

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -103,9 +103,9 @@ class TapisFilesView(BaseApiView):
             error_status = e.response.status_code
             error_json = e.response.json()
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
-            if error_status == 502:
-                # In case of 502 determine cause
-                system = dict(client.systems.get(systemId=system))
+            if error_status == 500:
+                # In case of 500 determine cause
+                system = client.systems.getSystem(systemId=system)
                 allocations = get_allocations(request.user.username)
 
                 # If user is missing a non-corral allocation mangle error to a 403

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -4,6 +4,7 @@ from portal.apps.users.utils import get_allocations
 from django.conf import settings
 from django.http import JsonResponse, HttpResponseForbidden
 from requests.exceptions import HTTPError
+from tapipy.errors import InternalServerError
 from portal.views.base import BaseApiView
 from portal.libs.agave.utils import service_account
 from portal.apps.datafiles.handlers.tapis_handlers import (tapis_get_handler,
@@ -99,24 +100,25 @@ class TapisFilesView(BaseApiView):
 
             operation in NOTIFY_ACTIONS and \
                 notify(request.user.username, operation, 'success', {'response': response})
-        except HTTPError as e:
+        except InternalServerError as e:
             error_status = e.response.status_code
             error_json = e.response.json()
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             if error_status == 500:
+                logger.info(e)
                 # In case of 500 determine cause
                 system = client.systems.getSystem(systemId=system)
                 allocations = get_allocations(request.user.username)
 
                 # If user is missing a non-corral allocation mangle error to a 403
-                if not any(system['storage']['host'].endswith(ele) for ele in
+                if not any(system.host.endswith(ele) for ele in
                            list(allocations['hosts'].keys()) + ['cloud.corral.tacc.utexas.edu', 'data.tacc.utexas.edu']):
                     e.response.status_code = 403
                     raise e
 
                 # If a user needs to push keys, return a response specifying the system
                 error_json['system'] = system
-                return JsonResponse(error_json, status=error_status)
+                return JsonResponse(error_json, status=error_status, encoder=BaseTapisResultSerializer)
             raise e
 
         return JsonResponse({'data': response})

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -18,6 +18,7 @@ from portal.libs.agave.serializers import BaseTapisResultSerializer
 from portal.exceptions.api import ApiException
 from portal.apps.datafiles.models import Link
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.utils.decorators import method_decorator
 from portal.apps.users.utils import get_user_data
 from .utils import notify, NOTIFY_ACTIONS
@@ -113,8 +114,7 @@ class TapisFilesView(BaseApiView):
                 # If user is missing a non-corral allocation mangle error to a 403
                 if not any(system.host.endswith(ele) for ele in
                            list(allocations['hosts'].keys()) + ['cloud.corral.tacc.utexas.edu', 'data.tacc.utexas.edu']):
-                    e.response.status_code = 403
-                    raise e
+                    raise PermissionDenied
 
                 # If a user needs to push keys, return a response specifying the system
                 error_json['system'] = system

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from mock import MagicMock
-from requests.exceptions import HTTPError
+from tapipy.errors import InternalServerError
 from portal.apps.datafiles.models import Link
 from django.conf import settings
 from tapipy.tapis import TapisResult
@@ -32,7 +32,7 @@ def get_user_data(mocker):
 
 def test_get_no_allocation(client, authenticated_user, mocker, monkeypatch, mock_tapis_client):
     mock_tapis_get = mocker.patch('portal.apps.datafiles.views.tapis_get_handler')
-    mock_error = HTTPError()
+    mock_error = InternalServerError()
     monkeypatch.setattr(
         mock_error, 'response', MagicMock(
             json=MagicMock(return_value={}),
@@ -46,11 +46,7 @@ def test_get_no_allocation(client, authenticated_user, mocker, monkeypatch, mock
         'hosts': {}
     }
 
-    mock_tapis_client.systems.get.return_value = {
-        'storage': {
-            'host': 'frontera.tacc.utexas.edu'
-        }
-    }
+    mock_tapis_client.systems.getSystem.return_value = TapisResult(host='frontera.tacc.utexas.edu')
 
     response = client.get('/api/datafiles/tapis/listing/private/frontera.home.username/')
     assert response.status_code == 403
@@ -58,7 +54,7 @@ def test_get_no_allocation(client, authenticated_user, mocker, monkeypatch, mock
 
 def test_ignore_missing_corral(client, authenticated_user, mocker, monkeypatch, mock_tapis_client):
     mock_tapis_get = mocker.patch('portal.apps.datafiles.views.tapis_get_handler')
-    mock_error = HTTPError()
+    mock_error = InternalServerError()
     monkeypatch.setattr(
         mock_error, 'response', MagicMock(
             json=MagicMock(return_value={}),
@@ -72,11 +68,7 @@ def test_ignore_missing_corral(client, authenticated_user, mocker, monkeypatch, 
         'hosts': {}
     }
 
-    mock_tapis_client.systems.get.return_value = {
-        'storage': {
-            'host': 'data.tacc.utexas.edu'
-        }
-    }
+    mock_tapis_client.systems.getSystem.return_value = TapisResult(host='data.tacc.utexas.edu')
 
     response = client.get('/api/datafiles/tapis/listing/private/corral.home.username/')
     assert response.status_code == 500
@@ -84,7 +76,7 @@ def test_ignore_missing_corral(client, authenticated_user, mocker, monkeypatch, 
 
 def test_get_requires_push_keys(client, authenticated_user, mocker, monkeypatch, mock_tapis_client):
     mock_tapis_get = mocker.patch('portal.apps.datafiles.views.tapis_get_handler')
-    mock_error = HTTPError()
+    mock_error = InternalServerError()
     monkeypatch.setattr(
         mock_error, 'response', MagicMock(
             json=MagicMock(return_value={}),
@@ -99,12 +91,10 @@ def test_get_requires_push_keys(client, authenticated_user, mocker, monkeypatch,
     }
 
     system = {
-        'storage': {
-            'host': 'frontera.tacc.utexas.edu'
-        }
+        'host': 'frontera.tacc.utexas.edu'
     }
 
-    mock_tapis_client.systems.get.return_value = system
+    mock_tapis_client.systems.getSystem.return_value = TapisResult(**system)
 
     response = client.get('/api/datafiles/tapis/listing/private/frontera.home.username/')
     assert response.status_code == 500

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -36,7 +36,7 @@ def test_get_no_allocation(client, authenticated_user, mocker, monkeypatch, mock
     monkeypatch.setattr(
         mock_error, 'response', MagicMock(
             json=MagicMock(return_value={}),
-            status_code=502
+            status_code=500
         )
     )
     mock_tapis_get.side_effect = mock_error
@@ -62,7 +62,7 @@ def test_ignore_missing_corral(client, authenticated_user, mocker, monkeypatch, 
     monkeypatch.setattr(
         mock_error, 'response', MagicMock(
             json=MagicMock(return_value={}),
-            status_code=502
+            status_code=500
         )
     )
     mock_tapis_get.side_effect = mock_error
@@ -79,7 +79,7 @@ def test_ignore_missing_corral(client, authenticated_user, mocker, monkeypatch, 
     }
 
     response = client.get('/api/datafiles/tapis/listing/private/corral.home.username/')
-    assert response.status_code == 502
+    assert response.status_code == 500
 
 
 def test_get_requires_push_keys(client, authenticated_user, mocker, monkeypatch, mock_tapis_client):
@@ -88,7 +88,7 @@ def test_get_requires_push_keys(client, authenticated_user, mocker, monkeypatch,
     monkeypatch.setattr(
         mock_error, 'response', MagicMock(
             json=MagicMock(return_value={}),
-            status_code=502
+            status_code=500
         )
     )
     mock_tapis_get.side_effect = mock_error
@@ -107,7 +107,7 @@ def test_get_requires_push_keys(client, authenticated_user, mocker, monkeypatch,
     mock_tapis_client.systems.get.return_value = system
 
     response = client.get('/api/datafiles/tapis/listing/private/frontera.home.username/')
-    assert response.status_code == 502
+    assert response.status_code == 500
     assert response.json() == {'system': system}
 
 

--- a/server/portal/libs/agave/utils.py
+++ b/server/portal/libs/agave/utils.py
@@ -158,7 +158,7 @@ def text_preview(url):
     """
     try:
         resp = requests.get(url)
-        if (resp.encoding is not None and resp.encoding.lower() == 'utf-8'):
+        if (resp.content or (resp.encoding is not None and resp.encoding.lower() == 'utf-8')):
             content = resp.text
             # Raises UnicodeDecodeError for files with non-ascii characters
             content.encode('ascii', 'strict')


### PR DESCRIPTION
## Overview

In Tapis v2, a failed file listing call on a system returned a `502` error. In v3, a failed file listing returns `500`. Treat these `500` responses as a need for the user to push keys and create a user credential for the system.

## Related

* [TV3-154](https://jira.tacc.utexas.edu/browse/TV3-154)

## Testing

1. Via command line, delete your frontera credential, replacing `$USERNAME` with your username:
  a. `client.systems.removeUserCredential(systemId='frontera', userName=$USERNAME)`
2. Wait a few minutes for the cache to clear in Tapis
3. Go to https://cep.test/workbench/data/tapis/private/frontera
4. Confirm you get the prompt to push keys.
5. Push keys and confirm the process works.
