### PR TITLE
bug/WP-46 Fix Filter Inconsistencies

### DIFF
--- a/server/portal/libs/agave/filter_mapping.py
+++ b/server/portal/libs/agave/filter_mapping.py
@@ -140,7 +140,7 @@ filter_mapping = {
         "out",
         "txt"
     ],
-    "Zip": [
+    "ZIP": [
         "zip",
         "tar",
         "gz",

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -131,7 +131,7 @@ def search(client, system, path='', offset=0, limit=100, query_string='', filter
     else:
         # search without a query should just filter current path
         search = search.sort('name._exact')
-        search = search.filter('term', **{'basePath._exact': '/' + path.strip('/')})
+        search = search.filter('term', **{'basePath._exact': path.strip('/')})
     if filter:
         search = search.filter(filter_query)
 


### PR DESCRIPTION
## Overview

The goal for this task was to fix filter inconsistencies when using the `ZIP` filter. During testing, I noticed that the filter functionality was not working at all. This PR also includes a fix for that. 

The filtering bug was caused because the `basePath` saved for a file in the elasticsearch index does not include a leading slash whereas when we are making the search we included a leading slash which was resulting in no matches found. 

The `ZIP` filter bug was caused by a case mismatch between the filter value that was sent in and the value in the `filter_mapping` object in the backend. 

## Related

* [WP-46](https://jira.tacc.utexas.edu/browse/WP-46)

## Changes

- Removed leading slash from basePath when searching for an indexed file 
- Changed the `filter_mapping` value from `Zip` to `ZIP` which is also consistent with the other values.

## Testing

1. Open Data Files 
2. Use the filters and ensure it works correctly

## UI

No UI changes

## Notes

