### PR TITLE
task/WP-315: Handle interactive session messages

### DIFF
--- a/client/src/components/Jobs/JobsSessionModal/JobsSessionModal.jsx
+++ b/client/src/components/Jobs/JobsSessionModal/JobsSessionModal.jsx
@@ -4,7 +4,12 @@ import { bool, func, string } from 'prop-types';
 import './JobsSessionModal.global.scss';
 import styles from './JobsSessionModal.module.scss';
 
-const JobsSessionModal = ({ isOpen, toggle, interactiveSessionLink }) => {
+const JobsSessionModal = ({
+  isOpen,
+  toggle,
+  interactiveSessionLink,
+  message,
+}) => {
   return (
     <Modal isOpen={isOpen} toggle={toggle} contentClassName="session-modal">
       <ModalHeader
@@ -18,6 +23,7 @@ const JobsSessionModal = ({ isOpen, toggle, interactiveSessionLink }) => {
         <span>
           Click the button below to connect to the interactive session.
         </span>
+        {message && <b>{message}</b>}
         <span>To end the job, quit the application within the session.</span>
         <span>
           Files may take some time to appear in the output location after the

--- a/client/src/components/Jobs/JobsStatus/JobsStatus.jsx
+++ b/client/src/components/Jobs/JobsStatus/JobsStatus.jsx
@@ -72,6 +72,7 @@ function JobsStatus({ status, fancy, jobUuid }) {
 
   const notifs = useSelector((state) => state.notifications.list.notifs);
   let interactiveSessionLink;
+  let message;
 
   const jobConcluded = isTerminalState(status) || status === 'ARCHIVING';
 
@@ -85,6 +86,7 @@ function JobsStatus({ status, fancy, jobUuid }) {
     );
     const notif = interactiveNotifs.find((n) => n.extra.uuid === jobUuid);
     interactiveSessionLink = notif ? notif.action_link : null;
+    message = notif ? notif.message : null;
   }
 
   return (
@@ -109,6 +111,7 @@ function JobsStatus({ status, fancy, jobUuid }) {
             toggle={toggleModal}
             isOpen={modal}
             interactiveSessionLink={interactiveSessionLink}
+            message={message}
           />
         </>
       )}

--- a/server/portal/apps/projects/workspace_operations/shared_workspace_migration.py
+++ b/server/portal/apps/projects/workspace_operations/shared_workspace_migration.py
@@ -62,7 +62,11 @@ def migrate_project(project_id):
 
     for co_pi in v2_project.co_pis.all():
         v2_role = get_role(project_id, co_pi.username)
-        v3_role = ROLE_MAP[v2_role]
+        try:
+            v3_role = ROLE_MAP[v2_role]
+        except KeyError:
+            print(f'ERROR: No role found for: {v2_role}')
+            v3_role = "reader"
         try:
             add_user_to_workspace(client, project_id, co_pi.username, v3_role)
         except NotFoundError:
@@ -71,7 +75,11 @@ def migrate_project(project_id):
 
     for team_member in v2_project.team_members.all():
         v2_role = get_role(project_id, team_member.username)
-        v3_role = ROLE_MAP[v2_role]
+        try:
+            v3_role = ROLE_MAP[v2_role]
+        except KeyError:
+            print(f'ERROR: No role found for: {v2_role}')
+            v3_role = "reader"
         try:
             add_user_to_workspace(client, project_id, team_member.username, v3_role)
         except NotFoundError:

--- a/server/portal/apps/webhooks/views.py
+++ b/server/portal/apps/webhooks/views.py
@@ -161,6 +161,7 @@ class InteractiveWebhookView(BaseApiView):
         job_uuid = request.POST.get('job_uuid', None)
         job_owner = request.POST.get('owner', None)
         address = request.POST.get('address', None)
+        message = request.POST.get('message', None)
 
         if not address:
             msg = "Missing required interactive webhook parameter: address"
@@ -173,6 +174,9 @@ class InteractiveWebhookView(BaseApiView):
             Notification.USER: job_owner,
             Notification.ACTION_LINK: address
         }
+
+        if message:
+            event_data[Notification.MESSAGE] = message
 
         # confirm that there is a corresponding running tapis job before sending notification
         try:


### PR DESCRIPTION
## Overview

Some apps may require additional, freeform information to be rendered to the interactive session modal. This PR takes the "message" param from a webhook if it exists and renders it to the user.

## Related

* [WP-315](https://jira.tacc.utexas.edu/browse/WP-315)


## Testing

1. Update your settings_secret.py with https://stache.utexas.edu/entry/bedc97190d3a907cb44488785440595c
2. Uncomment the lines under "DEV TENANT SETTINGS" to enable the dev tenant locally
3. Sign out and back in to https://cep.test/login
4. Run `./manage.py import-apps -c` in your local `core_portal_django` container to get the latest apps
5. Run an Rstudio session at https://cep.test/workbench/applications/rstudio?appVersion=4.3
6. Confirm the interactive session modal includes a message with a session password

## UI

![Screenshot 2023-10-06 at 3 55 39 PM](https://github.com/TACC/Core-Portal/assets/20326896/9d390b46-fea5-4761-a533-483ed7524d89)


## Notes
Inviting feedback on how this should look.
