### PR TITLE
Task/WP-211: App Form updates to allow target path

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -463,7 +463,12 @@ export const AppSchemaForm = ({ app }) => {
         onSubmit={(values, { setSubmitting, resetForm }) => {
           const job = cloneDeep(values);
 
-          // Transform input field values into format that jobs service wants
+          // Transform input field values into format that jobs service wants.
+          // File Input structure will have 2 fields if target path is required by the app.
+          // field 1 - has source url
+          // field 2 - has target path for the source url.
+          // tapis wants only 1 field with 2 properties - source url and target path.
+          // The logic below handles that scenario by merging the related fields into 1 field.
           job.fileInputs = Object.values(
             Object.entries(job.fileInputs)
               .map(([k, v]) => {
@@ -494,7 +499,13 @@ export const AppSchemaForm = ({ app }) => {
               }, {})
           )
             .flat()
-            .filter((fileInput) => fileInput.sourceUrl); // filter out any empty values
+            .filter((fileInput) => fileInput.sourceUrl) // filter out any empty values
+            .map((fileInput) => {
+              fileInput.targetPath = checkAndSetDefaultTargetPath(
+                fileInput.targetPath
+              );
+              return fileInput;
+            });
 
           job.parameterSet = Object.assign(
             {},

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -479,7 +479,6 @@ export const AppSchemaForm = ({ app }) => {
                   targetDir: isTargetPathField(k) ? v : null,
                 };
               })
-              .filter((fileInput) => fileInput.sourceUrl || fileInput.targetDir) // filter out any empty values
               .reduce((acc, entry) => {
                 // merge input field and targetPath fields into one.
                 const key = getInputFieldFromTargetPathField(entry.name);
@@ -493,7 +492,9 @@ export const AppSchemaForm = ({ app }) => {
                   acc[key]['targetPath'] ?? entry.targetDir;
                 return acc;
               }, {})
-          ).flat();
+          )
+            .flat()
+            .filter((fileInput) => fileInput.sourceUrl); // filter out any empty values
 
           job.parameterSet = Object.assign(
             {},

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -19,10 +19,14 @@ import { Link } from 'react-router-dom';
 import { getSystemName } from 'utils/systems';
 import FormSchema from './AppFormSchema';
 import {
+  checkAndSetDefaultTargetPath,
+  isTargetPathField,
+  getInputFieldFromTargetPathField,
   getQueueMaxMinutes,
   getMaxMinutesValidation,
   getNodeCountValidation,
   getCoresPerNodeValidation,
+  getTargetPathFieldName,
   updateValuesForQueue,
 } from './AppFormUtils';
 import DataFilesSelectModal from '../../DataFiles/DataFilesModals/DataFilesSelectModal';
@@ -459,17 +463,37 @@ export const AppSchemaForm = ({ app }) => {
         onSubmit={(values, { setSubmitting, resetForm }) => {
           const job = cloneDeep(values);
 
-          job.fileInputs = Object.entries(job.fileInputs)
-            .map(([k, v]) => {
-              // filter out read only inputs. 'FIXED' inputs are tracked as readOnly
-              if (
-                Object.hasOwn(appFields.fileInputs, k) &&
-                appFields.fileInputs[k].readOnly
-              )
-                return;
-              return { name: k, sourceUrl: v };
-            })
-            .filter((fileInput) => fileInput && fileInput.sourceUrl); // filter out any empty values
+          // Transform input field values into format that jobs service wants
+          job.fileInputs = Object.values(
+            Object.entries(job.fileInputs)
+              .map(([k, v]) => {
+                // filter out read only inputs. 'FIXED' inputs are tracked as readOnly
+                if (
+                  Object.hasOwn(appFields.fileInputs, k) &&
+                  appFields.fileInputs[k].readOnly
+                )
+                  return;
+                return {
+                  name: k,
+                  sourceUrl: !isTargetPathField(k) ? v : null,
+                  targetDir: isTargetPathField(k) ? v : null,
+                };
+              })
+              .filter((fileInput) => fileInput.sourceUrl || fileInput.targetDir) // filter out any empty values
+              .reduce((acc, entry) => {
+                // merge input field and targetPath fields into one.
+                const key = getInputFieldFromTargetPathField(entry.name);
+                if (!acc[key]) {
+                  acc[key] = {};
+                }
+                acc[key]['name'] = key;
+                acc[key]['sourceUrl'] =
+                  acc[key]['sourceUrl'] ?? entry.sourceUrl;
+                acc[key]['targetPath'] =
+                  acc[key]['targetPath'] ?? entry.targetDir;
+                return acc;
+              }, {})
+          ).flat();
 
           job.parameterSet = Object.assign(
             {},
@@ -559,8 +583,15 @@ export const AppSchemaForm = ({ app }) => {
                     </div>
                     {Object.entries(appFields.fileInputs).map(
                       ([name, field]) => {
-                        // TODOv3 handle fileInputArrays https://jira.tacc.utexas.edu/browse/TV3-81
-                        return (
+                        // TODOv3 handle fileInputArrays https://jira.tacc.utexas.edu/browse/WP-81
+                        return isTargetPathField(name) ? (
+                          <FormField
+                            {...field}
+                            name={`fileInputs.${name}`}
+                            placeholder="Target Path Name"
+                            key={`fileInputs.${name}`}
+                          />
+                        ) : (
                           <FormField
                             {...field}
                             name={`fileInputs.${name}`}

--- a/client/src/components/Applications/AppForm/AppFormSchema.js
+++ b/client/src/components/Applications/AppForm/AppFormSchema.js
@@ -101,6 +101,9 @@ const FormSchema = (app) => {
     }
   );
 
+  // The default is to not show target path for file inputs.
+  const showTargetPathForFileInputs =
+    app.definition.notes.showTargetPath ?? false;
   (app.definition.jobAttributes.fileInputs || []).forEach((i) => {
     const input = i;
     /* TODOv3 consider hidden file inputs https://jira.tacc.utexas.edu/browse/WP-102
@@ -137,6 +140,9 @@ const FormSchema = (app) => {
         : input.sourceUrl;
 
     // Add targetDir for all sourceUrl
+    if (!showTargetPathForFileInputs) {
+      return;
+    }
     const targetPathName = getTargetPathFieldName(input.name);
     appFields.schema.fileInputs[targetPathName] = Yup.string();
     appFields.schema.fileInputs[targetPathName] = appFields.schema.fileInputs[
@@ -150,7 +156,9 @@ const FormSchema = (app) => {
     appFields.fileInputs[targetPathName] = {
       label: 'Target Path for ' + input.name,
       description:
-        "The target path is the location to which data are copied from the input. Empty target path or '*' indicates, the simple directory or file name from the input path is automatically assign to the target path.",
+        'The name of the ' +
+        input.name +
+        ' after it is copied to the target system, but before the job is run. Leave this value blank to just use the name of the input file.',
       required: false,
       readOnly: field.readOnly,
       type: 'text',

--- a/client/src/components/Applications/AppForm/AppFormSchema.js
+++ b/client/src/components/Applications/AppForm/AppFormSchema.js
@@ -1,4 +1,8 @@
 import * as Yup from 'yup';
+import {
+  checkAndSetDefaultTargetPath,
+  getTargetPathFieldName,
+} from './AppFormUtils';
 
 const FormSchema = (app) => {
   const appFields = {
@@ -131,6 +135,28 @@ const FormSchema = (app) => {
       input.sourceUrl === null || typeof input.sourceUrl === 'undefined'
         ? ''
         : input.sourceUrl;
+
+    // Add targetDir for all sourceUrl
+    const targetPathName = getTargetPathFieldName(input.name);
+    appFields.schema.fileInputs[targetPathName] = Yup.string();
+    appFields.schema.fileInputs[targetPathName] = appFields.schema.fileInputs[
+      targetPathName
+    ].matches(
+      /^tapis:\/\//g,
+      "Input file Target Directory must be a valid Tapis URI, starting with 'tapis://'"
+    );
+
+    appFields.schema.fileInputs[targetPathName] = false;
+    appFields.fileInputs[targetPathName] = {
+      label: 'Target Path for ' + input.name,
+      description:
+        "The target path is the location to which data are copied from the input. Empty target path or '*' indicates, the simple directory or file name from the input path is automatically assign to the target path.",
+      required: false,
+      readOnly: field.readOnly,
+      type: 'text',
+    };
+    appFields.defaults.fileInputs[targetPathName] =
+      checkAndSetDefaultTargetPath(input.targetPath);
   });
   return appFields;
 };

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -1,6 +1,8 @@
 import * as Yup from 'yup';
 import { getSystemName } from 'utils/systems';
 
+export const TARGET_PATH_FIELD_PREFIX = '_TargetPath_';
+
 export const getQueueMaxMinutes = (app, queueName) => {
   return app.exec_sys.batchLogicalQueues.find((q) => q.name === queueName)
     .maxMinutes;
@@ -164,4 +166,58 @@ export const updateValuesForQueue = (app, values) => {
      */
 
   return updatedValues;
+};
+
+/**
+ * Get the field name used for target path in AppForm
+ *
+ * @function
+ * @param {String} inputFieldName
+ * @returns {String} field Name prefixed with target path
+ */
+export const getTargetPathFieldName = (inputFieldName) => {
+  return TARGET_PATH_FIELD_PREFIX + inputFieldName;
+};
+
+/**
+ * Whether a field name is a system defined field for Target Path
+ *
+ * @function
+ * @param {String} inputFieldName
+ * @returns {String} field Name suffixed with target path
+ */
+export const isTargetPathField = (inputFieldName) => {
+  return inputFieldName && inputFieldName.startsWith(TARGET_PATH_FIELD_PREFIX);
+};
+
+/**
+ * From target path field name, derive the original input field name.
+ *
+ * @function
+ * @param {String} targetPathFieldName
+ * @returns {String} actual field name
+ */
+export const getInputFieldFromTargetPathField = (targetPathFieldName) => {
+  return targetPathFieldName.replace(TARGET_PATH_FIELD_PREFIX, '');
+};
+
+/**
+ * Sets the default value if target path is not set.
+ *
+ * @function
+ * @param {String} targetPathFieldValue
+ * @returns {String} target path value
+ */
+export const checkAndSetDefaultTargetPath = (targetPathFieldValue) => {
+  if (targetPathFieldValue === null || targetPathFieldValue === undefined) {
+    return '*';
+  }
+
+  targetPathFieldValue = targetPathFieldValue.trim();
+
+  if (targetPathFieldValue.trim() === '') {
+    return '*';
+  }
+
+  return targetPathFieldValue;
 };


### PR DESCRIPTION
## Overview
TAPIS V3 provides a mechanism to pass in path to copy input contents into. This path is optional. 
From tapis docs:
_"A JobFileInput object is complete when its sourceUrl and targetPath are assigned; this provides the minimal information needed to effect a transfer. If only the sourceUrl is set, Jobs will use the simple directory or file name from the URL to automatically assign the targetPath. Specifying a targetPath as “*” results in the same automatic assignment."_
[TAPIS V3 doc](https://tapis.readthedocs.io/en/latest/technical/jobs.html)

## Related

* [WP-211](https://jira.tacc.utexas.edu/browse/WP-211)
* App Form: Add support for "targetPath" of a fileInput

## Changes

* Add form field for target path when processing file inputs
* When populating job data, retrieve target path info and populate it according to tapis v3 structure.
* Use notes: targetPath as a hint to show or hide target Path in App Form. The default is false.

## Testing

1. Check if extract or compress app are in app tray or any other app that takes file input.
2. Target Path is shown for extract app. 
3. Target Path is NOT shown for compress app. This is hidden based on the app definition (see notes section).
4. Check that for every field with file input, there is a Target Path for <field name> field added to the form
5. Check with different input types - providing a name, * or empty value (results in *) work with successfully creating a job.
6. Check if the job output matches what is expected.



## UI

**Input form change**
![Screenshot 2023-09-26 at 10 14 55 AM](https://github.com/TACC/Core-Portal/assets/2568355/31a73528-5304-4f80-b0c5-cdf67cd67ef0)

**Input with no target path (example OpenSees)**
![Screenshot 2023-09-26 at 10 32 37 AM](https://github.com/TACC/Core-Portal/assets/2568355/79c44c24-9ca2-401e-96e7-5dfecf1f8a4a)


**Successful job submission**
![Screenshot 2023-09-12 at 6 22 20 PM](https://github.com/TACC/Core-Portal/assets/2568355/f235fe29-4418-466b-9b98-c7ad4d833aae)

**Job payload updated**
![Screenshot 2023-09-12 at 6 28 11 PM](https://github.com/TACC/Core-Portal/assets/2568355/03e32c9e-2710-42a5-ac7f-16f036286637)

**Job output folder**
![Screenshot 2023-09-12 at 6 29 35 PM](https://github.com/TACC/Core-Portal/assets/2568355/71defb34-03c3-4889-86cc-84245db4334c)


## Notes

<img width="540" alt="Screenshot 2023-08-02 at 2 56 46 PM" src="https://github.com/TACC/Core-Portal/assets/43958517/adb2a2a1-22b9-4a95-a9e3-0b3ebf269886">

