### PR TITLE
task/WP-43 - System Monitor UI Update - UI Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ NOTE: This may require a computer restart to take effect.
 2. With Default Keychains > login selected, choose File > Import Items... from the menu.
 3. Navigate to `./server/conf/nginx/certificates`
 4. Select `ca.pem`
-5. Under the "All" or "Certificates" tab,\
-    Search for CEP and double click on the certificate
+5. Search for CEP and double click on the certificate
 6. In the Trust section, find the "When using this certificate" dropdown and select "Always Trust"
 7. Close the window to save.
 

--- a/client/src/components/SystemStatus/SystemStatus.jsx
+++ b/client/src/components/SystemStatus/SystemStatus.jsx
@@ -51,17 +51,12 @@ const Layout = ({ hostname }) => {
   return (
     <>
       <Section
-        className={styles['section']}
-        contentLayoutName="oneColumn"
+        className={styles['root']}
+        contentLayoutName="twoColumn"
+        contentClassName={styles['layout']}
         content={
-          <>
-            <SectionTableWrapper
-              className={styles['sysmon-content']}
-              contentShouldScroll
-            >
-              <Sysmon system={selectedSystem?.hostname}></Sysmon>
-            </SectionTableWrapper>
-
+          <div className={styles['panel-1']}>
+            <Sysmon system={selectedSystem?.hostname} />
             {loading ? (
               <LoadingSpinner />
             ) : (
@@ -72,8 +67,9 @@ const Layout = ({ hostname }) => {
                 <SystemStatusQueueTable system={selectedSystem} />
               </SectionTableWrapper>
             )}
-          </>
+          </div>
         }
+        /* For Average Wait Times table, add a second <div> */
       />
     </>
   );

--- a/client/src/components/SystemStatus/SystemStatus.module.scss
+++ b/client/src/components/SystemStatus/SystemStatus.module.scss
@@ -11,8 +11,10 @@
 /* So we control when column count changes */
 /* CAVEAT: Not supported on Safari until v16 */
 /* FAQ: The `contentLayoutName` triggers CSS that changes column count based on media query */
-.layout {
-  column-count: 1;
+@container system-section-root (width > 0px) {
+  .layout {
+    column-count: 1;
+  }
 }
 @container system-section-root (width > 1000px) {
   .layout {

--- a/client/src/components/SystemStatus/SystemStatus.module.scss
+++ b/client/src/components/SystemStatus/SystemStatus.module.scss
@@ -1,28 +1,44 @@
-.content {
-  /* WARNING: Mimicked on: History, Allocation, DataFiles, DataFilesProjectsList, DataFilesProjectFileListing, PublicData */
-  padding-top: 1.75rem; /* ~28px (22.5px * design * 1.2 design-to-app ratio) */
-  padding-left: 1.5em; /* ~24px (20px * design * 1.2 design-to-app ratio) */
+/* To allow a container query */
+/* CAVEAT: Not supported on Safari until v16 */
+.root {
+  container-type: inline-size;
+  container-name: system-section-root;
 
-  /* As a flex child */
-  flex-grow: 1;
-  height: 85%;
-  width: 100% !important;
+  /* FAQ: Only necessary because container-type: (…-)size */
+  /* https://stackoverflow.com/a/73980194/11817077 */
+  width: 100%;
+}
+/* So we control when column count changes */
+/* CAVEAT: Not supported on Safari until v16 */
+/* FAQ: The `contentLayoutName` triggers CSS that changes column count based on media query */
+.layout {
+  column-count: 1;
+}
+@container system-section-root (width > 1000px) {
+  .layout {
+    column-count: 2;
+  }
 }
 
-.sysmon-content {
-  /* WARNING: Mimicked on: History, Allocation, DataFiles, DataFilesProjectsList, DataFilesProjectFileListing, PublicData */
-  padding-top: 1.75rem; /* ~28px (22.5px * design * 1.2 design-to-app ratio) */
-  padding-left: 1.5em; /* ~24px (20px * design * 1.2 design-to-app ratio) */
 
-  /* As a flex child */
-  flex-grow: 1;
-  height: 15%;
-  width: 100% !important;
+
+.layout {
+  padding-top: var(--global-space--section-top);
+  padding-left: var(--global-space--section-left);
+  padding-bottom: var(--global-space--section-right);
 }
 
-.section {
-  width: 50% !important;
+
+
+.panel-1 {
+  /* To align child tables vertically and support scrollbars they could have */
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 3rem;
 }
+
+
 
 /* Error message */
 .error {
@@ -31,12 +47,11 @@
   align-items: center;
 }
 
+
+
 .header {
   padding-bottom: 1.5rem;
 }
-
-.header {
-  h3 {
-    font-size: 1.25rem;
-  }
+.header h3 {
+  font-size: 1.25rem;
 }

--- a/client/src/components/SystemStatus/SystemStatus.module.scss
+++ b/client/src/components/SystemStatus/SystemStatus.module.scss
@@ -1,24 +1,25 @@
-/* To allow a container query */
+/* To override `contentLayoutName` media queries */
 /* CAVEAT: Not supported on Safari until v16 */
-.root {
-  container-type: inline-size;
-  container-name: system-section-root;
+@supports(container-type: inline-size) {
+  /* To allow a container query */
+  .root {
+    container-type: inline-size;
+    container-name: system-section-root;
 
-  /* FAQ: Only necessary because container-type: (…-)size */
-  /* https://stackoverflow.com/a/73980194/11817077 */
-  width: 100%;
-}
-/* So we control when column count changes */
-/* CAVEAT: Not supported on Safari until v16 */
-/* FAQ: The `contentLayoutName` triggers CSS that changes column count based on media query */
-@container system-section-root (width > 0px) {
+    /* FAQ: Only necessary because container-type: (…-)size */
+    /* https://stackoverflow.com/a/73980194/11817077 */
+    width: 100%;
+  }
+
+  /* So we control when column count changes */
+  /* FAQ: The `contentLayoutName` triggers CSS that changes column count based on media query */
   .layout {
     column-count: 1;
   }
-}
-@container system-section-root (width > 1000px) {
-  .layout {
-    column-count: 2;
+  @container system-section-root (width > 1000px) {
+    .layout {
+      column-count: 2;
+    }
   }
 }
 

--- a/client/src/components/_common/SectionContent/SectionContent.layouts.module.css
+++ b/client/src/components/_common/SectionContent/SectionContent.layouts.module.css
@@ -61,13 +61,13 @@
   .multi-column {
     column-gap: var(--column-gap);
     column-rule: 1px solid rgb(112 112 112 / 25%);
-    column-fill: auto;
   }
   .two-column > *:not(:last-child),
   .multi-column > *:not(:last-child) {
     margin-bottom: var(--vertical-buffer);
   }
 
+  .two-column,
   .balance {
     column-fill: balance;
   }

--- a/client/src/components/_common/SectionContent/SectionContent.layouts.module.css
+++ b/client/src/components/_common/SectionContent/SectionContent.layouts.module.css
@@ -67,11 +67,11 @@
     margin-bottom: var(--vertical-buffer);
   }
 
-  .two-column:is(with-unequal-columns),
+  .two-column:is(.with-unequal-columns),
   .multi-column {
     column-fill: auto;
   }
-  .two-column:not(with-unequal-columns),
+  .two-column:not(.with-unequal-columns),
   .balance {
     column-fill: balance;
   }

--- a/client/src/components/_common/SectionContent/SectionContent.layouts.module.css
+++ b/client/src/components/_common/SectionContent/SectionContent.layouts.module.css
@@ -67,7 +67,11 @@
     margin-bottom: var(--vertical-buffer);
   }
 
-  .two-column,
+  .two-column:is(with-unequal-columns),
+  .multi-column {
+    column-fill: auto;
+  }
+  .two-column:not(with-unequal-columns),
   .balance {
     column-fill: balance;
   }

--- a/client/src/components/_common/Sidebar/Sidebar.module.css
+++ b/client/src/components/_common/Sidebar/Sidebar.module.css
@@ -10,8 +10,8 @@
   padding-top: 20px;
 }
 
-/* when there is a sidebar inside a section */
-:global(.c-section--has-content-layout-has-sidebar) main {
+/* when there is a sidebar directly inside a section */
+:global(.c-section--has-content-layout-has-sidebar) > main {
   padding-left: 0;
 }
 


### PR DESCRIPTION
## Overview

Fix various UI issues in #807.

## Related

* [WP-43](https://jira.tacc.utexas.edu/browse/WP-43)
* [TUP-514](https://jira.tacc.utexas.edu/browse/TUP-514)
* builds upon #807

## Changes

- **fixed** two relevant bugs (4421eb93, af76710)
- **changed** Section layout to `twoColumn` (e2d96d0)
- **changed** code to align tables vertically (e2d96d0)
- **added** override of `twoColumn` layout media queries with container queries (e2d96d0)
- **removed** `SectionTableWrapper` around single-row (i.e. no-need-to-scroll) table (e2d96d0)

## Testing

1. Review "System Status" section at various screen heights and widths.
2. System Status table should scroll (when space is limited).
3. System Monitor table should never scroll.
4. The "System Status" section tables should be:
    - half-width on a wide screen
    - full-width on a narrow screen*

<sup>* On up-to-date and evergreen browsers (Chrome, Firefox, Safari 16), the table width change happens before table becomes difficult to read. On older browser's (Safari 15–), the table width changes after table becomes difficult to read.</sup>

## UI

### After 6b796ba & c4b65c1 & Merge `main`

#### Dahsboard

| short | narrow | full |
| - | - | - |
| ![dashboard - short](https://github.com/TACC/Core-Portal/assets/62723358/210037c6-5537-4a68-892a-2da271f388d5) | ![dashboard - narrow](https://github.com/TACC/Core-Portal/assets/62723358/76e9c657-0572-4ac6-923a-05e5d8660f4a) | ![dashboard - full](https://github.com/TACC/Core-Portal/assets/62723358/da07df80-d8cd-407f-a2e3-daf0c8a2fb0e) |

#### System Status

| short | narrow | full |
| - | - | - |
| ![system - short](https://github.com/TACC/Core-Portal/assets/62723358/3415a0b2-1329-434e-b651-52d457a77627) | ![system - narrow](https://github.com/TACC/Core-Portal/assets/62723358/b2e5092d-0072-44f1-97f9-746a9c7087e1) | ![system - full](https://github.com/TACC/Core-Portal/assets/62723358/6a100fae-bd52-46de-a471-5b718a7b6929) |

### Newer Browser (Actual Test)

I took these screenshots using the code as is, as of e2d96d0.

| wide | narrow |
| - | - |
| ![new browser (actual) - wide](https://github.com/TACC/Core-Portal/assets/62723358/809b7dc2-64d5-4e74-9de1-e4bb495a65fa) | ![new browser (actual) - narrow](https://github.com/TACC/Core-Portal/assets/62723358/a0058a79-df6c-4268-856c-e08c80cda3fd) |

### Older Browser (Estimated Test)

I took these screenshots after temporarily removing the CSS that is unsupported by Safari 15–.

| wide | narrow |
| - | - |
| ![old browser (estimate) - wide](https://github.com/TACC/Core-Portal/assets/62723358/193bd692-fe11-43d5-827e-f2638e1493b2) | ![old browser (estimate) - narrow](https://github.com/TACC/Core-Portal/assets/62723358/31cad333-54f6-4302-8365-81d8c3d4c4f2) |

## Notes

In 8e1fdde and fc883a0, I better isolated the code that is unsupported by Safari 15–.