### PR TITLE
task/WP-65-DropdownViewFullPath - dropdown-menu css component 

### DIFF
--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.jsx
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.jsx
@@ -209,6 +209,7 @@ const DataFilesBreadcrumbs = ({
         <ButtonDropdown
           isOpen={dropdownOpen}
           toggle={toggleDropdown}
+          id="go-to-button-dropdown"
           className="go-to-button-dropdown"
         >
           <DropdownToggle tag={Button}>Go to ...</DropdownToggle>

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
@@ -1,5 +1,5 @@
 @import '../../../styles/tools/mixins.scss';
-@import '../DataFilesSidebar/DataFilesSidebar.scss';
+@import '../../../styles/components/dropdown-menu.css';
 
 .breadcrumbs {
   /* ... */
@@ -42,51 +42,32 @@
   padding-left: var(--horizontal-buffer);
 }
 
-/* HACK: Quick solution to prevent styles from cascading into header dropdown */
-.go-to-button-dropdown {
+/* Nested to prevent styles from affecting CMS header dropdown */
+/* HACK: Using ID to increase specificity (until source of problem is fixed) */
+/* HELP: Why does DataFilesSidebar not need such specificity? */
+/* .go-to-button-dropdown { */
+#go-to-button-dropdown {
+  /* To fix menu not showing */
+  /* HELP: Why does DataFilesSidebar not need this? */
   .dropdown-menu {
     opacity: 1 !important;
-    border-color: var(--global-color-accent--normal);
-    border-radius: 0;
-    margin-top: 34px;
-    padding: 0;
-    width: 200px;
-    vertical-align: top;
     pointer-events: auto !important;
+  }
+  /* To restyle */
+  .dropdown-menu {
+    margin-top: 38px;
   }
   .dropdown-menu::before,
   .dropdown-menu::after {
-    position: absolute;
-    top: -10px;
     left: 23px;
-    border-right: 10px solid transparent;
-    border-bottom: 10px solid var(--global-color-accent--normal);
-    border-left: 10px solid transparent;
-    content: '';
+    margin-left: 0;
   }
   .dropdown-menu::after {
     top: -9px;
-    left: 23px;
-    border-bottom: 10px solid #ffffff;
   }
 
   .dropdown-item {
     display: inline-block;
-    padding: 10px 6px;
-    color: var(--global-color-primary--x-dark);
-    font-size: 14px;
-    i {
-      padding-right: 19px;
-      font-size: 20px;
-      vertical-align: top;
-    }
-    &:hover {
-      color: var(--global-color-primary--x-dark);
-    }
-  }
-  .dropdown-item:focus,
-  .dropdown-item:hover {
-    background-color: var(--global-color-accent--weak);
   }
 }
 

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
@@ -48,7 +48,7 @@
 /* .go-to-button-dropdown { */
 #go-to-button-dropdown {
   /* To fix menu not showing */
-  /* HELP: Why does DataFilesSidebar not need this? */
+  /* HELP: Why does DataFilesSidebar not need `!important`? */
   .dropdown-menu {
     opacity: 1 !important;
     pointer-events: auto !important;

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
@@ -48,7 +48,7 @@
 /* .go-to-button-dropdown { */
 #go-to-button-dropdown {
   /* To fix menu not showing */
-  /* HELP: Why does DataFilesSidebar not need `!important`? */
+  /* HELP: Why does DataFilesSidebar not need this fix? */
   .dropdown-menu {
     opacity: 1 !important;
     pointer-events: auto !important;

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/components/dropdown-menu.css';
+
 .data-files-btn {
   background-color: var(--global-color-accent--normal);
   border-color: var(--global-color-accent--normal);
@@ -19,56 +21,17 @@
   padding-top: 20px;
 }
 
-/* HACK: Quick solution to prevent styles from cascading into header dropdown */
+/* Nested to prevent styles from affecting CMS header dropdown */
 .data-files-sidebar {
   .dropdown-menu {
-    border-color: var(--global-color-accent--normal);
-    border-radius: 0;
     margin-top: 11px;
-    padding: 0;
-    width: 200px;
-    vertical-align: top;
-  }
-  .dropdown-menu::before {
-    position: absolute;
-    top: -10px;
-    left: 65px;
-    border-right: 10px solid transparent;
-    border-bottom: 10px solid var(--global-color-accent--normal);
-    border-left: 10px solid transparent;
-    margin-left: 20px;
-    content: '';
   }
   .dropdown-menu::after {
-    position: absolute;
     top: -9px;
     left: 66px;
-    border-right: 9px solid transparent;
-    border-bottom: 9px solid #ffffff;
-    border-left: 9px solid transparent;
-    margin-left: 20px;
-    content: '';
-  }
-
-  .dropdown-item {
-    padding: 10px 6px;
-    color: var(--global-color-primary--x-dark);
-    font-size: 14px;
-    i {
-      padding-right: 19px;
-      font-size: 20px;
-      vertical-align: middle;
-    }
-    &:hover {
-      color: var(--global-color-primary--x-dark);
-    }
-  }
-  .dropdown-item:focus,
-  .dropdown-item:hover {
-    /* FAQ: Before FP-1083, value was #E6E0FB, which matched Design
-            and was `--global-color-accent` at 25% opacity on white…
-            which is what `--global-color-accent--weak` is now */
-    background-color: var(--global-color-accent--weak);
+    border-right-width: 9px;
+    border-bottom-width: 9px;
+    border-left-width: 9px;
   }
 }
 

--- a/client/src/styles/components/dropdown-menu.css
+++ b/client/src/styles/components/dropdown-menu.css
@@ -1,0 +1,54 @@
+/*
+Dropdown
+
+A menu of navigation elements.
+
+Styleguide Components.Dropdown
+*/
+
+/* Nested to prevent styles from affecting CMS header dropdown */
+.workbench-wrapper {
+  .dropdown-menu {
+    border-color: var(--global-color-accent--normal);
+    border-radius: 0;
+    margin-top: 11px;
+    padding: 0;
+    width: 200px;
+    vertical-align: top;
+  }
+  .dropdown-menu::before,
+  .dropdown-menu::after {
+    position: absolute;
+    top: -10px;
+    left: 65px;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid var(--global-color-accent--normal);
+    border-left: 10px solid transparent;
+    margin-left: 20px;
+    content: '';
+  }
+  .dropdown-menu::after {
+    border-bottom-color: var(--global-color-primary--xx-light);
+  }
+
+  .dropdown-item {
+    padding: 10px 6px;
+    color: var(--global-color-primary--x-dark);
+    font-size: 14px;
+    & i {
+      padding-right: 19px;
+      font-size: 20px;
+      vertical-align: middle;
+    }
+    &:hover {
+      color: var(--global-color-primary--x-dark);
+    }
+  }
+  .dropdown-item:focus,
+  .dropdown-item:hover {
+    /* FAQ: Before FP-1083, value was #E6E0FB, which matched Design
+            and was `--global-color-accent` at 25% opacity on white…
+            which is what `--global-color-accent--weak` is now */
+    background-color: var(--global-color-accent--weak);
+  }
+}


### PR DESCRIPTION
## Overview

Do **not** duplicate dropdown-menu styles (to resolve https://github.com/TACC/Core-Portal/pull/866#discussion_r1341649579).

## Related

* improve #866

## Changes

- **added** `dropdown-menu.css`
- **changed** Data Files Breadcrumbs & Sidebar to use new CSS component
- **changed** Data Files Breadcrumbs to use **temporary** ID[^1] for specificity

[^1]: Use of ID for this is **not** recommended, hence "temporary". See [UI - CSS Style Guide - Specificity @ IDs in CSS](https://confluence.tacc.utexas.edu/display/~wbomar/UI+-+CSS+Style+Guide+-+Specificity#UICSSStyleGuideSpecificity-IDsinCSS).

## Testing

1. Open https://cep.test/workbench/data/.
2. Navigate to a deeply-nested folder.
3. Open [ + Add ] and [ Go to ... ] menus.
4. Verify UI matches #866.
5. If UI differs, verify UI matches [design](https://jira.tacc.utexas.edu/secure/attachment/18219/new%20design%202023-09-20.png).

## UI

| add | go to ... |
| - | - |
| ![DataFilesSidebar](https://github.com/TACC/Core-Portal/assets/62723358/ba7bb3bf-4d7c-4a9a-942d-b038d49e520a) | ![DataFilesBreadcrumbs](https://github.com/TACC/Core-Portal/assets/62723358/17015f60-2b13-403e-8697-010916bae271) |

## Notes

There are some undesirable UI hacks and bugs. They may be fixed in separate PRs, because they seem to be caused by issues from target branch or `main` branch. **If _actually_ <ins>this</ins> PR is causing new bugs, please report.**