### PR TITLE
task/TV3-169: Replace tapis profile info with TAS info

### DIFF
--- a/server/portal/apps/auth/backends.py
+++ b/server/portal/apps/auth/backends.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from portal.apps.accounts.models import PortalProfile
+from portal.apps.users.utils import get_user_data
 
 
 logger = logging.getLogger(__name__)
@@ -27,21 +28,22 @@ class TapisOAuthBackend(ModelBackend):
                 tapis_user = json_result['result']
                 username = tapis_user['username']
                 UserModel = get_user_model()
+
                 try:
-                    user = UserModel.objects.get(username=username)
-                    user.first_name = tapis_user['given_name']
-                    user.last_name = tapis_user['last_name']
-                    user.email = tapis_user['email']
-                    user.save()
-                except UserModel.DoesNotExist:
-                    logger.info('Creating local user record for "%s" '
-                                'from Tapis Profile' % username)
-                    user = UserModel.objects.create_user(
-                        username=username,
-                        first_name=tapis_user['given_name'],
-                        last_name=tapis_user['last_name'],
-                        email=tapis_user['email']
-                    )
+                    user_data = get_user_data(username=username)
+                    defaults = {
+                        'first_name': user_data['firstName'],
+                        'last_name': user_data['lastName'],
+                        'email': user_data['email']
+                    }
+                except Exception as e:
+                    logger.exception(e)
+                    return user
+
+                user, created = UserModel.objects.update_or_create(username=username, defaults=defaults)
+
+                if created:
+                    logger.info('Created local user record for "%s" from TAS Profile' % username)
 
                 try:
                     profile = PortalProfile.objects.get(user=user)

--- a/server/portal/apps/auth/backends.py
+++ b/server/portal/apps/auth/backends.py
@@ -36,9 +36,9 @@ class TapisOAuthBackend(ModelBackend):
                         'last_name': user_data['lastName'],
                         'email': user_data['email']
                     }
-                except Exception as e:
-                    logger.exception(e)
-                    return user
+                except Exception:
+                    logger.exception("Error retrieving TAS user profile data for user: {}".format(username))
+                    defaults = {}
 
                 user, created = UserModel.objects.update_or_create(username=username, defaults=defaults)
 

--- a/server/portal/apps/auth/unit_test.py
+++ b/server/portal/apps/auth/unit_test.py
@@ -45,7 +45,7 @@ class TestTapisOAuthBackend(TransactionTestCase):
     def tearDown(self):
         super(TestTapisOAuthBackend, self).tearDown()
         self.mock_requests_patcher.stop()
-        self.mock_requests_patcher.stop()
+        self.mock_user_data_patcher.stop()
 
     def test_bad_backend_params(self):
         # Test backend authenticate with no params

--- a/server/portal/apps/auth/unit_test.py
+++ b/server/portal/apps/auth/unit_test.py
@@ -31,8 +31,20 @@ class TestTapisOAuthBackend(TransactionTestCase):
         )
         self.mock_requests = self.mock_requests_patcher.start()
 
+        self.mock_user_data_patcher = patch(
+            'portal.apps.auth.backends.get_user_data',
+            return_value={
+                'username': 'testuser',
+                'firstName': 'test',
+                'lastName': 'user',
+                'email': 'new@email.com'
+            }
+        )
+        self.mock_user_data = self.mock_user_data_patcher.start()
+
     def tearDown(self):
         super(TestTapisOAuthBackend, self).tearDown()
+        self.mock_requests_patcher.stop()
         self.mock_requests_patcher.stop()
 
     def test_bad_backend_params(self):
@@ -60,10 +72,7 @@ class TestTapisOAuthBackend(TransactionTestCase):
         self.mock_response.json.return_value = {
             "status": "success",
             "result": {
-                "username": "testuser",
-                "given_name": "test",
-                "last_name": "user",
-                "email": "test@user.com"
+                "username": "testuser"
             }
         }
         result = self.backend.authenticate(backend='tapis', token='1234')
@@ -86,9 +95,6 @@ class TestTapisOAuthBackend(TransactionTestCase):
             "status": "success",
             "result": {
                 "username": "testuser",
-                "given_name": "test",
-                "last_name": "user",
-                "email": "test@user.com"
             }
         }
         result = self.backend.authenticate(backend='tapis', token='1234')
@@ -96,4 +102,4 @@ class TestTapisOAuthBackend(TransactionTestCase):
         self.assertEqual(result, user)
         # Existing user object should be updated
         user = get_user_model().objects.get(username="testuser")
-        self.assertEqual(user.email, "test@user.com")
+        self.assertEqual(user.email, "new@email.com")


### PR DESCRIPTION
## Overview

Previously we were relying on a call to Tapis profiles `userinfo` to retrieve a user's name and email. Now, we will use TAS to get that info.

This PR also adds some error handling and cleans up the user model creation/updating step.

## Related

* [TV3-169](https://jira.tacc.utexas.edu/browse/TV3-169)


## Testing

1. Confirm logging into the portal works
2. Change your name or email in LDAP, and wait a few minutes for it to update in TAS: https://accounts.tacc.utexas.edu/profile
3. Logout and back into the portal, and confirm your info has updated under manage account
