### PR TITLE
Quick: handle missing default system; enable work as default system locally

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -201,7 +201,7 @@ export const AppSchemaForm = ({ app }) => {
     const hasCorral =
       configuration.length &&
       ['corral.tacc.utexas.edu', 'data.tacc.utexas.edu'].some((s) =>
-        defaultHost.endsWith(s)
+        defaultHost?.endsWith(s)
       );
     return {
       allocations: matchingExecutionHost

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -48,7 +48,7 @@ class SystemListingView(BaseApiView):
                 if 'homeDir' in system else system for system in portal_systems
             ]
 
-            default_system = settings.PORTAL_DATAFILES_DEFAULT_STORAGE_SYSTEM
+            default_system = settings.PORTAL_DATAFILES_DEFAULT_STORAGE_SYSTEM or settings.PORTAL_DATAFILES_STORAGE_SYSTEMS[0]
             if default_system:
                 system_id = default_system.get('system')
                 system_def = request.user.tapis_oauth.client.systems.getSystem(systemId=system_id, select='host')

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -512,7 +512,7 @@ KEY_SERVICE_TOKEN = getattr(settings_secret, "_KEY_SERVICE_TOKEN", '')
 PORTAL_DATAFILES_STORAGE_SYSTEMS = getattr(
     settings_custom, '_PORTAL_DATAFILES_STORAGE_SYSTEMS', []
 )
-PORTAL_DATAFILES_DEFAULT_STORAGE_SYSTEM = next((sys for sys in PORTAL_DATAFILES_STORAGE_SYSTEMS if sys['default'] is True), None)
+PORTAL_DATAFILES_DEFAULT_STORAGE_SYSTEM = next((sys for sys in PORTAL_DATAFILES_STORAGE_SYSTEMS if sys.get('default')), None)
 
 PORTAL_SEARCH_MANAGERS = {
     'my-data': 'portal.apps.search.api.managers.private_data_search.PrivateDataSearchManager',

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -59,22 +59,21 @@ _PORTAL_KEYS_MANAGER = 'portal.apps.accounts.managers.ssh_keys.KeysManager'
 
 _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
     {
-        'name': 'My Data (Corral)',
-        'system': 'cloud.data',
-        'scheme': 'private',
-        'api': 'tapis',
-        'homeDir': '/home/{username}',
-        'icon': None,
-        'keyservice': True,
-        'default': True
-    },
-    {
         'name': 'My Data (Work)',
         'system': 'frontera',
         'scheme': 'private',
         'api': 'tapis',
         'homeDir': '/work/{tasdir}',
         'icon': None,
+        'default': True
+    },
+    {
+        'name': 'My Data (Scratch)',
+        'system': 'frontera',
+        'scheme': 'private',
+        'api': 'tapis',
+        'homeDir': '/scratch1/{tasdir}',
+        'icon': None
     },
     {
         'name': 'My Data (Frontera)',


### PR DESCRIPTION
## Overview

- Fixes case where the default system is not the first system in the list
- Fixes case where no default is set, and sets first system as default if so
- Adds the scratch filesystem, and removes the my data corral filesystem
- Sets the work filesystem as default locally

## Testing

1. Spin up the portal and confirm the work filesystem is default
2. Confirm the scratch filesystem also works
3. Remove the `default` flag from the work filesystem in `_PORTAL_DATAFILES_STORAGE_SYSTEMS` and confirm work is still set as default
4. 3. Remove the `default` flag from the work filesystem in `_PORTAL_DATAFILES_STORAGE_SYSTEMS` and make another filesystem default, and confirm that system now shows as default 