### PR TITLE
bug/WP-249 Shared Workspace Copy Bug Fix

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.jsx
@@ -81,7 +81,7 @@ const DataFilesCopyModal = React.memo(() => {
         srcApi: params.api,
         destApi: modalParams.api,
         destSystem: system,
-        destPath: path,
+        destPath: path || '/',
         name,
         callback: reloadPage,
       });

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
@@ -112,7 +112,7 @@ const DataFilesModalButtonCell = ({
   operationOnlyForFolders,
   disabled,
 }) => {
-  const onClick = () => operationCallback(system, path, name);
+  const onClick = () => operationCallback(system, path || '/', name);
   const formatSupportsOperation =
     !operationOnlyForFolders || format === 'folder';
   return (

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.jsx
@@ -112,7 +112,7 @@ const DataFilesModalButtonCell = ({
   operationOnlyForFolders,
   disabled,
 }) => {
-  const onClick = () => operationCallback(system, path || '/', name);
+  const onClick = () => operationCallback(system, path, name);
   const formatSupportsOperation =
     !operationOnlyForFolders || format === 'folder';
   return (

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesCopyModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesCopyModal.test.js
@@ -69,13 +69,13 @@ describe('DataFilesCopyModal', () => {
     expect(projectLink).toBeDefined();
     expect(store.getActions()).toEqual([
       { type: 'GET_SYSTEM_MONITOR' },
-      { type: 'PROJECTS_GET_LISTING', payload: { queryString: null } },
+      { type: 'PROJECTS_GET_LISTING', payload: { queryString: null, modal: 'copy' } },
     ]);
     fireEvent.click(projectLink);
 
     expect(store.getActions()).toEqual([
       { type: 'GET_SYSTEM_MONITOR' },
-      { type: 'PROJECTS_GET_LISTING', payload: { queryString: null } },
+      { type: 'PROJECTS_GET_LISTING', payload: { queryString: null, modal: 'copy' } },
       {
         type: 'FETCH_FILES',
         payload: {
@@ -113,7 +113,7 @@ describe('DataFilesCopyModal', () => {
       { type: 'GET_SYSTEM_MONITOR' },
       {
         type: 'PROJECTS_GET_LISTING',
-        payload: { queryString: null },
+        payload: { queryString: null, modal: 'copy' },
       },
       {
         type: 'DATA_FILES_SET_MODAL_PROPS',

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesCopyModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesCopyModal.test.js
@@ -69,13 +69,19 @@ describe('DataFilesCopyModal', () => {
     expect(projectLink).toBeDefined();
     expect(store.getActions()).toEqual([
       { type: 'GET_SYSTEM_MONITOR' },
-      { type: 'PROJECTS_GET_LISTING', payload: { queryString: null, modal: 'copy' } },
+      {
+        type: 'PROJECTS_GET_LISTING',
+        payload: { queryString: null, modal: 'copy' },
+      },
     ]);
     fireEvent.click(projectLink);
 
     expect(store.getActions()).toEqual([
       { type: 'GET_SYSTEM_MONITOR' },
-      { type: 'PROJECTS_GET_LISTING', payload: { queryString: null, modal: 'copy' } },
+      {
+        type: 'PROJECTS_GET_LISTING',
+        payload: { queryString: null, modal: 'copy' },
+      },
       {
         type: 'FETCH_FILES',
         payload: {

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.jsx
@@ -30,6 +30,7 @@ const DataFilesProjectsList = ({ modal }) => {
       type: actionType,
       payload: {
         queryString: modal ? null : query.query_string,
+        modal,
       },
     });
   }, [dispatch, query.query_string]);

--- a/client/src/redux/sagas/projects.sagas.js
+++ b/client/src/redux/sagas/projects.sagas.js
@@ -11,9 +11,11 @@ export async function fetchProjectsListing(queryString) {
 }
 
 export function* getProjectsListing(action) {
-  yield put({
-    type: 'DATA_FILES_CLEAR_FILE_SELECTION',
-  });
+  if (!action.payload?.modal) {
+    yield put({
+      type: 'DATA_FILES_CLEAR_FILE_SELECTION',
+    });
+  }
   yield put({
     type: 'PROJECTS_GET_LISTING_STARTED',
   });


### PR DESCRIPTION
## Overview

The goal for this was to fix a bug where no backend requests were sent when doing a file copy operation from a private system to a shared workspace. 

Upon further investigation this bug seems to stem from a previous PR [bug/FP-1567](https://github.com/TACC/Core-Portal/pull/619). In that PR a [side effect](https://github.com/TACC/Core-Portal/pull/619/files#diff-935654badc41f6dce6ff84b12fbeb2f09d08fec0e1d6441c641d0347c0225550R14) was added that cleared the data file selection whenever a shared workspace listing happened to fix a toolbar bug that was occurring. Due to this, when a file is selected for copy and the user selects a shared workspace to copy it to, the `getProjectsListing` saga clears the selected file in the state, and since there is no file to copy anymore no backend request was made when the copy button is clicked. 


## Related

* [WP-249](https://jira.tacc.utexas.edu/browse/WP-249)

## Changes
- Added a `modal` param to the payload in `DataFilesProjectsList` saga that indicates whether or not a modal is active 
- Added a condition in `getProjectsListing` saga where the `DATA_FILES_CLEAR_FILE_SELECTION` side effect isn't run when a modal is active

## Testing

1. Go to a private system and select a file to copy 
2. Select a shared workspace to copy the file to 
3. Click Copy and ensure that the operation successfully completes

## UI

No UI changes

## Notes

