### PR TITLE
Changed upload function to use Tapis 1.3.2 files insert function

### DIFF
--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -452,15 +452,9 @@ def upload(client, system, path, uploaded_file):
     token = client.access_token.access_token
     systemId = system
     dest_path = os.path.join(path.strip('/'), uploaded_file.name)
-
-    res = r.post(
-        url=f'{base_url}/v3/files/ops/{systemId}/{dest_path}',
-        files={"file": uploaded_file.file},
-        headers={"X-Tapis-Token": token})
-
-    res.raise_for_status()
-
-    response_json = res.json()
+    
+    response_json = client.files.insert(systemId=systemId, path = dest_path, file = uploaded_file)
+    
 
     tapis_indexer.apply_async(kwargs={'access_token': client.access_token.access_token,
                                       'systemId': system,


### PR DESCRIPTION
## Overview

Tapipy 1.3.2 introduces native support for `t.files.insert` operation. Previous upload function made a POST request to upload files to the system. This new code simplifies the upload operation. 

## Related

* [WP-62](https://jira.tacc.utexas.edu/browse/WP-62)

## Changes

* Replaced POST operation with `client.files.insert` function
* Removed res.json() - Response returned already in JSON

## Testing

1. Check with multiple files
2. Check with different file sizes

## UI

![image](https://github.com/TACC/Core-Portal/assets/54924215/283a3fe7-6c78-4f12-afe2-8331afa84eb8)


## Notes

