### PR TITLE
task/WP-272-OnboardingAdminUsername

### DIFF
--- a/client/src/components/Onboarding/OnboardingAdmin.jsx
+++ b/client/src/components/Onboarding/OnboardingAdmin.jsx
@@ -120,6 +120,8 @@ const OnboardingAdminListUser = ({ user, viewLogCallback }) => {
           {index === 0 && (
             <td rowSpan={stepCount} className={styles.name}>
               {`${user.firstName} ${user.lastName}`}
+              <br />
+              <span className={styles.username}>{user.username}</span>
             </td>
           )}
           <td className={step.state === 'staffwait' ? styles.staffwait : ''}>

--- a/client/src/components/Onboarding/OnboardingAdmin.module.scss
+++ b/client/src/components/Onboarding/OnboardingAdmin.module.scss
@@ -87,6 +87,12 @@
   background-color: #c6c6c61a;
 }
 
+.username {
+  display: inline-block; /* needed to make margin-top work with span */
+  margin-top: 5px; /* adjust value as needed to create more space between fullname and username */
+  font-weight: bold;
+}
+
 /* HACK: This selector has knowledge of sibling component's internal markup */
 /* FAQ: Because we cannot pass `className`to <Pill> via <OnboardingStatus> */
 /* FAQ: Because <OnboardingStatus> has a superfluous root element */

--- a/client/src/components/Onboarding/OnboardingAdmin.test.js
+++ b/client/src/components/Onboarding/OnboardingAdmin.test.js
@@ -29,5 +29,6 @@ describe('Onboarding Admin View', () => {
 
     const { getByText } = renderOnboardingAdminComponent(store);
     expect(getByText(/First Last/)).toBeDefined();
+    expect(getByText(/username/)).toBeDefined();
   });
 });


### PR DESCRIPTION
## Overview

Currently we only show the user's full name in the [Onboarding Admin](https://cep.test/workbench/onboarding/admin) view of users. We want to include the user's username at the end of their name in parenthesis, like so:

Sal Tijerina (sal)

Note that you will need to be [staff](https://github.com/TACC/Core-Portal/wiki/How-to-Set-Your-User-as-Staff-or-Superuser) in order to access this page locally

## Related

* [WP-272](https://jira.tacc.utexas.edu/browse/WP-272)

## Changes

- Added username return underneath First and Last name of OnboardingAdmin component
- Added custom local style design for username in OnboardingAdmin module scss
- Consulted with CEP design team about look and design of task
- Added unit test for username 


## Testing

1. Go to [https://cep.test/workbench/onboarding/admin](https://cep.test/workbench/onboarding/admin) 
2. Compare to screenshot below

## UI
<img width="1386" alt="WP-272v3" src="https://github.com/TACC/Core-Portal/assets/50084480/4379f96e-4933-49a9-afe4-5888b2781a2d">



## Notes

