### PR TITLE
Task/WP-194 filter out readonly parameters and file inputs from job submission

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -474,7 +474,7 @@ export const AppSchemaForm = ({ app }) => {
               ([parameterSet, parameterValue]) => {
                 return {
                   [parameterSet]: Object.entries(parameterValue)
-                     .map(([k, v]) => {
+                    .map(([k, v]) => {
                       if (!v) return;
                       // filter read only parameters. 'FIXED' parameters are tracked as readOnly
                       if (Object.hasOwn(appFields.parameterSet[parameterSet], k)

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -461,9 +461,12 @@ export const AppSchemaForm = ({ app }) => {
 
           job.fileInputs = Object.entries(job.fileInputs)
             .map(([k, v]) => {
+              // filter out read only inputs. 'FIXED' inputs are tracked as readOnly
+              if (Object.hasOwn(appFields.fileInputs, k)
+                          && appFields.fileInputs[k].readOnly) return;
               return { name: k, sourceUrl: v };
             })
-            .filter((fileInput) => fileInput.sourceUrl); // filter out any empty values
+            .filter((fileInput) => fileInput && fileInput.sourceUrl); // filter out any empty values
 
           job.parameterSet = Object.assign(
             {},
@@ -471,8 +474,11 @@ export const AppSchemaForm = ({ app }) => {
               ([parameterSet, parameterValue]) => {
                 return {
                   [parameterSet]: Object.entries(parameterValue)
-                    .map(([k, v]) => {
+                     .map(([k, v]) => {
                       if (!v) return;
+                      // filter read only parameters. 'FIXED' parameters are tracked as readOnly
+                      if (Object.hasOwn(appFields.parameterSet[parameterSet], k)
+                          && appFields.parameterSet[parameterSet][k].readOnly) return;
                       return parameterSet === 'envVariables'
                         ? { key: k, value: v }
                         : { name: k, arg: v };

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -462,8 +462,11 @@ export const AppSchemaForm = ({ app }) => {
           job.fileInputs = Object.entries(job.fileInputs)
             .map(([k, v]) => {
               // filter out read only inputs. 'FIXED' inputs are tracked as readOnly
-              if (Object.hasOwn(appFields.fileInputs, k)
-                          && appFields.fileInputs[k].readOnly) return;
+              if (
+                Object.hasOwn(appFields.fileInputs, k) &&
+                appFields.fileInputs[k].readOnly
+              )
+                return;
               return { name: k, sourceUrl: v };
             })
             .filter((fileInput) => fileInput && fileInput.sourceUrl); // filter out any empty values
@@ -477,8 +480,14 @@ export const AppSchemaForm = ({ app }) => {
                     .map(([k, v]) => {
                       if (!v) return;
                       // filter read only parameters. 'FIXED' parameters are tracked as readOnly
-                      if (Object.hasOwn(appFields.parameterSet[parameterSet], k)
-                          && appFields.parameterSet[parameterSet][k].readOnly) return;
+                      if (
+                        Object.hasOwn(
+                          appFields.parameterSet[parameterSet],
+                          k
+                        ) &&
+                        appFields.parameterSet[parameterSet][k].readOnly
+                      )
+                        return;
                       return parameterSet === 'envVariables'
                         ? { key: k, value: v }
                         : { name: k, arg: v };


### PR DESCRIPTION
## Overview
In tapis-v3, if a parameter or file input is marked 'FIXED' in app definition, it is not allowed to be overridden in job submission parameters. [Note from tapis docs](https://tapis.readthedocs.io/en/latest/technical/apps.html#arg-attributes-table)

To avoid failing job submission, any 'FIXED' parameters should be removed from job submission.

Some of the use cases seen in app definitions:
* FIXED parameter with notes field set to hidden. This is hidden and not shown in UI. This is already skipped in job submission even without this PR.
* FIXED parameter with no hidden value in notes field. This is shown in UI but as readonly field. This is currently submitted to jobs and the job creation fails.

## Related

* [WP-194](https://jira.tacc.utexas.edu/browse/WP-194)

## Changes
In onsubmit for creating a Job, filter out parameters and file input. The code reference uses readonly property. readonly is how 'FIXED' parameters are tracked once the app definition is read into AppForm.

## Testing

Local setup:
Use the settings from this stache: https://stache.utexas.edu/entry/bedc97190d3a907cb44488785440595c. This enables portals.tapis.io applications to shown in client and enables better testing.

### Testing without the fix:
* Submit https://cep.test/workbench/applications/jupyter-notebook-hpc?appVersion=0.0.1 and see the error 
![Screenshot 2023-07-26 at 10 28 53 AM](https://github.com/TACC/Core-Portal/assets/2568355/1f8822eb-0ce1-4c81-ac56-07e496348e83)

### Testing with the fix:
* Submit https://cep.test/workbench/applications/jupyter-notebook-hpc?appVersion=0.0.1 job and see that it is successful
* Job parameters submitted to backend:
```
{
  "job": {
    "fileInputs": [],
    "parameterSet": {
      "appArgs": [],
      "containerArgs": [],
      "schedulerOptions": [
        {
          "name": "TACC Allocation",
          "description": "The TACC allocation associated with this job execution",
          "include": true,
          "arg": "-A TACC-ACI"
        }
      ],
      "envVariables": []
    },
    "name": "jupyter-notebook-hpc-0.0.1_2023-07-28T16:03:02",
    "nodeCount": 1,
    "coresPerNode": 1,
    "maxMinutes": 10,
    "archiveSystemId": "cloud.data",
    "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
    "archiveOnAppError": true,
    "appId": "jupyter-notebook-hpc",
    "appVersion": "0.0.1",
    "execSystemId": "frontera",
    "execSystemLogicalQueue": "development"
  },
  "licenseType": null,
  "isInteractive": true
}
```
Screenshot of successful submission
![Screenshot 2023-07-27 at 9 49 57 PM](https://github.com/TACC/Core-Portal/assets/2568355/84049300-ef26-4437-900d-e05fb33b6e8a)



* Submit file input based app to ensure there is no regression with change in file input processing : https://cep.test/workbench/applications/extract?appVersion=0.0.1
Job is created successfully and job input has the right parameters
```
{
  "job": {
    "fileInputs": [
      {
        "name": "Input File",
        "sourceUrl": "tapis://cloud.data/home/cyemparala/tmp/samplefile.txt.zip"
      }
    ],
    "parameterSet": {
      "appArgs": [],
      "containerArgs": [],
      "schedulerOptions": [
        {
          "name": "TACC Allocation",
          "description": "The TACC allocation associated with this job execution",
          "include": true,
          "arg": "-A TACC-ACI"
        }
      ],
      "envVariables": []
    },
    "name": "extract-0.0.1_2023-07-28T16:03:52",
    "nodeCount": 1,
    "coresPerNode": 1,
    "maxMinutes": 10,
    "archiveSystemId": "cloud.data",
    "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
    "archiveOnAppError": true,
    "appId": "extract",
    "appVersion": "0.0.1",
    "execSystemId": "frontera",
    "execSystemLogicalQueue": "development"
  },
  "licenseType": null,
  "isInteractive": false
}
```

* npm run test did not show any failures

## UI
There is no UI change.


## Notes
More thorough testing can be done via unit tests, this PR does not include it. Next step would be to update AppForm tests to include job submission. analysis.
