### PR TITLE
Bug/WP-306: If input file target path is empty, do not send it to tapis

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -19,7 +19,7 @@ import { Link } from 'react-router-dom';
 import { getSystemName } from 'utils/systems';
 import FormSchema from './AppFormSchema';
 import {
-  checkAndSetDefaultTargetPath,
+  isTargetPathEmpty,
   isTargetPathField,
   getInputFieldFromTargetPathField,
   getQueueMaxMinutes,
@@ -501,9 +501,12 @@ export const AppSchemaForm = ({ app }) => {
             .flat()
             .filter((fileInput) => fileInput.sourceUrl) // filter out any empty values
             .map((fileInput) => {
-              fileInput.targetPath = checkAndSetDefaultTargetPath(
-                fileInput.targetPath
-              );
+              if (isTargetPathEmpty(fileInput.targetPath)){
+                return {
+                  name : fileInput.name,
+                  sourceUrl : fileInput.sourceUrl
+                };
+              }
               return fileInput;
             });
 

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -202,6 +202,27 @@ export const getInputFieldFromTargetPathField = (targetPathFieldName) => {
 };
 
 /**
+ * Check if targetPath is empty on input field
+ *
+ * @function
+ * @param {String} targetPathFieldValue
+ * @returns {boolean} if target path is empty
+ */
+export const isTargetPathEmpty = (targetPathFieldValue) => {
+  if (targetPathFieldValue === null || targetPathFieldValue === undefined) {
+    return true;
+  }
+
+  targetPathFieldValue = targetPathFieldValue.trim();
+
+  if (targetPathFieldValue.trim() === '') {
+    return true;
+  }
+
+  return false;
+};
+
+/**
  * Sets the default value if target path is not set.
  *
  * @function
@@ -209,13 +230,7 @@ export const getInputFieldFromTargetPathField = (targetPathFieldName) => {
  * @returns {String} target path value
  */
 export const checkAndSetDefaultTargetPath = (targetPathFieldValue) => {
-  if (targetPathFieldValue === null || targetPathFieldValue === undefined) {
-    return '*';
-  }
-
-  targetPathFieldValue = targetPathFieldValue.trim();
-
-  if (targetPathFieldValue.trim() === '') {
+  if (isTargetPathEmpty(targetPathFieldValue)) {
     return '*';
   }
 


### PR DESCRIPTION
## Overview
A recent change [#857](https://github.com/TACC/Core-Portal/pull/857) introduced target path for input file. But, this was done only if the app definition requested for it. 
When the app definition does not want this feature, the current implementation is overriding target path to "*" always. This is a regression. The production behavior is to not send targetPath back to tapis.


## Related

* [WP-306](https://jira.tacc.utexas.edu/browse/WP-306)

## Changes
The behavior in prod is to not send targetPath. This code change will match that to not send target path if it is empty (undefined, null or empty in UI). This will meet all conditions.


## Testing

1.Tested OpenSees which was failing before to copy files to right location
Job parameters ( this matches prod):
```
{
    "job": {
        "fileInputs": [
            {
                "name": "TCL Input Directory",
                "sourceUrl": "tapis://cloud.data/corral/tacc/aci/CEP/community/opensees-sp/examples/smallsp"
            }
        ],
        "parameterSet": {
            "appArgs": [
                {
                    "name": "TCL Script",
                    "arg": "Example.tcl"
                }
            ],
            "containerArgs": [],
            "schedulerOptions": [
                {
                    "name": "TACC Allocation",
                    "description": "The TACC allocation associated with this job execution",
                    "include": true,
                    "arg": "-A TACC-ACI"
                }
            ],
            "envVariables": []
        },
        "name": "opensees-sp-v35-0.0.1_2023-10-03T22:56:41",
        "nodeCount": 1,
        "coresPerNode": 4,
        "maxMinutes": 120,
        "archiveSystemId": "frontera",
        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
        "archiveOnAppError": true,
        "appId": "opensees-sp-v35",
        "appVersion": "0.0.1",
        "execSystemId": "frontera",
        "execSystemLogicalQueue": "development"
    },
    "licenseType": null,
    "isInteractive": false
}
```

2. Tested extract which has target path exposed.
The job worked

3. Tested with namd
It matches the production behavior (compared with frontera)

## UI
No Change


## Notes

