### PR TITLE
Security: Prevent user search endpoint from returning all user profiles

### DIFF
--- a/server/portal/apps/users/views.py
+++ b/server/portal/apps/users/views.py
@@ -107,6 +107,11 @@ class SearchView(BaseApiView):
         if role:
             logger.info(role)
             user_rs = user_rs.filter(groups__name=role)
+
+        # Prevent endpoint from returning unfiltered user list.
+        if not q and not role:
+            return HttpResponseNotFound()
+
         resp = [model_to_dict(u, fields=resp_fields) for u in user_rs]
         if len(resp):
             return JsonResponse(resp, safe=False)


### PR DESCRIPTION
## Overview
Address a security issue where a call to `/api/users` would return all user profiles if a query string wasn't passed.

