### PR TITLE
Add targetPath to job.fileInputs

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -461,7 +461,13 @@ export const AppSchemaForm = ({ app }) => {
 
           job.fileInputs = Object.entries(job.fileInputs)
             .map(([k, v]) => {
-              return { name: k, sourceUrl: v };
+              return { 
+                name: k, 
+                sourceUrl: v, 
+                targetPath: app.definition.jobAttributes.fileInputs.find(
+                  (file) => file.name === k
+                ).targetPath,
+              };
             })
             .filter((fileInput) => fileInput.sourceUrl); // filter out any empty values
 


### PR DESCRIPTION
targetPath from app definition is added to the job submission under job.fileInputs

## Overview



## Related

* [WP-211](https://jira.tacc.utexas.edu/browse/WP-211)
* App Form: Add support for "targetPath" of a fileInput

## Changes

Add targetPath value to job.fleInputs

## Testing

1.



## UI



## Notes

<img width="540" alt="Screenshot 2023-08-02 at 2 56 46 PM" src="https://github.com/TACC/Core-Portal/assets/43958517/adb2a2a1-22b9-4a95-a9e3-0b3ebf269886">
