### PR TITLE
WP-172: Minimize unit test warnings

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -186,7 +186,7 @@ module.exports = {
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run
-  // verbose: undefined,
+  verbose: true,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
   // watchPathIgnorePatterns: [],

--- a/client/jest.setup.js
+++ b/client/jest.setup.js
@@ -1,1 +1,11 @@
 jest.mock('@niivue/niivue', () => {});
+
+global.console = {
+  ...console,
+  // uncomment to ignore a specific log level
+  //log: jest.fn(),
+  //debug: jest.fn(),
+  //info: jest.fn(),
+  //warn: jest.fn(),
+  //error: jest.fn(),
+};


### PR DESCRIPTION
## Overview

Running unit tests results in a lot of errors, this change adds some options in the settings to hide various levels of warnings, errors, etc.

## Related

* [WP-172](https://jira.tacc.utexas.edu/browse/WP-172)

## Changes

Added setting to jest configuration that can be uncommented to suppress various levels of logging. Also added the "verbose" option to make the unit test output nicer looking.

## Testing

1. In client/jest.setup.js uncomment log levels 
2. Run tests and verify that the log levels are suppressed

## UI

With all log levels suppressed

![Screenshot from 2023-06-29 14-29-31](https://github.com/TACC/Core-Portal/assets/1160892/9566eb4f-b32e-40c0-9b93-8428b557ea1b)


## Notes

