### PR TITLE
Quick: handle 3dem workspace migrations

### DIFF
--- a/server/portal/apps/projects/workspace_operations/shared_workspace_migration.py
+++ b/server/portal/apps/projects/workspace_operations/shared_workspace_migration.py
@@ -55,8 +55,10 @@ def migrate_project(project_id):
     except BaseTapyException as e:
         if 'SYSAPI_SYS_EXISTS' in e.message:
             print('A Tapis V3 workspace already exists for this system.')
-            return
-        raise
+        else:
+            print('Error creating workspace system')
+            print(e)
+        return
 
     for co_pi in v2_project.co_pis.all():
         v2_role = get_role(project_id, co_pi.username)

--- a/server/portal/apps/projects/workspace_operations/shared_workspace_migration.py
+++ b/server/portal/apps/projects/workspace_operations/shared_workspace_migration.py
@@ -32,6 +32,7 @@ def get_role(project_id, username):
 
 
 def migrate_project(project_id):
+    print(f'Beginning migration for project: {project_id}')
     client = service_account()
     system_id = f"{settings.PORTAL_PROJECTS_SYSTEM_PREFIX}.{project_id}"
     try:
@@ -77,9 +78,9 @@ def migrate_project(project_id):
 
     client.systems.changeSystemOwner(systemId=system_id, userName=owner)
 
+    print(f'Successfully migrated project id: {project_id}')
+
 
 def migrate_all_projects():
     for prj in ProjectMetadata.objects.all():
-        print(f'Beginning migration for project: {prj.project_id}')
         migrate_project(prj.project_id)
-        print(f'Successfully migrated project id: {prj.project_id}')


### PR DESCRIPTION
## Overview

In Tapis v3, system ids cannot include numbers. To get around this, we need two system prefixes to perform migrations.

## Testing

1. Tested migrating the [3DEM PPRD portal](https://3dem-staging.tacc.utexas.edu/)
