### PR TITLE
bug/WP-45 Fix Sysmon blank fields for unoperational systems 

### DIFF
--- a/client/src/components/SystemMonitor/SystemMonitor.jsx
+++ b/client/src/components/SystemMonitor/SystemMonitor.jsx
@@ -34,11 +34,11 @@ const SystemsList = ({ system }) => {
         Cell: Load,
       },
       {
-        accessor: ({ jobs }) => (jobs ? jobs.running : '--'),
+        accessor: ({ jobs }) => (jobs?.running ? jobs.running : 0),
         Header: 'Running Jobs',
       },
       {
-        accessor: ({ jobs }) => (jobs ? jobs.queued : '--'),
+        accessor: ({ jobs }) => (jobs?.queued ? jobs.queued : 0),
         Header: 'Waiting Jobs',
       },
     ],


### PR DESCRIPTION
## Overview

Includes fix for a bug where the `Running` and `Waiting` fields in System Monitor component appeared blank when a system is unoperational

## Related

* [WP-45](https://jira.tacc.utexas.edu/browse/WP-45)

## Changes

- Modified an if statement that now checks if job `running` and `waiting` values are defined or not

## Testing

1. To simulate some test data, go to `server/portal/apps/system_monitor/views.py` and replace line 41 with the following snippet

<details>
       <summary>View Snippet</summary>

  ```js
            systems_json = {
                    "Lonestar6": {
                    "display_name": "Lonestar6",
                    "tas_name": "lonestar6",
                    "hostname": "ls6.tacc.utexas.edu",
                    "system_type": "COMPUTE",
                    "timestamp": "2023-07-25T15:30:11.219662+00:00",
                    "online": True,
                    "reachable": False
                    },
                    "Stampede2": {
                    "display_name": "Stampede2",
                    "tas_name": "stampede4",
                    "hostname": "stampede2.tacc.utexas.edu",
                    "system_type": "COMPUTE",
                    "timestamp": "2023-07-25T15:30:12.451893+00:00",
                    "online": True,
                    "reachable": True,
                    "queues_down": True,
                    "load": 0.7872,
                    "running": 330,
                    "waiting": 0,
                    "in_maintenance": False,
                    "next_maintenance": None,
                    "reservations": [
                        {
                            "name": "float_dev",
                            "begin_time": "2023-07-25T12:31:22-05:00",
                            "end_time": "2024-07-24T12:31:22-05:00"
                        }
                        ]
                    }
                }
  ```
</details>

2. Go to the Dashboard in the portal and ensure System Monitor component displays systems correctly and that for systems in maintenance the `Running` and `Waiting` fields are not blank and show 0

## UI

Before
<img width="2048" alt="Screen Shot 2023-07-25 at 10 25 07 AM" src="https://github.com/TACC/Core-Portal/assets/23081932/e4c267d7-9b12-429f-a11b-bc97214a0906">

After
<img width="2048" alt="Screen Shot 2023-07-25 at 1 46 26 PM" src="https://github.com/TACC/Core-Portal/assets/23081932/e4047ceb-1241-4ae9-895e-f428ca252321">


## Notes

