### PR TITLE
task/TV3-166 Remove Unused Agave Settings

### DIFF
--- a/server/portal/libs/agave/models/systems/base.py
+++ b/server/portal/libs/agave/models/systems/base.py
@@ -268,7 +268,7 @@ class BaseSystem(BaseAgaveResource):
         query['limit'] = limit
         resp = requests.get(
             '{baseurl}/systems/v2'.format(
-                baseurl=settings.AGAVE_TENANT_BASEURL
+                baseurl=settings.TAPIS_TENANT_BASEURL
             ),
             headers=headers,
             params=query

--- a/server/portal/libs/agave/models/systems/base_unit_test.py
+++ b/server/portal/libs/agave/models/systems/base_unit_test.py
@@ -11,7 +11,7 @@ def test_system_success(mock_tapis_client):
     assert result == 'SUCCESS'
 
 
-SYSTEM_LISTING_URL = "{}/files/v2/listings/system/{}/".format(settings.AGAVE_TENANT_BASEURL, "systemId")
+SYSTEM_LISTING_URL = "{}/files/v2/listings/system/{}/".format(settings.TAPIS_TENANT_BASEURL, "systemId")
 
 
 @pytest.mark.skip(reason="not using storage system class in v3")

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -360,15 +360,6 @@ TAPIS_CLIENT_KEY = settings_secret._TAPIS_CLIENT_KEY
 # Long-live portal admin access token
 TAPIS_ADMIN_JWT = getattr(settings_secret, '_TAPIS_ADMIN_JWT', '')
 
-# Agave Tenant.
-AGAVE_TENANT_ID = settings_secret._AGAVE_TENANT_ID
-AGAVE_TENANT_BASEURL = settings_secret._AGAVE_TENANT_BASEURL
-
-# Agave Client Configuration
-AGAVE_CLIENT_KEY = settings_secret._AGAVE_CLIENT_KEY
-AGAVE_CLIENT_SECRET = settings_secret._AGAVE_CLIENT_SECRET
-AGAVE_SUPER_TOKEN = settings_secret._AGAVE_SUPER_TOKEN
-
 PORTAL_ADMIN_USERNAME = settings_secret._PORTAL_ADMIN_USERNAME
 
 AGAVE_JWT_PUBKEY = (

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -207,7 +207,7 @@ _PORTAL_ICON_FILENAME = '/static/site_cms/img/favicons/favicon.ico'
 # Using test account under personal email.
 # To use during dev, Tracking Protection in browser needs to be turned OFF.
 # Need to setup an admin account to aggregate tracking properties for portals.
-# NOTE: Use the _AGAVE_TENANT_ID URL value when setting up the tracking property.
+# NOTE: Use the _TAPIS_TENANT_BASEURL URL value when setting up the tracking property.
 _GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-XXXXX-Y'
 
 ########################

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -214,7 +214,7 @@ _PORTAL_ICON_FILENAME = '/static/img/favicon.ico'
 # Using test account under personal email.
 # To use during dev, Tracking Protection in browser needs to be turned OFF.
 # Need to setup an admin account to aggregate tracking properties for portals.
-# NOTE: Use the _AGAVE_TENANT_ID URL value when setting up the tracking property.
+# NOTE: Use the _TAPIS_TENANT_BASEURL URL value when setting up the tracking property.
 _GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-114289987-X'
 
 ########################

--- a/server/portal/settings/settings_secret.example.py
+++ b/server/portal/settings/settings_secret.example.py
@@ -37,15 +37,6 @@ _RT_PW = 'password'
 # Admin account
 _PORTAL_ADMIN_USERNAME = 'portal_admin'
 
-# Agave Tenant.
-_AGAVE_TENANT_ID = 'tenant_name'
-_AGAVE_TENANT_BASEURL = 'https://agave.mytenant.org'
-
-# Agave Client Configuration
-_AGAVE_CLIENT_KEY = 'TH1$_!$-MY=K3Y!~'
-_AGAVE_CLIENT_SECRET = 'TH1$_!$-My=S3cr3t!~'
-_AGAVE_SUPER_TOKEN = 'S0m3T0k3n_tHaT-N3v3r=3xp1R35'
-
 ########################
 # TAPIS v3 SETTINGS
 # NOTE: ONLY USED FOR TAPIS V3 DEVELOPMENT.

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -279,17 +279,7 @@ TAPIS_TENANT_BASEURL = 'https://example.tapis.io'
 # Tapis Client Configuration
 TAPIS_CLIENT_ID = 'test'
 TAPIS_CLIENT_KEY = 'test'
-
 TAPIS_ADMIN_JWT = 'test'
-
-# Agave Tenant.
-AGAVE_TENANT_ID = 'portal'
-AGAVE_TENANT_BASEURL = 'https://api.example.com'
-
-# Agave Client Configuration
-AGAVE_CLIENT_KEY = 'test'
-AGAVE_CLIENT_SECRET = 'test'
-AGAVE_SUPER_TOKEN = 'test'
 TAPIS_DEFAULT_TRASH_NAME = 'test'
 
 AGAVE_JWT_HEADER = 'HTTP_X_AGAVE_HEADER'


### PR DESCRIPTION
## Overview

Removed unused `AGAVE` settings and their usages in the code

## Related

* [TV3-166](https://jira.tacc.utexas.edu/browse/TV3-166)

## Changes

- Removed all `AGAVE` settings from the static settings files 
- Refactored code to use new Tapis settings 

## Testing

1. Update secrets file by removing the `Agave Tenant` and `Agave Client Configuration` settings
2. Make sure app builds and runs fine

## UI

No UI changes

## Notes
Once this is approved we can also go in and update the existing v3 secret files and stache entries and remove the Agave settings
