### PR TITLE
WP-190: Client Token Mutex

### DIFF
--- a/server/portal/apps/auth/models.py
+++ b/server/portal/apps/auth/models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.conf import settings
 from tapipy.tapis import Tapis
 from django.db import transaction
+from threading import Lock
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,11 @@ class TapisOAuthToken(models.Model):
         with transaction.atomic():
             if self.expired:
                 try:
-                    client.refresh_tokens()
+                    lock = Lock()
+                    logger.debug("getting lock")
+                    with lock:
+                        logger.debug("refreshing token with lock")
+                        client.refresh_tokens()
                 except Exception:
                     logger.exception('Tapis Token refresh failed')
                     raise


### PR DESCRIPTION
## Overview

Attempting to add a threading lock to the client refresh token code so that it doesn't keep trying to refresh the token on new threads.

## Related

* [WP-190](https://jira.tacc.utexas.edu/browse/WP-190)

## Changes

Added a small bit of code to (hopefully) lock the refresh_token function so that it is only called once. 

## Testing

I have no idea how to test this, definitely need to do some stress testing in dev or something before full deploy. 

## UI



## Notes

