### PR TITLE
WP-299: Add Data Files button dropdown needs minor adjustment in alignment

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -24,7 +24,7 @@
   .dropdown-menu {
     border-color: var(--global-color-accent--normal);
     border-radius: 0;
-    margin: 11px 3px 0px;
+    margin: 11px 3px 0;
     width: 200px;
     vertical-align: top;
   }


### PR DESCRIPTION
## Overview

Minor adjust in alignment to address bug found in testing. Add Data Files dropdown isn't aligned properly.

## Related

* [WP-299](https://jira.tacc.utexas.edu/browse/WP-299)

## Changes

* Added margin and switched the dropdown triangle to right


## Testing

1. Go to Data Files and click on "Add Data Files" button to check alignment

## UI

![image](https://github.com/TACC/Core-Portal/assets/54924215/de24c49a-71d3-419f-ae01-5d5bbbe9a47f)



## Notes

