### PR TITLE
docs: fix bad desc of branch prefix "style"

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/Introdu
     - `feat/` for features and updates
     - `fix/` for bugfixes and hotfixes
     - `refactor/` for large internal changes
-    - `style/` for strictly visual changes
+    - `style/` for code style changes (white-space, formatting, etc.)
     - `chore/` for no-op changes
     - `docs/` for documentation
     - `perf/` for performance improvements


### PR DESCRIPTION
## Overview

Fix an inaccurate description for one branch prefix.

## Related

* fixes mistake in #814

## Changes

* **changed** misleading text

## Testing

1. Compare our short descriptions to [longer descritpions I found](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13#types)

## UI

N/A

## Notes

We can use these branch names to help auto-generate changelogs for GitHub releases. I am testing it in TACC/Core-Styles ([workflows](https://github.com/TACC/Core-Styles/tree/main/.github), [release with relevant PRs](https://github.com/TACC/Core-Styles/releases), [labels](https://github.com/TACC/Core-Styles/labels), [guide](https://tiagomichaelsousa.dev/articles/stop-writing-your-changelogs-manually)).