### PR TITLE
task/TV3-176: Revised `parameterSet` view in AppForm

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -536,45 +536,43 @@ export const AppSchemaForm = ({ app }) => {
                     )}
                   </div>
                 )}
-                {Object.entries(appFields.parameterSet).map(
-                  ([parameterSet, parameterValue]) => {
-                    return (
-                      Object.keys(parameterValue).length > 0 && (
-                        <div className="appSchema-section" key={parameterSet}>
-                          <div className="appSchema-header">
-                            <span>{parameterSet}</span>
-                          </div>
-                          {Object.entries(parameterValue).map(
-                            ([name, field]) => (
-                              <FormField
-                                {...field}
-                                name={`parameterSet.${parameterSet}.${name}`}
-                                key={`parameterSet.${parameterSet}.${name}`}
-                              >
-                                {field.options
-                                  ? field.options.map((item) => {
-                                      let val = item;
-                                      if (val instanceof String) {
-                                        const tmp = {};
-                                        tmp[val] = val;
-                                        val = tmp;
-                                      }
-                                      return Object.entries(val).map(
-                                        ([key, value]) => (
-                                          <option key={key} value={key}>
-                                            {value}
-                                          </option>
-                                        )
-                                      );
-                                    })
-                                  : null}
-                              </FormField>
-                            )
-                          )}
-                        </div>
-                      )
-                    );
-                  }
+                {Object.keys(appFields.parameterSet).length > 0 && (
+                  <div className="appSchema-section">
+                    <div className="appSchema-header">
+                      <span>Parameters</span>
+                    </div>
+                    {Object.entries(appFields.parameterSet).map(
+                      ([parameterSet, parameterValue]) => {
+                        return Object.entries(parameterValue).map(
+                          ([name, field]) => (
+                            <FormField
+                              {...field}
+                              name={`parameterSet.${parameterSet}.${name}`}
+                              key={`parameterSet.${parameterSet}.${name}`}
+                            >
+                              {field.options
+                                ? field.options.map((item) => {
+                                    let val = item;
+                                    if (val instanceof String) {
+                                      const tmp = {};
+                                      tmp[val] = val;
+                                      val = tmp;
+                                    }
+                                    return Object.entries(val).map(
+                                      ([key, value]) => (
+                                        <option key={key} value={key}>
+                                          {value}
+                                        </option>
+                                      )
+                                    );
+                                  })
+                                : null}
+                            </FormField>
+                          )
+                        );
+                      }
+                    )}
+                  </div>
                 )}
                 <div className="appSchema-section">
                   <div className="appSchema-header">

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -526,7 +526,7 @@ export const AppSchemaForm = ({ app }) => {
                           <FormField
                             {...field}
                             name={`fileInputs.${name}`}
-                            agaveFile
+                            tapisFile
                             SelectModal={DataFilesSelectModal}
                             placeholder="Browse Data Files"
                             key={`fileInputs.${name}`}

--- a/client/src/components/Applications/AppForm/AppFormSchema.js
+++ b/client/src/components/Applications/AppForm/AppFormSchema.js
@@ -43,6 +43,7 @@ const FormSchema = (app) => {
           description: param.description,
           required: param.inputMode === 'REQUIRED',
           readOnly: param.inputMode === 'FIXED',
+          parameterSet: parameterSet,
         };
 
         if (param.notes?.enum_values) {

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -63,7 +63,7 @@ const FormField = ({
   // which we can spread on <input> and also replace ErrorMessage entirely.
   const [field, meta, helpers] = useField(props);
   const [openTapisFileModal, setOpenTapisFileModal] = useState(false);
-  const { id, name } = props;
+  const { id, name, parameterSet } = props;
   const hasAddon = addon !== undefined;
   const wrapperType = hasAddon ? 'InputGroup' : '';
 
@@ -74,7 +74,20 @@ const FormField = ({
       size="sm"
       style={{ display: 'flex', alignItems: 'center' }}
     >
-      {label}{' '}
+      {label}&nbsp;
+      {parameterSet && (
+        <code>
+          (
+          <a
+            href={`https://tapis.readthedocs.io/en/latest/technical/jobs.html#${parameterSet.toLowerCase()}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {parameterSet}
+          </a>
+          )
+        </code>
+      )}
       {required ? (
         <Badge color="danger" style={{ marginLeft: '10px' }}>
           Required

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -44,10 +44,10 @@ FormFieldWrapper.defaultProps = {
  * A standard form field that supports some customization and presets.
  *
  * Customizations:
- * - providing an `<InputGroupAddon>` (can not use with "Agave File Selector")
+ * - providing an `<InputGroupAddon>` (can not use with "Tapis File Selector")
  *
  * Presets:
- * - Agave File Selector (requires `agaveFile` and `SelectModal`)
+ * - Tapis File Selector (requires `tapisFile` and `SelectModal`)
  */
 const FormField = ({
   addon,
@@ -55,14 +55,14 @@ const FormField = ({
   label,
   description,
   required,
-  agaveFile,
+  tapisFile,
   SelectModal,
   ...props
 }) => {
   // useField() returns [formik.getFieldProps(), formik.getFieldMeta()]
   // which we can spread on <input> and also replace ErrorMessage entirely.
   const [field, meta, helpers] = useField(props);
-  const [openAgaveFileModal, setOpenAgaveFileModal] = useState(false);
+  const [openTapisFileModal, setOpenTapisFileModal] = useState(false);
   const { id, name } = props;
   const hasAddon = addon !== undefined;
   const wrapperType = hasAddon ? 'InputGroup' : '';
@@ -94,13 +94,13 @@ const FormField = ({
   );
 
   // Allowing ineffectual prop combinations would lead to confusion
-  if (addon && agaveFile) {
+  if (addon && tapisFile) {
     throw new Error(
-      'You must not pass `addon` and `agaveFile`, because `agaveFile` triggers its own field add-on'
+      'You must not pass `addon` and `tapisFile`, because `tapisFile` triggers its own field add-on'
     );
   }
-  if ((!agaveFile && SelectModal) || (agaveFile && !SelectModal)) {
-    throw new Error('An `agaveFile` and a `SelectModal` must both be passed');
+  if ((!tapisFile && SelectModal) || (tapisFile && !SelectModal)) {
+    throw new Error('A `tapisFile` and a `SelectModal` must both be passed');
   }
 
   return (
@@ -108,12 +108,12 @@ const FormField = ({
       {label && hasAddon ? <FieldLabel /> : null}
       <FormFieldWrapper type={wrapperType}>
         {label && !hasAddon ? <FieldLabel /> : null}
-        {agaveFile ? (
+        {tapisFile ? (
           <>
             <SelectModal
-              isOpen={openAgaveFileModal}
+              isOpen={openTapisFileModal}
               toggle={() => {
-                setOpenAgaveFileModal((prevState) => !prevState);
+                setOpenTapisFileModal((prevState) => !prevState);
               }}
               onSelect={(system, path) => {
                 helpers.setValue(`tapis://${system}/${path}`);
@@ -124,7 +124,7 @@ const FormField = ({
               <InputGroupAddon addonType="prepend">
                 <Button
                   type="secondary"
-                  onClick={() => setOpenAgaveFileModal(true)}
+                  onClick={() => setOpenTapisFileModal(true)}
                 >
                   Select
                 </Button>
@@ -151,7 +151,7 @@ FormField.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   required: PropTypes.bool,
-  agaveFile: PropTypes.bool,
+  tapisFile: PropTypes.bool,
   SelectModal: PropTypes.func,
   /** An [`<InputGroupAddon>`](https://reactstrap.github.io/components/input-group/) to add */
   addon: PropTypes.node,
@@ -164,7 +164,7 @@ FormField.defaultProps = {
   label: undefined,
   description: undefined,
   required: false,
-  agaveFile: undefined,
+  tapisFile: undefined,
   SelectModal: undefined,
   addon: undefined,
   addonType: undefined,

--- a/client/src/styles/elements/text-semantics.css
+++ b/client/src/styles/elements/text-semantics.css
@@ -8,6 +8,10 @@
 code {
   color: unset;
 }
+code > a,
+code > a:hover {
+  color: var(--global-color-accent--normal);
+}
 kbd {
   padding: unset;
   color: unset;

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -8,7 +8,7 @@
 @import url('./settings/space.css');
 
 /* TOOLS */
-@import './tools/mixins.scss';
+/* … */
 
 /* GENERIC */
 @import url('./generics/roots.css');

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -33,8 +33,3 @@
 /* NOTE: For the most part, allow React components to explicitely import as needed */
 @import url('./trumps/icon.css');
 @import url('./trumps/table.css');
-
-code > a,
-a:hover {
-  color: var(--global-color-accent--normal);
-}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -34,6 +34,7 @@
 @import url('./trumps/icon.css');
 @import url('./trumps/table.css');
 
-code > a, a:hover {
-    color: var(--global-color-accent--normal);
+code > a,
+a:hover {
+  color: var(--global-color-accent--normal);
 }

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -8,7 +8,7 @@
 @import url('./settings/space.css');
 
 /* TOOLS */
-/* … */
+@import './tools/mixins.scss';
 
 /* GENERIC */
 @import url('./generics/roots.css');
@@ -33,3 +33,7 @@
 /* NOTE: For the most part, allow React components to explicitely import as needed */
 @import url('./trumps/icon.css');
 @import url('./trumps/table.css');
+
+code > a, a:hover {
+    color: var(--global-color-accent--normal);
+}


### PR DESCRIPTION
## Overview

After discussion with CMD, we came down on this design:

- client apps have more complex required Parameters
- wma apps have less complex required Parameters
- regardless who owns the app:
    - add Parameters section
    - describe parameters well
    - after each label's text, but before [Required] add "(containerArgsOrWhatever)"
- avoid the term "Advanced"

## Related

* [TV3-176](https://jira.tacc.utexas.edu/browse/TV3-176)

## Testing

1. Go to https://cep.test/workbench/applications/qgis?appVersion=3.30
2. Confirm you get the correct sub-categorization in parentheses for all items under "Parameters"
3. Confirm links in parentheses work

## UI
![Screenshot 2023-06-15 at 4 01 27 PM](https://github.com/TACC/Core-Portal/assets/20326896/78be8672-fb66-4ea8-8fa1-d113c642e25c)
