### PR TITLE
Task/TV3-172: Prevent excessive refetching of user roles.

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/_cells/SystemRoleSelector.jsx
@@ -36,8 +36,14 @@ const setSystemRole = async (projectId, username, role) => {
 };
 
 export const useSystemRole = (projectId, username) => {
-  const query = useQuery(['system-role', projectId, username], () =>
-    getSystemRole(projectId, username)
+  const query = useQuery(
+    ['system-role', projectId, username],
+    () => getSystemRole(projectId, username),
+    {
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }
   );
   const mutation = useMutation(async (role) => {
     await setSystemRole(projectId, username, role);


### PR DESCRIPTION
## Overview

This might be contributing to weird uWSGI Harakiri errors we're seeing when trying to add users to Shared Workspaces.

## Related

* [TV3-172](https://jira.tacc.utexas.edu/browse/TV3-172)

## Changes
- Prevent refetching of user roles in the Team Members modal on remount/focus change.


