### PR TITLE
Bug/WP-276: Fixed Data Files Add button dropdown off-centered UI

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -12,7 +12,7 @@
   padding-left: var(--horizontal-buffer);
 }
 #data-files-add {
-  width: 140px;
+  width: 174px;
 }
 
 .data-files-nav {
@@ -36,6 +36,7 @@
     border-right: 10px solid transparent;
     border-bottom: 10px solid var(--global-color-accent--normal);
     border-left: 10px solid transparent;
+    margin-left: 20px;
     content: '';
   }
   .dropdown-menu::after {
@@ -45,6 +46,7 @@
     border-right: 9px solid transparent;
     border-bottom: 9px solid #ffffff;
     border-left: 9px solid transparent;
+    margin-left: 20px;
     content: '';
   }
 


### PR DESCRIPTION
## Overview

The triangle bit of the Data Files Add menu dropdown is not centered. This fix makes the dropdown centered and also makes the "Add" button centered.

## Related

* [WP-276](https://jira.tacc.utexas.edu/browse/WP-276)

## Changes

* Changed width of Add button
* Added margin to the drop down menu before and after it is clicked


## Testing

1. Navigate to portal > Data Files > Add button
2. Check if the "Add" button and dropdown triangle is centered 

## UI

![Desktop Display](https://github.com/TACC/Core-Portal/assets/54924215/8fd9d9e9-1012-4068-ba75-b841d2335e19)
![iPhone XR Display](https://github.com/TACC/Core-Portal/assets/54924215/fe65fd33-2fbf-45c5-b3a0-8715b2364d7b)


## Notes

