### PR TITLE
bug/WP-262 Workspace file operations bug fixes

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesMoveModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesMoveModal.jsx
@@ -50,10 +50,7 @@ const DataFilesMoveModal = React.memo(() => {
 
   const onOpened = () => {
     fetchListing({
-      api: 'tapis',
-      scheme: 'private',
-      system: selectedSystem.system,
-      path: `${selectedSystem.homeDir || ''}`,
+      ...params,
     });
   };
 
@@ -68,7 +65,7 @@ const DataFilesMoveModal = React.memo(() => {
       setDisabled(true);
       move({
         destSystem: system,
-        destPath: path,
+        destPath: path || '/',
         callback: reloadPage,
       });
     },

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -254,7 +254,7 @@ export function* renameFile(action) {
       action.payload.api,
       action.payload.scheme,
       file.system,
-      file.path,
+      '/' + file.path,
       action.payload.newName
     );
     yield put({


### PR DESCRIPTION
## Overview

Bug fixes for file operations noticed in shared workspaces. The bugs were mostly due to being in the root of a system and having blank strings as paths and not necessarily related to any shared workspace functionality itself. Bugs that were fixed include: 

- Page breaking when a move modal was opened in a shared workspace 
- Move operation failing when moving file to the root of a system
- Rename operation failing when renaming a file located at the root of a system

## Related

* [WP-262](https://jira.tacc.utexas.edu/browse/WP-262)

## Changes

- Simplified some code and added `'/'` to arguments to ensure paths are never empty strings

## Testing

1. Go to a Shared Workspace and test out the `move` and `rename` functionality and ensure everything works smoothly

## UI

No UI changes

## Notes

