### PR TITLE
Bug/WP-361: Fix query string construction

### DIFF
--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -188,7 +188,12 @@ class JobsView(BaseApiView):
         return data
 
     def search(self, client, request):
-
+        '''
+        Search using tapis in specific portal with providing query string.
+        Additonal parameters for search:
+        limit - limit param from request, otherwise default to 10
+        offset - offset param from request, otherwise default to 0
+        '''
         query_string = request.GET.get('query_string')
 
         limit = int(request.GET.get('limit', 10))
@@ -197,10 +202,10 @@ class JobsView(BaseApiView):
 
         sql_queries = [
             f"(tags IN ('portalName: {portal_name}')) AND",
-            f"(name like '%{query_string}%') OR",
+            f"((name like '%{query_string}%') OR",
             f"(archiveSystemDir like '%{query_string}%') OR",
             f"(appId like '%{query_string}%') OR",
-            f"(archiveSystemId like '%{query_string}%')",
+            f"(archiveSystemId like '%{query_string}%'))",
         ]
 
         data = client.jobs.getJobSearchListByPostSqlStr(
@@ -212,7 +217,6 @@ class JobsView(BaseApiView):
             },
             select="allAttributes"
         )
-
         return data
 
     def delete(self, request, *args, **kwargs):


### PR DESCRIPTION
## Overview
The job search is returning jobs from other portal sharing same tenant.
The search query conditions for portal name and query strings is enforcing portal condition correctly.

## Related

* [WP-361](https://jira.tacc.utexas.edu/browse/WP-361)

## Changes
Fix the query to force condition logic, add the missing parentheses  (portal_match) AND (name_match OR archiveSystemDir_match OR appid_match OR archiveSystemId_match)
* For future, instead of manually constructing the query, query building utils can be used to build the query and avoid issues like this 
## Testing

1. Without this PR, check the issue exists
2. In the [code change](https://github.com/TACC/Core-Portal/pull/896/files#diff-7a99e667ee8895ba518b7185992351579fcaf7e6f75310030fc8ba5c51db62c6R201) the portal name to 'Frontera'.
3. With dev tools open, run a query like `https://cep.test/workbench/history/jobs?query_string=jup`. See the network call and check the portal name in the job list. It will show names like 'CEP'.
![Screenshot 2023-11-06 at 12 28 49 PM](https://github.com/TACC/Core-Portal/assets/2568355/3f382eb1-b42c-430c-bdb7-87c77280415b)

5. Apply this PR.
6. Run search `https://cep.test/workbench/history/jobs?query_string=jup` again. See the results, no results will be returned. 
![Screenshot 2023-11-06 at 12 29 28 PM](https://github.com/TACC/Core-Portal/assets/2568355/24eeea93-e9b4-465f-a58c-78b92e5b3eec)

Outside the portal code, tested the query in test client, and checked with and without the fix:
```
query_string = 'jup'
limit = 100
offset = 0
portal_name = 'Frontera'

sql_queries = [
    f"(tags IN ('portalName: {portal_name}')) AND",
    f"((name like '%{query_string}%') OR",
    f"(archiveSystemDir like '%{query_string}%') OR",
    f"(appId like '%{query_string}%') OR",
    f"(archiveSystemId like '%{query_string}%'))",
]
data = client.jobs.getJobSearchListByPostSqlStr(
        limit=limit,
        startAfter=offset,
        orderBy='lastUpdated(desc),name(asc)',
        request_body={
            "search": sql_queries
        },
        select="allAttributes"
    )
print(len(data))

```

## UI



## Notes

