### PR TITLE
task/TV3-164 Remove 10 second system credential delay

### DIFF
--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -4,7 +4,6 @@
 """
 import logging
 import json
-import time
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
@@ -58,10 +57,6 @@ class SystemKeysView(BaseApiView):
                                   publ_key_str,
                                   priv_key_str,
                                   system_id)
-
-        # TODOv3: A 10s delay is added to work-around Tapis issue. This should be removed once the Tapis issue
-        # (https://github.com/tapis-project/tapis-files/issues/58) has been addressed. See https://jira.tacc.utexas.edu/browse/TV3-164
-        time.sleep(10)
 
         return JsonResponse(
             {


### PR DESCRIPTION
## Overview

Removing 10 second delay that was added as a workaround for a tapis cache issue mentioned [here](https://github.com/tapis-project/tapis-files/issues/58). The latest Tapis release has a fix for this cache delay

## Related

* [TV3-164](https://jira.tacc.utexas.edu/browse/TV3-164)

## Changes

- Removed the manual 10 second delay 

## Testing

1. Via command line, delete your frontera credentials, replacing `$USERNAME` with your username:
  a. `client.systems.removeUserCredential(systemId='frontera', userName=$USERNAME)`
2. Wait for cache to clear in Tapis 
3. Go to My Data (Frontera) and go through the push keys process. Ensure file listing works as soon as the modal closes

## UI

No UI Changes
