### PR TITLE
bug/WP-52 Jobs View Infinite Scroll Fix

### DIFF
--- a/client/src/components/Jobs/Jobs.jsx
+++ b/client/src/components/Jobs/Jobs.jsx
@@ -75,11 +75,14 @@ function JobsView({
   const infiniteScrollCallback = useCallback(() => {
     // TODOv3: dropV2Jobs
     const dispatchType = version === 'v3' ? 'GET_JOBS' : 'GET_V2_JOBS';
-    dispatch({
-      type: dispatchType,
-      params: { offset: jobs.length, queryString: query.query_string || '' },
-    });
-  }, [dispatch, jobs, query.query_string]);
+
+    if (!isJobLoading) {
+      dispatch({
+        type: dispatchType,
+        params: { offset: jobs.length, queryString: query.query_string || '' },
+      });
+    }
+  }, [dispatch, jobs, query.query_string, isJobLoading]);
 
   const jobDetailLink = useCallback(
     ({
@@ -217,22 +220,20 @@ function JobsView({
           disabled={isJobLoading || isNotificationLoading}
         />
       )}
-      <div className={includeSearchbar ? 'o-flex-item-table-wrap' : ''}>
-        <InfiniteScrollTable
-          tableColumns={filterColumns}
-          tableData={jobs}
-          onInfiniteScroll={infiniteScrollCallback}
-          isLoading={isJobLoading || isNotificationLoading}
-          className={showDetails ? 'jobs-detailed-view' : 'jobs-view'}
-          noDataText={
-            <Section className={'no-results-message'}>
-              <SectionMessage type="info">{noDataText}</SectionMessage>
-            </Section>
-          }
-          getRowProps={rowProps}
-          columnMemoProps={[version]} /* TODOv3: dropV2Jobs. */
-        />
-      </div>
+      <InfiniteScrollTable
+        tableColumns={filterColumns}
+        tableData={jobs}
+        onInfiniteScroll={infiniteScrollCallback}
+        isLoading={isJobLoading || isNotificationLoading}
+        className={showDetails ? 'jobs-detailed-view' : 'jobs-view'}
+        noDataText={
+          <Section className={'no-results-message'}>
+            <SectionMessage type="info">{noDataText}</SectionMessage>
+          </Section>
+        }
+        getRowProps={rowProps}
+        columnMemoProps={[version]} /* TODOv3: dropV2Jobs. */
+      />
     </>
   );
 }

--- a/client/src/components/Jobs/Jobs.test.js
+++ b/client/src/components/Jobs/Jobs.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import Jobs from './Jobs';
 import { createMemoryHistory } from 'history';
 import { default as jobsList } from './Jobs.fixture';
@@ -134,5 +134,36 @@ describe('Jobs View', () => {
     history.push('/jobs');
     const { getByText } = renderJobsComponent(store, history);
     expect(getByText(/unable to retrieve your jobs/)).toBeDefined();
+  });
+
+  it('should dispatch another get jobs event on scroll with proper offset', async () => {
+    const store = mockStore({
+      notifications,
+      jobs: { ...jobs, list: jobsList },
+      workbench: { ...workbench, config: { hideDataFiles: false } },
+      apps: {
+        appIcons: {},
+      },
+    });
+
+    const { container } = render(
+      <Provider store={store}>
+        <BrowserRouter>
+          <Jobs />
+        </BrowserRouter>
+      </Provider>
+    );
+
+    const scrollContainer = container.querySelector('.table-container');
+
+    fireEvent.scroll(scrollContainer, { target: { scrollTop: 1 } });
+
+    expect(store.getActions()).toEqual([
+      { type: 'GET_JOBS', params: { offset: 0, queryString: '' } },
+      {
+        type: 'GET_JOBS',
+        params: { offset: jobsList.length, queryString: '' },
+      },
+    ]);
   });
 });

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.jsx
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.jsx
@@ -62,51 +62,62 @@ const InfiniteScrollTable = ({
     useTable({ columns, data });
 
   const onScroll = ({ target }) => {
+    // added tolerance to deal with inconsistent scroll values
+    const tolerance = 0.5;
+
+    const difference = target.scrollHeight - target.scrollTop;
+
     const bottom =
-      target.scrollHeight - target.scrollTop === target.clientHeight;
+      difference <= target.clientHeight + tolerance ||
+      difference <= target.clientHeight - tolerance;
+
     if (bottom && target.scrollTop > 0) {
       onInfiniteScroll(tableData.length);
     }
   };
 
   return (
-    <table
-      {...getTableProps()}
-      className={`${className} InfiniteScrollTable o-fixed-header-table`}
-    >
-      <thead>
-        {headerGroups.map((headerGroup) => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map((column) => (
-              <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()} onScroll={onScroll}>
-        {rows.map((row) => {
-          prepareRow(row);
-          return (
-            <tr {...row.getRowProps()} {...getRowProps(row)}>
-              {row.cells.map((cell) => {
-                return (
-                  <td
-                    {...cell.getCellProps({ className: cell.column.className })}
-                  >
-                    {cell.render('Cell')}
-                  </td>
-                );
-              })}
+    <div className={'table-container'} onScroll={onScroll}>
+      <table
+        {...getTableProps()}
+        className={`${className} InfiniteScrollTable o-fixed-header-table`}
+      >
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => (
+                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+              ))}
             </tr>
-          );
-        })}
-        <InfiniteScrollLoadingRow isLoading={isLoading} />
-        <InfiniteScrollNoDataRow
-          display={!isLoading && tableData.length === 0}
-          noDataText={noDataText}
-        />
-      </tbody>
-    </table>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.map((row) => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()} {...getRowProps(row)}>
+                {row.cells.map((cell) => {
+                  return (
+                    <td
+                      {...cell.getCellProps({
+                        className: cell.column.className,
+                      })}
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+          <InfiniteScrollLoadingRow isLoading={isLoading} />
+          <InfiniteScrollNoDataRow
+            display={!isLoading && tableData.length === 0}
+            noDataText={noDataText}
+          />
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.jsx
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.jsx
@@ -62,14 +62,12 @@ const InfiniteScrollTable = ({
     useTable({ columns, data });
 
   const onScroll = ({ target }) => {
-    // added tolerance to deal with inconsistent scroll values
-    const tolerance = 0.5;
+    const scrollbarHeight = target.offsetHeight - target.clientHeight;
+    const clientRectHeight = target.getBoundingClientRect().height;
+    const clientCalcHeight = clientRectHeight - scrollbarHeight;
+    const difference = Math.floor(target.scrollHeight - target.scrollTop);
 
-    const difference = target.scrollHeight - target.scrollTop;
-
-    const bottom =
-      difference <= target.clientHeight + tolerance ||
-      difference <= target.clientHeight - tolerance;
+    const bottom = difference <= clientCalcHeight;
 
     if (bottom && target.scrollTop > 0) {
       onInfiniteScroll(tableData.length);

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
@@ -79,3 +79,8 @@
     width: 100%;
   }
 }
+
+.table-container {
+  height: 100%;
+  overflow: scroll;
+}

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -179,7 +179,7 @@ class JobsView(BaseApiView):
 
         data = client.jobs.getJobSearchList(
             limit=limit,
-            startAfter=offset,
+            skip=offset,
             orderBy='lastUpdated(desc),name(asc)',
             _tapis_query_parameters={'tags.contains': f'portalName: {portal_name}'},
             select='allAttributes'


### PR DESCRIPTION
## Overview

Includes fix for JobsView component in the History section not showing more than 50 jobs. This was due to a bug in the InfiniteScrollTable component.

## Related

* [WP-52](https://jira.tacc.utexas.edu/browse/WP-52)

## Changes

- Made minor changes to `InfiniteScrollTable` layout and css to make onScroll event handler work again
- Tweaked logic for scroll value calculations to correctly determine when bottom of page is reached 
- Added logic when dispatching `GET_JOBS` saga to ensure multiple requests are not sent
- Tweaked `getJobSearchList` Tapis query to use the `skip` parameter instead of `startAfter` since startAfter is not implemented yet

## Testing

1. Go to the History section in the portal 
2. In order to test infinite scroll functionality make sure you have more than 50 jobs submitted or change the `LIMIT` value on line 6 in `jobs.sagas.js` to a smaller number (Make sure there are still enough jobs displayed for scrolling to work)
3. Ensure loading indicator is shown when at bottom of page and that more jobs are loaded into the table 

## UI

No UI changes

## Notes

