### PR TITLE
task/WP-189 Handle timeout exit code for interactive app jobs

### DIFF
--- a/server/portal/apps/webhooks/views.py
+++ b/server/portal/apps/webhooks/views.py
@@ -54,6 +54,14 @@ def validate_tapis_job(job_uuid, job_owner, disallowed_states=[]):
     if job_data.status in disallowed_states:
         return None
 
+    if hasattr(job_data, 'notes') and job_data.status == 'FAILED':
+        notes = json.loads(job_data.notes)
+
+        # checks to see if an interactive job ended with tapis timeout code of 0:0
+        if notes.get('isInteractive', False) and job_data.remoteResultInfo == '0:0':
+            job_data.status = 'FINISHED'
+            job_data.remoteOutcome = 'FINISHED'
+
     return job_data
 
 
@@ -122,6 +130,7 @@ class JobsWebhookView(BaseApiView):
             job_details = validate_tapis_job(job_uuid, username, disallowed_states=non_terminal_states)
             if job_details:
                 event_data[Notification.EXTRA]['remoteOutcome'] = job_details.remoteOutcome
+                event_data[Notification.EXTRA]['status'] = job_details.status
 
                 try:
                     logger.info('Indexing job output for job={}'.format(job_uuid))

--- a/server/portal/apps/webhooks/views.py
+++ b/server/portal/apps/webhooks/views.py
@@ -20,6 +20,7 @@ from portal.apps.webhooks.utils import (
     validate_webhook,
     execute_callback
 )
+from portal.apps.workspace.api.utils import check_job_for_timeout
 
 from django.conf import settings
 
@@ -54,13 +55,7 @@ def validate_tapis_job(job_uuid, job_owner, disallowed_states=[]):
     if job_data.status in disallowed_states:
         return None
 
-    if hasattr(job_data, 'notes') and job_data.status == 'FAILED':
-        notes = json.loads(job_data.notes)
-
-        # checks to see if an interactive job ended with tapis timeout code of 0:0
-        if notes.get('isInteractive', False) and job_data.remoteResultInfo == '0:0':
-            job_data.status = 'FINISHED'
-            job_data.remoteOutcome = 'FINISHED'
+    job_data = check_job_for_timeout(job_data)
 
     return job_data
 

--- a/server/portal/apps/workspace/api/utils.py
+++ b/server/portal/apps/workspace/api/utils.py
@@ -1,0 +1,23 @@
+import json
+
+
+def get_tapis_timeout_error_messages(job_id):
+    return [
+        'JOBS_EARLY_TERMINATION Job terminated by Tapis because: TIME_EXPIRED',
+        f'JOBS_USER_APP_FAILURE The user application ({job_id}) ended with remote status "TIMEOUT" and returned exit code: 0:0.'
+    ]
+
+
+def check_job_for_timeout(job):
+    if (hasattr(job, 'notes')):
+        notes = json.loads(job.notes)
+
+        is_failed = job.status == 'FAILED'
+        is_interactive = notes.get('isInteractive', False)
+        has_timeout_message = job.lastMessage in get_tapis_timeout_error_messages(job.remoteJobId)
+
+        if is_failed and is_interactive and has_timeout_message:
+            job.status = 'FINISHED'
+            job.remoteOutcome = 'FINISHED'
+
+    return job

--- a/server/portal/apps/workspace/api/utils.py
+++ b/server/portal/apps/workspace/api/utils.py
@@ -9,6 +9,11 @@ def get_tapis_timeout_error_messages(job_id):
 
 
 def check_job_for_timeout(job):
+    """
+    Check an interactive job for timeout status and mark it as finished
+    since Tapis does not have native support for interactive jobs yet
+    """
+
     if (hasattr(job, 'notes')):
         notes = json.loads(job.notes)
 

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -138,7 +138,7 @@ class HistoricJobsView(BaseApiView):
 
 @method_decorator(login_required, name='dispatch')
 class JobsView(BaseApiView):
-    
+
     @staticmethod
     def check_job_for_timeout(job):
         if hasattr(job, 'notes') and job.status == 'FAILED':
@@ -148,9 +148,9 @@ class JobsView(BaseApiView):
             if notes.get('isInteractive', False) and job.remoteResultInfo == '0:0':
                 job.status = 'FINISHED'
                 job.remoteOutcome = 'FINISHED'
-        
+
         return job
-   
+
     def get(self, request, operation=None):
 
         allowed_actions = ['listing', 'search', 'select']
@@ -164,7 +164,7 @@ class JobsView(BaseApiView):
         data = op(tapis, request)
 
         if (isinstance(data, list)):
-            for index, job in enumerate(data): 
+            for index, job in enumerate(data):
                 data[index] = self.check_job_for_timeout(job)
         else:
             data = self.check_job_for_timeout(data)

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -140,28 +140,6 @@ class HistoricJobsView(BaseApiView):
 @method_decorator(login_required, name='dispatch')
 class JobsView(BaseApiView):
 
-    # @staticmethod
-    # def get_tapis_timeout_error_messages(job_id):
-    #     return [
-    #         'JOBS_EARLY_TERMINATION Job terminated by Tapis because: TIME_EXPIRED',
-    #         f'JOBS_USER_APP_FAILURE The user application ({job_id}) ended with remote status "TIMEOUT" and returned exit code: 0:0.'
-    #     ]
-
-    # @staticmethod
-    # def check_job_for_timeout(job, timeout_messages):
-    #     if (hasattr(job, 'notes')):
-    #         notes = json.loads(job.notes)
-
-    #         is_failed = job.status == 'FAILED'
-    #         is_interactive = notes.get('isInteractive', False)
-    #         has_timeout_message = job.lastMessage in timeout_messages
-
-    #         if is_failed and is_interactive and has_timeout_message:
-    #             job.status = 'FINISHED'
-    #             job.remoteOutcome = 'FINISHED'
-
-    #     return job
-
     def get(self, request, operation=None):
 
         allowed_actions = ['listing', 'search', 'select']


### PR DESCRIPTION
## Overview

Fixes an issue where after timing out an interactive job is displayed as FAILED when in fact the job was successful and should have the FINISHED state because it timed out after reaching the maximum allotted time.  

## Related

* [WP-189](https://jira.tacc.utexas.edu/browse/WP-189)

## Changes

The changes implemented here are on the portal side where a check is made to confirm if the job is interactive and whether or not it ended because of a timeout. On the tapis side the job state remains `FAILED` but we are able to use the exit code provided in the `remoteResultInfo` attribute of a job to determine if it was a timeout and display a success message on the portal side. This change is made in `JobsView` and `JobsWebhookView` endpoints 

## Testing

1. Enable webhook notifications in order to see job status updates without page refresh
1. Go to Applications inside the portal and select an interactive app such as [Jupyter Lab HPC](https://cep.test/workbench/applications/jupyter-lab-hpc?appVersion=0.0.1) 
2. Set the Maximum Job Runtime to a low number such as 1 
3. Start the job and after successful submission go to the History tab to monitor job progress
4. The job should go through the regular job states and should end with the `FINISHED` state after reaching the maximum runtime limit 

## UI

- No UI changes


## Notes

Follow up question: Does the last status message displayed in the job detail modal need to be modified as well? Currently it shows the timeout error message sent from Tapis