### PR TITLE
task/TV3-163: Add 10 s delay to workaround tapis-issue

### DIFF
--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -4,6 +4,7 @@
 """
 import logging
 import json
+import time
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
@@ -57,6 +58,10 @@ class SystemKeysView(BaseApiView):
                                   publ_key_str,
                                   priv_key_str,
                                   system_id)
+
+        # A 10s delay is added to work-around Tapis issue. This should be removed once the Tapis issue (https://github.com/tapis-project/tapis-files/issues/58)
+        # has been addressed. See https://jira.tacc.utexas.edu/browse/TV3-164
+        time.sleep(10)
 
         return JsonResponse(
             {

--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -59,8 +59,8 @@ class SystemKeysView(BaseApiView):
                                   priv_key_str,
                                   system_id)
 
-        # TODOv3: A 10s delay is added to work-around Tapis issue. This should be removed once the Tapis issue (https://github.com/tapis-project/tapis-files/issues/58)
-        # has been addressed. See https://jira.tacc.utexas.edu/browse/TV3-164
+        # TODOv3: A 10s delay is added to work-around Tapis issue. This should be removed once the Tapis issue
+        # (https://github.com/tapis-project/tapis-files/issues/58) has been addressed. See https://jira.tacc.utexas.edu/browse/TV3-164
         time.sleep(10)
 
         return JsonResponse(

--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -59,7 +59,7 @@ class SystemKeysView(BaseApiView):
                                   priv_key_str,
                                   system_id)
 
-        # A 10s delay is added to work-around Tapis issue. This should be removed once the Tapis issue (https://github.com/tapis-project/tapis-files/issues/58)
+        # TODOv3: A 10s delay is added to work-around Tapis issue. This should be removed once the Tapis issue (https://github.com/tapis-project/tapis-files/issues/58)
         # has been addressed. See https://jira.tacc.utexas.edu/browse/TV3-164
         time.sleep(10)
 


### PR DESCRIPTION
## Overview

Add 10s delay to work around tapis-ssiue

## Related

* [TV3-163](https://jira.tacc.utexas.edu/browse/TV3-163)

## Testing

You might need to add resource_set='dev' to the client initialization to test it out.  Thanks @shayanaijaz 

Testing is same as https://github.com/TACC/Core-Portal/pull/788:

1. Via command line, delete your frontera credential, replacing `$USERNAME` with your username:
  a. `client.systems.removeUserCredential(systemId='frontera', userName=$USERNAME)`
2. Wait for the cache to clear in Tapis
3. Go to https://cep.test/workbench/data/tapis/private/frontera
4. Confirm you get the prompt to push keys.
5. Push keys and confirm the process works.
6. Confirm the file listing works and we never see the "push keys" prompt.

## Notes

* [TV3-164](https://jira.tacc.utexas.edu/browse/TV3-164) is the follow on issue to remove this.


