### PR TITLE
Remove Maverick from sysmon and from sysmon fixtures

### DIFF
--- a/server/portal/fixtures/system_monitor/index.json
+++ b/server/portal/fixtures/system_monitor/index.json
@@ -21,22 +21,6 @@
       }
     ]
   },
-  "Maverick2": {
-    "display_name": "Maverick2",
-    "tas_name": "maverick3",
-    "hostname": "maverick2.tacc.utexas.edu",
-    "system_type": "COMPUTE",
-    "timestamp": "2022-11-07T14:30:15.071987+00:00",
-    "online": true,
-    "reachable": true,
-    "queues_down": false,
-    "load": 0.2,
-    "running": 6,
-    "queued": 0,
-    "in_maintenance": false,
-    "next_maintenance": null,
-    "reservations": []
-  },
   "Frontera": {
     "display_name": "Frontera",
     "tas_name": "frontera",

--- a/server/portal/fixtures/system_monitor/index_frontera_not_running.json
+++ b/server/portal/fixtures/system_monitor/index_frontera_not_running.json
@@ -21,22 +21,6 @@
       }
     ]
   },
-  "Maverick2": {
-    "display_name": "Maverick2",
-    "tas_name": "maverick3",
-    "hostname": "maverick2.tacc.utexas.edu",
-    "system_type": "COMPUTE",
-    "timestamp": "2022-11-07T14:30:15.071987+00:00",
-    "online": true,
-    "reachable": true,
-    "queues_down": false,
-    "load": 0.2,
-    "running": 6,
-    "queued": 0,
-    "in_maintenance": false,
-    "next_maintenance": null,
-    "reservations": []
-  },
   "Frontera": {
     "display_name": "Frontera",
     "tas_name": "frontera",

--- a/server/portal/fixtures/system_monitor/index_missing_frontera.json
+++ b/server/portal/fixtures/system_monitor/index_missing_frontera.json
@@ -37,22 +37,6 @@
       }
     ]
   },
-  "Maverick2": {
-    "display_name": "Maverick2",
-    "tas_name": "maverick3",
-    "hostname": "maverick2.tacc.utexas.edu",
-    "system_type": "COMPUTE",
-    "timestamp": "2022-11-07T14:30:15.071987+00:00",
-    "online": true,
-    "reachable": true,
-    "queues_down": false,
-    "load": 0.2,
-    "running": 6,
-    "queued": 0,
-    "in_maintenance": false,
-    "next_maintenance": null,
-    "reservations": []
-  },
   "Lonestar6": {
     "display_name": "Lonestar6",
     "tas_name": "lonestar6",

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -21,7 +21,7 @@ _WH_BASE_URL = ''
 _LOGIN_REDIRECT_URL = '/remote/login/'
 _LOGOUT_REDIRECT_URL = '/cms/logout/'
 
-_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera', 'Maverick2']
+_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera']
 
 ########################
 # DJANGO SETTINGS LOCAL

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -21,7 +21,7 @@ _WH_BASE_URL = ''
 _LOGIN_REDIRECT_URL = '/remote/login/'
 _LOGOUT_REDIRECT_URL = '/cms/logout/'
 
-_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera', 'Maverick2']
+_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera']
 
 ########################
 # DJANGO SETTINGS LOCAL


### PR DESCRIPTION
## Overview
Remove Maverick2 from _SYSTEM_MONITOR_DISPLAY_LIST in settings now that the system is retired

## Related



## Changes

- Removed sysmon fixtures that include Maverick2
- Removed Maverick2 from _SYSTEM_MONITOR_DISPLAY_LIST in settings

## Testing

1. Go to cep.test and make sure Maverick2 no longer appears in the system monitor

## UI

<img width="1521" alt="Screenshot 2023-06-02 at 10 35 32 AM" src="https://github.com/TACC/Core-Portal/assets/96220951/25c38e56-8269-4d78-a586-487b4f92115c">


## Notes
From Sal for deployment - 

> We'll have to remove it from each portal config in [https://github.com/TACC/Core-Portal-Deployments](https://github.com/TACC/Core-Portal-Deployments), and redeploy each individually
