### PR TITLE
Bug/WP-354: Workspace search - filter results visible to user

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.jsx
@@ -85,7 +85,9 @@ const DataFilesProjectsList = ({ modal }) => {
       Header: 'ID',
       headerStyle: { textAlign: 'left' },
       accessor: 'name',
-      Cell: (el) => <span>{el.value.split('-').slice(-1)[0]}</span>,
+      Cell: (el) => (
+        <span>{el.value ? el.value.split('-').slice(-1)[0] : ''}</span>
+      ),
     },
   ];
 

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -86,8 +86,14 @@ class ProjectsApiView(BaseApiView):
             search = search.extra(from_=int(offset), size=int(limit))
 
             res = search.execute()
-            hits = [hit.to_dict() for hit in res]
-            listing = hits
+            hits = list(map(lambda hit: hit.id, res))
+            if hits:
+                client = request.user.tapis_oauth.client
+                listing = list_projects(client)
+                filtered_list = filter(lambda prj: prj['id'] in hits, listing)
+                listing = list(filtered_list)
+            else:
+                listing = []
         else:
             client = request.user.tapis_oauth.client
             listing = list_projects(client)

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -84,16 +84,19 @@ class ProjectsApiView(BaseApiView):
 
             search = search.query(ngram_query | wildcard_query)
             search = search.extra(from_=int(offset), size=int(limit))
+            search = search.filter('prefix', **{'id': f'{settings.PORTAL_PROJECTS_SYSTEM_PREFIX}'})
 
             res = search.execute()
-            hits = list(map(lambda hit: hit.id, res))
-            listing = []
-            # Filter search results to projects specific to user
-            if hits:
-                client = request.user.tapis_oauth.client
-                listing = list_projects(client)
-                filtered_list = filter(lambda prj: prj['id'] in hits, listing)
-                listing = list(filtered_list)
+            hits = [hit.to_dict() for hit in res]
+            listing = hits
+            # hits = list(map(lambda hit: hit.id, res))
+            # listing = []
+            # # Filter search results to projects specific to user
+            # if hits:
+            #     client = request.user.tapis_oauth.client
+            #     listing = list_projects(client)
+            #     filtered_list = filter(lambda prj: prj['id'] in hits, listing)
+            #     listing = list(filtered_list)
         else:
             client = request.user.tapis_oauth.client
             listing = list_projects(client)

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -87,16 +87,14 @@ class ProjectsApiView(BaseApiView):
             search = search.filter('prefix', **{'id': f'{settings.PORTAL_PROJECTS_SYSTEM_PREFIX}'})
 
             res = search.execute()
-            hits = [hit.to_dict() for hit in res]
-            listing = hits
-            # hits = list(map(lambda hit: hit.id, res))
-            # listing = []
-            # # Filter search results to projects specific to user
-            # if hits:
-            #     client = request.user.tapis_oauth.client
-            #     listing = list_projects(client)
-            #     filtered_list = filter(lambda prj: prj['id'] in hits, listing)
-            #     listing = list(filtered_list)
+            hits = list(map(lambda hit: hit.id, res))
+            listing = []
+            # Filter search results to projects specific to user
+            if hits:
+                client = request.user.tapis_oauth.client
+                listing = list_projects(client)
+                filtered_list = filter(lambda prj: prj['id'] in hits, listing)
+                listing = list(filtered_list)
         else:
             client = request.user.tapis_oauth.client
             listing = list_projects(client)

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -87,13 +87,13 @@ class ProjectsApiView(BaseApiView):
 
             res = search.execute()
             hits = list(map(lambda hit: hit.id, res))
+            listing = []
+            # Filter search results to projects specific to user
             if hits:
                 client = request.user.tapis_oauth.client
                 listing = list_projects(client)
                 filtered_list = filter(lambda prj: prj['id'] in hits, listing)
                 listing = list(filtered_list)
-            else:
-                listing = []
         else:
             client = request.user.tapis_oauth.client
             listing = list_projects(client)

--- a/server/portal/apps/projects/workspace_operations/shared_workspace_operations.py
+++ b/server/portal/apps/projects/workspace_operations/shared_workspace_operations.py
@@ -274,9 +274,12 @@ def list_projects(client):
 
     fields = "id,host,description,notes,updated,owner,rootDir"
     query = f"id.like.{settings.PORTAL_PROJECTS_SYSTEM_PREFIX}.*"
+    # use limit as -1 to allow search to corelate with
+    # all projects available to the api user
     listing = client.systems.getSystems(listType='ALL',
                                         search=query,
-                                        select=fields)
+                                        select=fields,
+                                        limit=-1)
 
     serialized_listing = map(lambda prj: {
         "id": prj.id,


### PR DESCRIPTION
## Overview

Workspace search is crashing when parsing results.
Root cause: 
* Results are returned from search index and not the tapis api response results. For example, some items in search index does not have certain fields (like name) indexed.
* Results are retrieved from all users.  For example: searching for "test" brings various results from search index which should not be visible to the user.

## Related

* [WP-354](https://jira.tacc.utexas.edu/browse/WP-354)

## Changes

* Use the search results and find the matching ones from api. Provide the api result json instead of what is indexed.
* Search results are filtered to what is visible to the user.
* Add protection in js code to avoid crash

## Testing
 
Local testing:
1. with search match
2. with no matches
3. with no query

Testing on dev.cep:
1. Crash with out the fix. Search for a commonly used file name "test" which brings test results from other users. 

2. No crash with the fix and results are specific to the user. See recording below:

https://github.com/TACC/Core-Portal/assets/2568355/32a3fde0-80c4-4846-8e93-c121bb14fc6d



## UI
No change

## Notes
There were no tests written for this feature previously, will start working on that separately.
