### PR TITLE
Quick: add cloud.data as alias for corral

### DIFF
--- a/client/src/utils/systems.js
+++ b/client/src/utils/systems.js
@@ -8,7 +8,8 @@ export function getSystemName(host) {
   if (
     host.startsWith('data.tacc') ||
     host.startsWith('cloud.corral') ||
-    host.startsWith('secure.corral')
+    host.startsWith('secure.corral') ||
+    host.startsWith('cloud.data')
   ) {
     return 'Corral';
   }


### PR DESCRIPTION
## Overview

Adds `cloud.data` to the list of aliases for "corral"

## Testing

1. Go to https://cep.test/workbench/data/tapis/private/cloud.data/ and confirm the breadcrumb reads "Corral" instead of "Cloud"

## UI

![Screen Shot 2023-05-24 at 3 22 25 PM](https://github.com/TACC/Core-Portal/assets/20326896/447e0a68-74f7-426f-9fc7-974149a6fd87)


