### PR TITLE
task/WP-75  Implement cancel job action

### DIFF
--- a/client/src/components/History/HistoryViews/JobHistoryModal.jsx
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.jsx
@@ -141,6 +141,23 @@ function JobHistoryContent({
     toggle();
   };
 
+  const cancelJob = () => {
+    dispatch({
+      type: 'SUBMIT_JOB',
+      payload: {
+        job_uuid: jobDetails.uuid,
+        action: 'cancel',
+        onSuccess: {
+          type: 'GET_JOBS',
+          params: {
+            offset: 0,
+          },
+        },
+      },
+    });
+    toggle();
+  }
+
   if ('queue' in jobDisplay) {
     configDataObj.Queue = jobDisplay.queue;
   }
@@ -207,6 +224,17 @@ function JobHistoryContent({
             }
           }
         />
+        {!hasEnded && version === 'v3' && (
+          // TODOv3: dropV2Jobs
+          <Button
+            type="primary"
+            attr="submit"
+            className={styles['submit-button']}
+            onClick={cancelJob}
+          >
+            Cancel Job
+          </Button>
+        )}
         {hasEnded && version === 'v3' && (
           // TODOv3: dropV2Jobs
           <Button

--- a/client/src/components/History/HistoryViews/JobHistoryModal.jsx
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.jsx
@@ -156,7 +156,7 @@ function JobHistoryContent({
       },
     });
     toggle();
-  }
+  };
 
   if ('queue' in jobDisplay) {
     configDataObj.Queue = jobDisplay.queue;


### PR DESCRIPTION
## Overview

Goal for this task was to add a `Cancel Job` action for a job in the job details before it is completed.

## Related

* [WP-75](https://jira.tacc.utexas.edu/browse/WP-75)

## Changes

1- Added a Cancel Job button in the Jobs Detail view and added a cancel job flow that is kicked off after button is clicked

## Testing

1. Go to Applications in the Portal and using any Application submit a job
2. Go to the History tab and go to the job details of the job you submitted
3. Ensure Cancel Job button is visible
4. Click on Cancel Job and ensure modal closes and job status is updated. Will need to enable webhook notifications for status to update without page refresh

## UI
<img width="2048" alt="Screen Shot 2023-07-25 at 2 11 56 PM" src="https://github.com/TACC/Core-Portal/assets/23081932/0a6874e7-6290-4152-8f50-66dd91bcd82e">

<img width="2048" alt="Screen Shot 2023-07-25 at 2 12 07 PM" src="https://github.com/TACC/Core-Portal/assets/23081932/4ec68aac-48ff-4ec9-b6c9-60b69bad20fa">




## Notes

