### PR TITLE
fix/WI-39: Remove `MFAStep` from onboarding steps

### DIFF
--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -148,10 +148,6 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
 Sample:
 _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
     {
-        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
-        'settings': {}
-    },
-    {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {}
     },
@@ -178,10 +174,6 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
 """
 
 _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-    {
-        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
-        'settings': {}
-    },
     {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {}

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -146,10 +146,6 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
 Sample:
 _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
     {
-        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
-        'settings': {}
-    },
-    {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {}
     },
@@ -176,10 +172,6 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
 """
 
 _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-    {
-        'step': 'portal.apps.onboarding.steps.mfa.MFAStep',
-        'settings': {}
-    },
     {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {}


### PR DESCRIPTION
## Overview

TAS no longer houses a user's MFA pairing status. For now, we need to disable the MFAStep onboarding step from all portals by removing that step from _PORTAL_USER_ACCOUNT_SETUP_STEPS.

## Related

* [WI-39](https://jira.tacc.utexas.edu/browse/WI-39)

## Testing

1. Reset your "Multi-Factor Authentication" step in http://cep.test/workbench/onboarding/admin
2. Pull down this PR
3. Log out and back in, and confirm you bypass that step without needing to resolve it

