### PR TITLE
Fixed sorting for system list

### DIFF
--- a/client/src/components/SystemStatus/SystemStatus.jsx
+++ b/client/src/components/SystemStatus/SystemStatus.jsx
@@ -16,14 +16,16 @@ const root = `${ROUTES.WORKBENCH}${ROUTES.SYSTEM_STATUS}`;
 const SystemStatusSidebar = ({ systemList }) => {
   var sidebarItems = [];
 
-  systemList.forEach((system) => {
-    sidebarItems.push({
-      to: `${root}/${system.hostname}`,
-      label: `${system.display_name}`,
-      disabled: false,
-      hidden: false,
+  systemList
+    .sort((a, b) => a.display_name.localeCompare(b.display_name))
+    .forEach((system) => {
+      sidebarItems.push({
+        to: `${root}/${system.hostname}`,
+        label: `${system.display_name}`,
+        disabled: false,
+        hidden: false,
+      });
     });
-  });
 
   return <Sidebar sidebarItems={sidebarItems} />;
 };

--- a/client/src/components/SystemStatus/SystemStatus.jsx
+++ b/client/src/components/SystemStatus/SystemStatus.jsx
@@ -16,16 +16,14 @@ const root = `${ROUTES.WORKBENCH}${ROUTES.SYSTEM_STATUS}`;
 const SystemStatusSidebar = ({ systemList }) => {
   var sidebarItems = [];
 
-  systemList
-    .sort((a, b) => a.display_name.localeCompare(b.display_name))
-    .forEach((system) => {
-      sidebarItems.push({
-        to: `${root}/${system.hostname}`,
-        label: `${system.display_name}`,
-        disabled: false,
-        hidden: false,
-      });
+  systemList.forEach((system) => {
+    sidebarItems.push({
+      to: `${root}/${system.hostname}`,
+      label: `${system.display_name}`,
+      disabled: false,
+      hidden: false,
     });
+  });
 
   return <Sidebar sidebarItems={sidebarItems} />;
 };

--- a/client/src/redux/sagas/systemMonitor.sagas.js
+++ b/client/src/redux/sagas/systemMonitor.sagas.js
@@ -7,6 +7,9 @@ function* getSystemMonitor(action) {
     const result = yield call(fetchUtil, {
       url: '/api/system-monitor/',
     });
+
+    result.sort((a, b) => a.display_name.localeCompare(b.display_name));
+
     yield put({ type: 'SYSTEM_MONITOR_SUCCESS', payload: result });
   } catch (error) {
     yield put({


### PR DESCRIPTION
## Overview

On the portal dashboard and System Status page, the system list was not in alphabetical order. The default selection on System Status page was Frontera which appeared last in the list due to the system list not being sorted alphabetically. This has been fixed to sort the systemList in alphabetical order in both places and fix the default selector to be first item or Frontera.

## Related

* [WP-228](https://jira.tacc.utexas.edu/browse/WP-228)

## Changes

* Added code to sort the result of system monitor api call in the `src/redux/sagas/systemMonitor.sagas.js` file

## Testing

1. Log onto the portal and go to the main Dashboard
2. Ensure the System Status in the right appears in alphabetical order
3. Navigate to the System Status page by clicking on the System Status sidebar item and ensure system list is in alphabetical order

## UI

![Portal Dashboard System Status](https://github.com/TACC/Core-Portal/assets/54924215/b7797c23-b3ba-443a-9df3-69a2abf77e9f)

![System Status Page](https://github.com/TACC/Core-Portal/assets/54924215/39f7673c-7784-4637-9757-a62e6935ed4b)


## Notes

