### PR TITLE
task/WP-288-QueueFilter-v1

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -44,6 +44,7 @@ const appShape = PropTypes.shape({
     coresPerNode: PropTypes.number,
     maxMinutes: PropTypes.number,
     tags: PropTypes.arrayOf(PropTypes.string),
+    queueFilter: PropTypes.arrayOf(PropTypes.string),
   }),
   systemNeedsKeys: PropTypes.bool,
   pushKeysSystem: PropTypes.shape({}),
@@ -268,6 +269,7 @@ export const AppSchemaForm = ({ app }) => {
     appId: app.definition.id,
     appVersion: app.definition.version,
     execSystemId: app.definition.jobAttributes.execSystemId,
+    queueFilter: app.definition.notes.queueFilter,
   };
 
   let missingAllocation = false;
@@ -691,11 +693,21 @@ export const AppSchemaForm = ({ app }) => {
                         )
                         .map((q) => q.name)
                         .sort()
-                        .map((queueName) => (
-                          <option key={queueName} value={queueName}>
-                            {queueName}
-                          </option>
-                        ))
+                        .map((queueName) =>
+                          app.definition.notes.queueFilter ? (
+                            app.definition.notes.queueFilter.includes(
+                              queueName
+                            ) && (
+                              <option key={queueName} value={queueName}>
+                                {queueName}
+                              </option>
+                            )
+                          ) : (
+                            <option key={queueName} value={queueName}>
+                              {queueName}
+                            </option>
+                          )
+                        )
                         .sort()}
                     </FormField>
                   )}


### PR DESCRIPTION
## Overview
We know some apps only work on certain queues, and for these apps we want to be able to control which queues show up for the user in the queue selection dropdown.

Direction
Develop a queue filter schema based on a flag in the app's notes field, and implement this on the frontend. I suggest something along the lines of app -> notes -> queueFilter -> [], and if there is no queueFilter flag (or nothing in the array), show all queues

Reference
Talk to Sal for details on the schema for the queue filter in an app definition


## Related

* [WP-288](https://jira.tacc.utexas.edu/browse/WP-288)

## Changes

- Added additional, final filter that first checks if queueFilter flag exists. If it does it then checks each of the queueNames to see if they're included in the queueFilter array. If they are present, they're added as options to the dropdown. 
- If the queueFilter flag doesn't exist for the current application, it includes all available queues (that meet the first filter requirement of max/min nodeCount) in the dropdown instead. 
- Added queueFilter to appShape (which is an array of strings).
- Added initial value for queueFilter to be app.definition.notes.queueFilter.


## Testing

1. Sal updated the Namd application to include a queueFilter property in its app.definition.notes flag.
2. Go to https://cep.test/workbench/applications/
3. Navigate to the Simulation category.
4. Scroll down to Configuration -> Queue. (By default it should show 'small' as the queue)
5. Click queue dropdown. You should see 5 queues available. 'development', 'flex', 'normal', 'nvdimm', 'small'. 
6. console.log(app.definition.notes.queueFilter). You should see an array with those 5 elements.
7. Compare with another application. For example, OpenSeesMP (also in Simulation category).
8. Clicking on OpenSeesMP queue dropdown should show all 10 available queues. OpenSeesMP does not have a queueFilter flag in it's app.defintion.notes, so it will give all available queue options from original filter. 
9. You can also check by console.log(app.exec_sys.batchLogicalQueues). This will show you all the available queues that would show up in the dropdown with the first filter. You can compare NAMD's batchLogicalQueues array with its queueFilter array. 
10. Below is a screenshot showing NAMD's batchLogicalQueue array (10 total elements). Versus its queueFilter array (5 elements)
## UI
<img width="1424" alt="Screenshot 2023-10-10 at 11 02 09 AM" src="https://github.com/TACC/Core-Portal/assets/50084480/a0b65152-b8af-4184-8859-e65c81de5cac">



## Notes
This was designed so that in the future when we update other applications or create new applications, we can include queueFilter property in app.definition.notes and further filter which queues we want the users to see on the frontend.

*Frontera system is currently undergoing maintenance, so might have to wait to test dropdown. 
