### PR TITLE
Quick: Catch edge case in #830

### DIFF
--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -118,7 +118,7 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
       }
       if (
         ['private', 'projects'].includes(scheme) &&
-        currSystem.effectiveUserId === currentUser
+        currSystem?.effectiveUserId === currentUser
       ) {
         const link = (strings) => (
           <a


### PR DESCRIPTION
## Overview

Fixes an issue (related to #830) where the client would crash if the system doesn't exist.

## Related

* [WP-40](https://jira.tacc.utexas.edu/browse/WP-40)


## Testing

1. Go to https://cep.test/workbench/data/tapis/private/cloud.corral
2. Instead of crashing, displays the default error message.
