### PR TITLE
task/WP-43 - System Monitor UI Update - Sidebar Without Icons

### DIFF
--- a/client/src/components/SystemStatus/SystemStatus.jsx
+++ b/client/src/components/SystemStatus/SystemStatus.jsx
@@ -22,7 +22,6 @@ const SystemStatusSidebar = ({ systemList }) => {
       label: `${system.display_name}`,
       disabled: false,
       hidden: false,
-      iconName: '',
     });
   });
 

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -27,9 +27,7 @@ const SidebarItem = ({ to, iconName, label, children, disabled, hidden }) => {
             styles['content']
           } nav-content`}
         >
-          {iconName && (
-            <Icon name={iconName} className={styles['icon']} />
-          )}
+          {iconName && <Icon name={iconName} className={styles['icon']} />}
           <span className={styles['text']}>{label}</span>
           {children}
         </div>

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -27,7 +27,9 @@ const SidebarItem = ({ to, iconName, label, children, disabled, hidden }) => {
             styles['content']
           } nav-content`}
         >
-          <Icon name={iconName} />
+          {iconName && (
+            <Icon name={iconName} className={styles['icon']} />
+          )}
           <span className={styles['text']}>{label}</span>
           {children}
         </div>

--- a/client/src/components/_common/Sidebar/Sidebar.module.css
+++ b/client/src/components/_common/Sidebar/Sidebar.module.css
@@ -38,8 +38,10 @@
 }
 
 .text {
-  padding-left: 20px;
   font-size: 0.75em; /* ~20px (16px design * 1.2 design-to-app ratio) */
+}
+.icon + .text {
+  padding-left: 20px;
 }
 
 .disabled {


### PR DESCRIPTION
## Overview

Support sidebar with items that do not have icons.

## Related

* new feature first used by #807

## Changes

- **added** class to SidebarItem Icon
- **changed** SidebarItem icon to not appear if no iconName given
- **changed** SidebarItem text to only have padding-left if icon is present
- **changed** SystemMonitor to not pass empty iconName

## Testing

1. Verify "System Status" section sidebar items' left-aligned text is the same distance from edge of section as would be a sidebar item with an icon.

## UI

### Sans Icon

![sans icon](https://github.com/TACC/Core-Portal/assets/62723358/568b1f3e-bc57-4f77-adc6-6832af4d3e0b)

### With Icon

![with icon](https://github.com/TACC/Core-Portal/assets/62723358/556d4444-6430-43a4-9384-90e4fbc26345)