### PR TITLE
bug/WP-319: Fix email confirmation for tickets

### DIFF
--- a/server/portal/apps/tickets/rtUtil.py
+++ b/server/portal/apps/tickets/rtUtil.py
@@ -47,7 +47,7 @@ class DjangoRt:
                                           files=attachments,
                                           Subject=subject,
                                           Text=problem_description,
-                                          Requestors=requestor,
+                                          Requestor=requestor,
                                           Cc=cc,
                                           CF_resource=settings.RT_TAG)
 


### PR DESCRIPTION
## Overview
The rtpy documentation is misleading: https://python-rt.readthedocs.io/en/latest/rest1.html#rt.rest1.Rt.create_ticket 

Specifying "Requestors" instead of "Requestor" as we've been doing causes the requestors to be added AFTER ticket creation, meaning no one gets an email confirmation.


## Related

* [WP-319](https://jira.tacc.utexas.edu/browse/WP-319)

## Changes

- pass `Requestor` instead of `Requestors` to the create_ticket util.

## Testing

1. Submit a ticket through the portal and check that you get a confirmation email.

