### PR TITLE
fix(docker): use `latest` not `tapisv3` image

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -49,7 +49,7 @@ services:
   postgres:
     image: postgres:11.5
     volumes:
-      - core_portal_v3_postgres_data:/var/lib/postgresql/data/portal
+      - core_portal_postgres_data:/var/lib/postgresql/data/portal
     container_name: core_portal_postgres
     environment:
       - POSTGRES_PASSWORD=dev
@@ -140,5 +140,5 @@ volumes:
   core_portal_redis_data:
   core_portal_es_data:
   core_portal_rabbitmq_data:
-  core_portal_v3_postgres_data:
+  core_portal_postgres_data:
   core_cms_postgres_data:

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -87,7 +87,7 @@ services:
       - django
 
   websockets:
-    image: taccwma/core-portal:tapisv3
+    image: taccwma/core-portal:latest
     volumes:
       - ../../../.:/srv/www/portal
       - ../nginx/certificates/cep.test.crt:/etc/ssl/cep.test.crt
@@ -100,7 +100,7 @@ services:
     command: 'python manage.py runserver 0.0.0.0:9000'
 
   django:
-    image: taccwma/core-portal:tapisv3
+    image: taccwma/core-portal:latest
     volumes:
       - ../../../.:/srv/www/portal
       - ../../static:/var/www/portal/server/static
@@ -118,7 +118,7 @@ services:
     container_name: core_portal_django
 
   workers:
-    image: taccwma/core-portal:tapisv3
+    image: taccwma/core-portal:latest
     volumes:
       - ../../../.:/srv/www/portal
       - ../../static:/var/www/portal/server/static

--- a/server/conf/docker/docker-compose.yml
+++ b/server/conf/docker/docker-compose.yml
@@ -7,6 +7,6 @@ services:
         context: ../../../.
         dockerfile: server/conf/docker/Dockerfile
         target: development
-      image: taccwma/core-portal:tapisv3
+      image: taccwma/core-portal:latest
       command: /bin/bash
       container_name: core_portal_django


### PR DESCRIPTION
## Overview

Change the Core Portal Docker image to be `:latest` not `:tapisv3`.

> **Warning**
> I do **not** know if this is a correct solution.

## Related

* hotfix for #704

## Changes

- **changed** `:latest` to `:tapisv3`

## Testing

0. `make stop`
1. `make build`
2. `make start`
3. `python manage.py migrate`

Verify **no** `Error response from daemon: manifest for taccwma/core-portal:tapisv3 not found: manifest unknown: manifest unknown`. Verify portal is accessible at https://cep.test (assuming you set that up correctly prior to this PR).

## UI

N/A

## Notes

- [(internal) identification of problem and possible solution](https://tacc-team.slack.com/archives/C04TQ1P04UX/p1687882006083509?thread_ts=1687812398.730479&cid=C04TQ1P04UX)
