### PR TITLE
Task/WP-72 highlight matching search terms in job history search

### DIFF
--- a/client/src/components/History/HistoryViews/JobHistoryModal.jsx
+++ b/client/src/components/History/HistoryViews/JobHistoryModal.jsx
@@ -122,6 +122,8 @@ function JobHistoryContent({
   const outputDataObj = {
     'Job Name': jobName,
     'Output Location': outputLocation,
+    'Archive System': jobDetails.archiveSystemId,
+    'Archive Directory': jobDetails.archiveSystemDir,
   };
 
   const resubmitJob = () => {

--- a/client/src/components/Jobs/Jobs.jsx
+++ b/client/src/components/Jobs/Jobs.jsx
@@ -6,6 +6,7 @@ import {
   AppIcon,
   InfiniteScrollTable,
   Message,
+  HighlightSearchTerm,
   SectionMessage,
   Section,
 } from '_common';
@@ -88,7 +89,6 @@ function JobsView({
       },
     }) => {
       const query = queryStringParser.parse(useLocation().search);
-
       // TODOv3: dropV2Jobs
       const jobsPathname = uuid ? `/jobs/${uuid}` : `/jobsv2/${id}`;
       return (
@@ -205,7 +205,6 @@ function JobsView({
   ];
 
   const filterColumns = columns.filter((f) => f.show !== false);
-
   return (
     <>
       {includeSearchbar && (
@@ -231,6 +230,7 @@ function JobsView({
           }
           getRowProps={rowProps}
           columnMemoProps={[version]} /* TODOv3: dropV2Jobs. */
+          searchTerm={query.query_string}
         />
       </div>
     </>

--- a/client/src/components/_common/HighlightSearchTerm/HighlightSearchTerm.jsx
+++ b/client/src/components/_common/HighlightSearchTerm/HighlightSearchTerm.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link, useLocation } from 'react-router-dom';
+import * as ROUTES from '../../../constants/routes';
+import { getOutputPath } from 'utils/jobsUtil';
+
+const HighlightSearchTerm = ({ searchTerm, cell, id }) => {
+  const highlightParts = (content) => {
+    const parts = content.split(new RegExp(`(${searchTerm})`, 'gi'));
+    return parts.map((part, i) =>
+      part.toLowerCase() === searchTerm.toLowerCase() ? (
+        <mark key={i}>{part}</mark>
+      ) : (
+        part
+      )
+    );
+  };
+
+  if (id == 'Output Location') {
+    const outputLocation = getOutputPath(cell.row.original);
+
+    return outputLocation ? (
+      <Link
+        to={`${ROUTES.WORKBENCH}${ROUTES.DATA}/tapis/private/${outputLocation}`}
+        className="wb-link job__path"
+      >
+        {highlightParts(outputLocation)}
+      </Link>
+    ) : null;
+  } else if (id == 'uuid') {
+    return <mark>{cell.render('Cell')}</mark>;
+  } else if (id == 'name') {
+    const jobName = cell.row.values[id];
+
+    return <span>{highlightParts(jobName)}</span>;
+  }
+
+  return null;
+};
+
+HighlightSearchTerm.propTypes = {
+  searchTerm: PropTypes.string,
+  cell: PropTypes.object,
+  id: PropTypes.string,
+};
+
+HighlightSearchTerm.defaultProps = {
+  searchTerm: '',
+  outputLocation: '',
+};
+
+export default HighlightSearchTerm;

--- a/client/src/components/_common/HighlightSearchTerm/index.js
+++ b/client/src/components/_common/HighlightSearchTerm/index.js
@@ -1,0 +1,3 @@
+import HighlightSearchTerm from './HighlightSearchTerm';
+
+export default HighlightSearchTerm;

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.jsx
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.jsx
@@ -3,6 +3,7 @@ import { useTable } from 'react-table';
 import PropTypes from 'prop-types';
 import LoadingSpinner from '../LoadingSpinner';
 import './InfiniteScrollTable.scss';
+import { HighlightSearchTerm } from '_common';
 
 const rowContentPropType = PropTypes.oneOfType([
   PropTypes.string,
@@ -54,6 +55,7 @@ const InfiniteScrollTable = ({
   noDataText,
   getRowProps,
   columnMemoProps,
+  searchTerm,
 }) => {
   const columns = React.useMemo(() => tableColumns, columnMemoProps);
   const data = React.useMemo(() => tableData, [tableData]);
@@ -93,7 +95,18 @@ const InfiniteScrollTable = ({
                   <td
                     {...cell.getCellProps({ className: cell.column.className })}
                   >
-                    {cell.render('Cell')}
+                    {searchTerm !== '' &&
+                    (cell.column.id === 'name' ||
+                      cell.column.id === 'Output Location' ||
+                      cell.column.id === 'uuid') ? (
+                      <HighlightSearchTerm
+                        searchTerm={searchTerm}
+                        cell={cell}
+                        id={cell.column.id}
+                      />
+                    ) : (
+                      cell.render('Cell')
+                    )}
                   </td>
                 );
               })}
@@ -119,12 +132,15 @@ InfiniteScrollTable.propTypes = {
   noDataText: rowContentPropType,
   getRowProps: PropTypes.func,
   columnMemoProps: PropTypes.arrayOf(PropTypes.any),
+  searchTerm: PropTypes.string,
+  cell: PropTypes.object,
 };
 InfiniteScrollTable.defaultProps = {
   onInfiniteScroll: (offset) => {},
   isLoading: false,
   className: '',
   noDataText: '',
+  searchTerm: '',
   getRowProps: (row) => {},
   columnMemoProps: [],
 };

--- a/client/src/components/_common/index.js
+++ b/client/src/components/_common/index.js
@@ -16,6 +16,7 @@ export { default as Icon } from './Icon';
 export { default as Message } from './Message';
 export { default as InlineMessage } from './InlineMessage';
 export { default as SectionMessage } from './SectionMessage';
+export { default as HighlightSearchTerm } from './HighlightSearchTerm';
 export { default as Sidebar } from './Sidebar';
 export { default as DescriptionList } from './DescriptionList';
 export { default as DropdownSelector } from './DropdownSelector';

--- a/client/src/utils/jobsUtil.js
+++ b/client/src/utils/jobsUtil.js
@@ -1,3 +1,4 @@
+import { object } from 'prop-types';
 import { getSystemName } from './systems';
 
 const TERMINAL_STATES = [`FINISHED`, `CANCELLED`, `FAILED`];
@@ -59,9 +60,13 @@ export function getAllocatonFromDirective(directive) {
  * Get display values from job, app and execution system info
  */
 export function getJobDisplayInformation(job, app) {
-  const fileInputs = JSON.parse(job.fileInputs);
+  const fileInputs = JSON.parse(job.fileInputs).filter((obj) =>
+    obj.notes != null ? !JSON.parse(obj.notes).isHidden : true
+  );
   const parameterSet = JSON.parse(job.parameterSet);
-  const parameters = parameterSet.appArgs;
+  const parameters = parameterSet.appArgs.filter((obj) =>
+    obj.notes != null ? !JSON.parse(obj.notes).isHidden : true
+  );
   const envVariables = parameterSet.envVariables;
   const schedulerOptions = parameterSet.schedulerOptions;
   const display = {
@@ -104,6 +109,13 @@ export function getJobDisplayInformation(job, app) {
       //                 a webhookUrl will be a required input for interactive jobs,
       //                 but we want to hide that input
 
+      // display.parameters.filter((input) => {
+      //   const matchingParameter = app.definition.inputs.find((obj => {
+      //     return input.id === obj.id;
+      //   }));
+      //   console.log(matchingParameter)
+      // });
+
       // filter non-visible
       // display.inputs.filter((input) => {
       //   const matchingParameter = app.definition.inputs.find((obj) => {
@@ -123,6 +135,22 @@ export function getJobDisplayInformation(job, app) {
       //   }
       //   return true;
       // });
+
+      // Note: Code below also filters v3 parameters by cross referenceing but utilizes more resources
+      // The quicker workaround solution is implemented in Line 63 and 65 and utilizes Array.filter method
+      /*
+      display.parameters.filter((input) => {
+        const matchingParameter = app.definition.jobAttributes.parameterSet.appArgs.find((obj) => {
+          return input.label === obj.name
+        });
+
+        console.log("matching", matchingParameter)
+        if (matchingParameter && matchingParameter.notes.isHidden) {
+          display.parameters.splice(display.parameters.findIndex(item => item.label))
+        }
+        return true
+      })
+      */
 
       const workPath = envVariables.find(
         (env) => env.key === '_tapisJobWorkingDir'
@@ -148,6 +176,7 @@ export function getJobDisplayInformation(job, app) {
       // ignore if there is problem using the app definition to improve display
     }
   }
+
   return display;
 }
 


### PR DESCRIPTION
## Overview

[PR FP-319](https://github.com/TACC/Core-Portal/pull/756) introduced the job history search feature. Future item included highlighting the matching search terms/ query in the Job History Search that this PR achieves.

## Related

* [WP-72](https://jira.tacc.utexas.edu/browse/WP-72)

## Changes

* Created a new component `HighlightSearchTerm` that highlights the matching queries
* Updated new props
* Added a new logic in `InfiniteScrollTable.jsx` for rendering the HighlightSearchTerm component

## Testing

1. Go to the History page in the portal
2. Type query in the searchbar and confirm if the queries are highlighted
3. When no matching term is found in the Job Name and/or Output Location, it will highlight the 'View Details' button

## UI

![image](https://github.com/TACC/Core-Portal/assets/54924215/c138cfa0-102e-4327-8345-98c904dca16b)
![image](https://github.com/TACC/Core-Portal/assets/54924215/7ed1abd8-94d9-4d8c-aae3-aca531f240ec)
![image](https://github.com/TACC/Core-Portal/assets/54924215/992e2e2a-524c-457c-85b3-0e25d841dcc3)
![image](https://github.com/TACC/Core-Portal/assets/54924215/2735b187-bb97-435a-a959-ea5912eb430b)

## Notes

