### PR TITLE
task/WP-355: Fixing issue with icons on dev/prod sites

### DIFF
--- a/client/src/utils/doesClassExist.js
+++ b/client/src/utils/doesClassExist.js
@@ -3,10 +3,16 @@ function doesClassExist(className, stylesheets) {
     //Required to make this work with Jest/identity-obj-proxy
     if (typeof stylesheet === 'object') {
       if (stylesheet[className]) {
+        console.log('Of type Object');
         return true;
       }
     } else if (typeof stylesheet === 'string') {
-      if (stylesheet.includes(`.${className}::before`)) {
+      if (
+        //Required to fix issue with dev and prod defaulting to icon-applications for every icon
+        stylesheet.includes(`.${className}::before`) ||
+        stylesheet.includes(`.${className}:before`)
+      ) {
+        console.log('Of type String');
         return true;
       }
     }

--- a/client/src/utils/doesClassExist.js
+++ b/client/src/utils/doesClassExist.js
@@ -3,7 +3,6 @@ function doesClassExist(className, stylesheets) {
     //Required to make this work with Jest/identity-obj-proxy
     if (typeof stylesheet === 'object') {
       if (stylesheet[className]) {
-        console.log('Of type Object');
         return true;
       }
     } else if (typeof stylesheet === 'string') {
@@ -12,7 +11,6 @@ function doesClassExist(className, stylesheets) {
         stylesheet.includes(`.${className}::before`) ||
         stylesheet.includes(`.${className}:before`)
       ) {
-        console.log('Of type String');
         return true;
       }
     }

--- a/client/src/utils/doesClassExist.test.js
+++ b/client/src/utils/doesClassExist.test.js
@@ -1,0 +1,55 @@
+import doesClassExist from './doesClassExist';
+
+const mockStylesheet = `
+.icon-upload:before {
+    content: "\\ea57"
+}
+
+.icon-user-reverse:before {
+    content: "\\ea58"
+}
+
+.icon-user:before {
+    content: "\\ea59"
+}
+
+.icon-visualization:before {
+    content: "\\ea5a"
+}
+
+.icon-zoom-in:before {
+    content: "\\ea5b"
+}
+
+.icon-zoom-out:before {
+    content: "\\ea5c"
+}
+`;
+
+describe('doesClassExist', () => {
+  it('should return true for existing class in string stylesheet', async () => {
+    const result = doesClassExist('icon-visualization', [mockStylesheet]);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for non-existing class in string stylesheet', async () => {
+    const result = doesClassExist('icon-nonexistent', [mockStylesheet]);
+    expect(result).toBe(false);
+  });
+
+  it('should return true for existing class in object stylesheet', async () => {
+    const mockStylesheetObject = {
+      'icon-visualization': true,
+    };
+    const result = doesClassExist('icon-visualization', [mockStylesheetObject]);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for non-existing class in object stylesheet', async () => {
+    const mockStylesheetObject = {
+      'icon-visualization': true,
+    };
+    const result = doesClassExist('icon-nonexistent', [mockStylesheetObject]);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION

## Overview
During the testing session, we realized that all app icons in the categories are defaulting to icon-applications instead of their unique icon or the category icon on dev.cep and frontera (dev) sites. The previous PR WP-273 was working correctly on cep.test, however once deployed to dev/pprod, the logic failed. Wanted to investigate where there was a difference between local env and dev/pprod env.  

Portals: cep, frontera.


## Related

* [WP-355](https://jira.tacc.utexas.edu/browse/WP-355)

## Changes

- In the doesClassExist function, added a second check in the if statement to see if either ::before or :before pseudos existed after the className. 
- In the stylesheet/css files we were using to check for classNames--all the css rules have ::before after the icon classNames. However, once the css file was being built for dev/prod the css rules were changing to :before after each icon className in the file. This was fine for cep.test and testing locally--but in dev.cep and frontera it was failing bc it was checking for classNames with ::before only. (Look at screenshots below for context)
- Added a doesClassExist.test.js file to run various unit tests on the function.


## Testing

1. You can test it locally on [cep.test](https://cep.test/workbench/applications) first and make sure the icons in the Applications tray either have their own unique icon, have their category's icon (if no unique icon for that app), or defaults to icon-applications (if no unique icon for app and category doesn't have its own custom icon either). 
2. The real test will be checking dev.cep and frontera (dev) once this branch is deployed there to see if the local env and dev/pprod env are consistent for this feature in both places--with the new code.

## UI
Tested this in the console on dev.cep to make sure it would work correctly using the stylesheet available there via fetch. 
**This is an example of how the code was written before where it was checking for ::before only (notice function returns false)**
![Original](https://github.com/TACC/Core-Portal/assets/50084480/0ede4210-f819-4034-9d50-e13db03f1ec5)

**This is an example of me manually changing the doesClassExist function to check for :before instead (now the function returns true)**
![New](https://github.com/TACC/Core-Portal/assets/50084480/a5b23361-97d2-4b4b-89b0-adf2a4ed5fd3)

**Combining the two checks in the if-statement to make sure both cases are handled regardless of how css file/rules are being built in dev/pprod (still returns true)**
![Logic_for_dev](https://github.com/TACC/Core-Portal/assets/50084480/8eaaab98-f8b8-4353-a657-765629170540)



## Notes

