### PR TITLE
Task/update-readme: Minor update to readme to add a bit more context to local build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ NOTE: This may require a computer restart to take effect.
 
      _WARNING: This name **must** match the **agave callback URL** defined for the client in `settings_secret.py` for `_AGAVE_TENANT_ID`._
 
-  2. Direct your browser to `https://cep.test`. This will display the django CMS default page. To login to the portal, point your browser to `https://cep.test/login`.
+  2. Do this step after going through the server and client code configuration steps in next section.
+     
+     Direct your browser to `https://cep.test`. This will display the django CMS default page. To login to the portal, point your browser to `https://cep.test/login`.
   
      _NOTE: If when navigating to `https://cep.test` you see a "Server not found" error while on the VPN, follow these steps and try again:_
       1. Open the Network app utility
@@ -133,8 +135,7 @@ OR
     npm run build
 
 -  _Note: During local development you can also use `npm run dev` to set a livereload watch on your local system that will update the portal code in real-time. Again, make sure that you are using NodeJS LTS and not an earlier version. You will also need the port 3000 available locally._
-
-
+   _Note: During local development if your settings.DEBUG is set to true, you will have to use `npm run dev` to have a functional app. In DEBUG setting, the requests are handled via [vite][3]._
 #### Initialize the application in the `core_portal_django` container:
 
     docker exec -it core_portal_django /bin/bash
@@ -286,3 +287,4 @@ Sign your commits ([see this link](https://help.github.com/en/github/authenticat
 [Core Styles]: https://github.com/TACC/tup-ui/tree/main/libs/core-styles
 [1]: https://docs.docker.com/get-docker/
 [2]: https://docs.docker.com/compose/install/
+[3]: https://vitejs.dev/

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ OR
     npm ci
     npm run build
 
--  _Notes:_ 
-       _During local development you can also use `npm run dev` to set a livereload watch on your local system that will update the portal code in real-time. Again, make sure that you are using NodeJS LTS and not an earlier version. You will also need the port 3000 available locally._
-       _If your settings.DEBUG is set to true, you will have to use `npm run dev` to have a functional app. In DEBUG setting, the requests are handled via [vite][3]._
+-  _Notes: During local development you can also use `npm run dev` to set a live reload watch on your local system that will update the portal code in real-time. Again, make sure that you are using NodeJS LTS and not an earlier version. You will also need the port 3000 available locally._
+  
+-  _Notes: If your settings.DEBUG is set to true, you will have to use `npm run dev` to have a functional app. In DEBUG setting, the requests are handled via [vite][3]._
 #### Initialize the application in the `core_portal_django` container:
 
     docker exec -it core_portal_django /bin/bash

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ OR
     npm ci
     npm run build
 
--  _Note: During local development you can also use `npm run dev` to set a livereload watch on your local system that will update the portal code in real-time. Again, make sure that you are using NodeJS LTS and not an earlier version. You will also need the port 3000 available locally._
-   _Note: During local development if your settings.DEBUG is set to true, you will have to use `npm run dev` to have a functional app. In DEBUG setting, the requests are handled via [vite][3]._
+-  _Notes:_ 
+       _During local development you can also use `npm run dev` to set a livereload watch on your local system that will update the portal code in real-time. Again, make sure that you are using NodeJS LTS and not an earlier version. You will also need the port 3000 available locally._
+       _If your settings.DEBUG is set to true, you will have to use `npm run dev` to have a functional app. In DEBUG setting, the requests are handled via [vite][3]._
 #### Initialize the application in the `core_portal_django` container:
 
     docker exec -it core_portal_django /bin/bash


### PR DESCRIPTION
## Overview
After I followed the readme to do a local setup, I found two steps where more details could have helped. 

## Related


## Changes
There are two updates here:
* For the step, go to browser and check https://cep.test, this step needs to happen after local setup is complete. Add a note to add that info.
* For local client, npm run dev is needed when debug setting is on. Without that the requests to cep.test:3000 fail and nothing works. Added a note for that.


## Testing

Look at preview

## UI
NA

## Notes
NA
