### PR TITLE
task/WP-164 Implement Workspace Search

### DIFF
--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -76,11 +76,11 @@ class ProjectsApiView(BaseApiView):
             search = IndexedProject.search()
 
             ngram_query = Q("query_string", query=query_string,
-                            fields=["title"],
+                            fields=["title", "id"],
                             minimum_should_match='100%',
                             default_operator='or')
 
-            wildcard_query = Q("wildcard", title=f'*{query_string}*')
+            wildcard_query = Q("wildcard", title=f'*{query_string}*') | Q("wildcard", id=f'*{query_string}*')
 
             search = search.query(ngram_query | wildcard_query)
             search = search.extra(from_=int(offset), size=int(limit))

--- a/server/portal/apps/search/tasks.py
+++ b/server/portal/apps/search/tasks.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from celery import shared_task
 from portal.libs.agave.utils import user_account, service_account
-from portal.libs.elasticsearch.utils import index_listing
+from portal.libs.elasticsearch.utils import index_listing, index_project_listing
 from portal.apps.users.utils import get_tas_allocations
 from portal.apps.projects.models.metadata import ProjectMetadata
 from portal.libs.elasticsearch.docs.base import (IndexedAllocation,
@@ -78,3 +78,8 @@ def index_project(self, project_id):
     project_doc = IndexedProject(**project_dict)
     project_doc.meta.id = project_id
     project_doc.save()
+
+
+@shared_task(bind=True, max_retries=3, queue='default')
+def tapis_project_listing_indexer(self, projects):
+    index_project_listing(projects)

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -139,7 +139,7 @@ def search(client, system, path='', offset=0, limit=100, query_string='', filter
     if filter:
         search = search.filter(filter_query)
 
-    search = search.filter('prefix', **{'path._exact': path})
+    search = search.filter('prefix', **{'path._exact': path.strip('/')})
     search = search.filter('term', **{'system._exact': system})
     search = search.extra(from_=int(offset), size=int(limit))
     res = search.execute()

--- a/server/portal/libs/agave/operations_unit_test.py
+++ b/server/portal/libs/agave/operations_unit_test.py
@@ -74,7 +74,7 @@ class TestOperations(TestCase):
                                                      "name._exact, name._pattern"],
                                                  default_operator='and'))
 
-        mock_search().query().filter.assert_called_with('prefix', **{'path._exact': '/path'})
+        mock_search().query().filter.assert_called_with('prefix', **{'path._exact': 'path'})
         mock_search().query().filter().filter.assert_called_with('term', **{'system._exact': 'test.system'})
         mock_search().query().filter().filter().extra.assert_called_with(from_=int(0), size=int(100))
         self.assertEqual(search_res, {'listing':

--- a/server/portal/libs/elasticsearch/docs/base.py
+++ b/server/portal/libs/elasticsearch/docs/base.py
@@ -17,37 +17,21 @@ logger = logging.getLogger(__name__)
 
 
 class IndexedProject(Document):
+    id = Keyword()
     title = Text(fields={'_exact': Keyword()})
     description = Text()
-    created = Date()
-    lastModified = Date()
-    projectId = Keyword()
+    path = Text()
+    name = Text()
+    host = Text()
     owner = Object(
-        properties={
-            'username': Keyword(),
-            'fullName': Text()
-        }
+            properties={
+                'username': Keyword(),
+                'firstName': Text(),
+                'lastName': Text(),
+                'email': Text()
+            }
     )
-    pi = Object(
-        properties={
-            'username': Keyword(),
-            'fullName': Text()
-        }
-    )
-    coPIs = Object(
-        multi=True,
-        properties={
-            'username': Keyword(),
-            'fullName': Text()
-        }
-    )
-    teamMembers = Object(
-        multi=True,
-        properties={
-            'username': Keyword(),
-            'fullName': Text()
-        }
-    )
+    updated = Date()
 
     @classmethod
     def from_id(cls, projectId):

--- a/server/portal/libs/elasticsearch/docs/base.py
+++ b/server/portal/libs/elasticsearch/docs/base.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class IndexedProject(Document):
-    id = Keyword()
+    id = Keyword(fields={'_exact': Keyword()})
     title = Text(fields={'_exact': Keyword()})
     description = Text()
     path = Text()

--- a/server/portal/libs/elasticsearch/utils.py
+++ b/server/portal/libs/elasticsearch/utils.py
@@ -207,6 +207,8 @@ def index_listing(files):
         file_dict = dict(_file)
         if file_dict['name'][0] == '.':
             continue
+        if not file_dict['path'].startswith('/'):
+            file_dict['path'] = '/' + file_dict['path']
         file_dict['lastUpdated'] = current_time()
         file_dict['basePath'] = os.path.dirname(file_dict['path'])
         file_uuid = file_uuid_sha256(file_dict['system'], file_dict['path'])
@@ -217,5 +219,27 @@ def index_listing(files):
             '_op_type': 'update',
             'doc_as_upsert': True
             })
+
+    bulk(client, ops)
+
+
+def index_project_listing(projects):
+    from portal.libs.elasticsearch.docs.base import IndexedProject
+
+    idx = IndexedProject.Index.name
+    client = get_connection('default')
+    ops = []
+
+    for _project in projects:
+        project_dict = dict(_project)
+        project_dict['lastUpdated'] = current_time()
+        project_uuid = get_sha256_hash(project_dict['id'])
+        ops.append({
+            '_index': idx,
+            '_id': project_uuid,
+            'doc': project_dict,
+            '_op_type': 'update',
+            'doc_as_upsert': True
+        })
 
     bulk(client, ops)

--- a/server/portal/libs/elasticsearch/utils.py
+++ b/server/portal/libs/elasticsearch/utils.py
@@ -232,7 +232,7 @@ def index_project_listing(projects):
 
     for _project in projects:
         project_dict = dict(_project)
-        project_dict['lastUpdated'] = current_time()
+        project_dict['updated'] = current_time()
         project_uuid = get_sha256_hash(project_dict['id'])
         ops.append({
             '_index': idx,

--- a/server/portal/libs/elasticsearch/utils.py
+++ b/server/portal/libs/elasticsearch/utils.py
@@ -207,8 +207,6 @@ def index_listing(files):
         file_dict = dict(_file)
         if file_dict['name'][0] == '.':
             continue
-        if not file_dict['path'].startswith('/'):
-            file_dict['path'] = '/' + file_dict['path']
         file_dict['lastUpdated'] = current_time()
         file_dict['basePath'] = os.path.dirname(file_dict['path'])
         file_uuid = file_uuid_sha256(file_dict['system'], file_dict['path'])


### PR DESCRIPTION
## Overview

Implements workspace search that matches the new tapis v3 implementation of workspaces/projects

## Related

* [WP-164](https://jira.tacc.utexas.edu/browse/WP-164)

## Changes

- Simplified `IndexedProject` document wrapper to more closely resemble the actual response that is sent to the frontend 
- Added new shared task that indexes the projects 
- Added elasticsearch query for when a `query_string` parameter is sent in a get projects request
- Fixed a bug that was causing file listing search within shared workspaces to not work

## Testing

1. Setup search index using instructions from the Core Portal [README](https://github.com/TACC/Core-Portal#setting-up-search-index)
2. Go to shared workspace and test out the search functionality. The title field for a workspace is search on at the moment 
3. Go into a shared workspace and test out the file search functionality and ensure that works as well 

## UI

No UI changes

## Notes

TODO: 

- [x] Add searching on project id field 
- [x] ~~Add unit test for new added feature~~ Added task [WP-341](https://jira.tacc.utexas.edu/browse/WP-341) for updating workspace tests
