### PR TITLE
bug/WP-230: Prevent other users' files from appearing in search results

### DIFF
--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -110,6 +110,10 @@ def search(client, system, path='', offset=0, limit=100, query_string='', filter
         List of dicts containing file metadata from Elasticsearch
 
     """
+
+    # Perform a listing to ensure the user has access to the directory they're searching
+    listing(client, system, path)
+
     if filter == 'Folders':
         filter_query = Q('term', **{'format': 'folder'})
     else:
@@ -135,6 +139,7 @@ def search(client, system, path='', offset=0, limit=100, query_string='', filter
     if filter:
         search = search.filter(filter_query)
 
+    search = search.filter('prefix', **{'path._exact': path})
     search = search.filter('term', **{'system._exact': system})
     search = search.extra(from_=int(offset), size=int(limit))
     res = search.execute()

--- a/server/portal/libs/agave/operations_unit_test.py
+++ b/server/portal/libs/agave/operations_unit_test.py
@@ -50,8 +50,9 @@ class TestOperations(TestCase):
         self.assertEqual(ls, {'listing': mock_response_listing,
                               'reachedEnd': True})
 
+    @patch('portal.libs.agave.operations.listing')
     @patch('portal.libs.agave.operations.IndexedFile.search')
-    def test_search(self, mock_search):
+    def test_search(self, mock_search, mock_listing):
         mock_hit = Hit({})
         mock_hit.system = 'test.system'
         mock_hit.path = '/path/to/file'
@@ -59,7 +60,7 @@ class TestOperations(TestCase):
         mock_result = MagicMock()
         mock_result.__iter__.return_value = [mock_hit]
         mock_result.hits.total.value = 1
-        mock_search().query().filter().extra().execute\
+        mock_search().query().filter().filter().extra().execute\
             .return_value = mock_result
 
         search_res = search(None, 'test.system', '/path', query_string='query')
@@ -72,8 +73,10 @@ class TestOperations(TestCase):
                                                  fields=[
                                                      "name._exact, name._pattern"],
                                                  default_operator='and'))
-        mock_search().query().filter.assert_called_with('term', **{'system._exact': 'test.system'})
-        mock_search().query().filter().extra.assert_called_with(from_=int(0), size=int(100))
+        
+        mock_search().query().filter.assert_called_with('prefix', **{'path._exact': '/path'})
+        mock_search().query().filter().filter.assert_called_with('term', **{'system._exact': 'test.system'})
+        mock_search().query().filter().filter().extra.assert_called_with(from_=int(0), size=int(100))
         self.assertEqual(search_res, {'listing':
                                       [{'system': 'test.system',
                                         'path': '/path/to/file'}],

--- a/server/portal/libs/agave/operations_unit_test.py
+++ b/server/portal/libs/agave/operations_unit_test.py
@@ -73,7 +73,7 @@ class TestOperations(TestCase):
                                                  fields=[
                                                      "name._exact, name._pattern"],
                                                  default_operator='and'))
-        
+
         mock_search().query().filter.assert_called_with('prefix', **{'path._exact': '/path'})
         mock_search().query().filter().filter.assert_called_with('term', **{'system._exact': 'test.system'})
         mock_search().query().filter().filter().extra.assert_called_with(from_=int(0), size=int(100))


### PR DESCRIPTION
## Overview
Fix a bug where multiple users' files could appear in search results in Data Files

## Related

* [WP-230](https://jira.tacc.utexas.edu/browse/WP-230)

## Changes
- use the path as a prefix when querying the Files index, so that search results do not contain files from out of scope.
- Perform a listing before the search query to double check that the client performing the search has access to the files.


## Testing

1. Perform a search in the Data Files area and make sure no other users' files appear in the listing.


