### PR TITLE
bug/WP-356: Use home dir to isolate the search.

### DIFF
--- a/server/portal/apps/site_search/api/unit_test.py
+++ b/server/portal/apps/site_search/api/unit_test.py
@@ -144,7 +144,7 @@ def test_file_search_util(mock_file_search, regular_user):
                                      [{'name': 'testfile',
                                        'path': '/path/to/testfile'}]}
     client = regular_user.tapis_oauth.client
-    res = files_search(client, 'test_query', 'test_system')
+    res = files_search(client, 'test_query', 'test_system', '/',)
 
     mock_file_search.assert_called_with(client, 'test_system', '/',
                                         query_string='test_query',

--- a/server/portal/apps/site_search/api/views.py
+++ b/server/portal/apps/site_search/api/views.py
@@ -36,8 +36,8 @@ def cms_search(query_string, offset=0, limit=10):
     return total, results
 
 
-def files_search(client, query_string, system, filter=None, offset=0, limit=10):
-    res = search_operation(client, system, '/', offset=offset, limit=limit,
+def files_search(client, query_string, system, path, filter=None, offset=0, limit=10):
+    res = search_operation(client, system, path, offset=offset, limit=limit,
                            query_string=query_string, filter=filter)
     return (res['count'], res['listing'])
 
@@ -65,7 +65,7 @@ class SiteSearchApiView(BaseApiView):
                                and ('siteSearchPriority' in conf and conf['siteSearchPriority'] is not None))
             client = request.user.tapis_oauth.client if (request.user.is_authenticated and request.user.profile.setup_complete) else service_account()
             (public_total, public_results) = \
-                files_search(client, qs, public_conf['system'], filter=filter,
+                files_search(client, qs, public_conf['system'], public_conf.get("homeDir", "/"), filter=filter,
                              offset=offset, limit=limit)
             response['public'] = {'count': public_total,
                                   'listing': public_results,
@@ -84,7 +84,7 @@ class SiteSearchApiView(BaseApiView):
                          and ('siteSearchPriority' in conf and conf['siteSearchPriority'] is not None))
                 client = request.user.tapis_oauth.client
                 (community_total, community_results) = \
-                    files_search(client, qs, community_conf['system'], filter=filter,
+                    files_search(client, qs, community_conf['system'], community_conf.get("homeDir", "/"), filter=filter,
                                  offset=offset,
                                  limit=limit)
                 response['community'] = {'count': community_total,


### PR DESCRIPTION
## Overview
Site search is resulting in public and community files from root level path.

## Related
* [WP-356](https://jira.tacc.utexas.edu/browse/WP-356)

## Changes
Use the home directory for public and community data files as path to search.


## Testing
Deployed the branch to [dev.cep](https://dev.cep.tacc.utexas.edu/)
* Used site search and checked the following:
  * The paths listed in the public and community data folders are accurate. They are correctly based on config: corral/tacc/aci/CEP/public and corral/tacc/aci/CEP/community
  * The search results from site-search match the results from data files search.

Screenshots:

Site search shows 37 results for public and 6 results for community:
![Screenshot 2023-11-07 at 12 25 42 PM](https://github.com/TACC/Core-Portal/assets/2568355/ec928b6d-c9c7-4e31-b5ee-f3294b767011)

Public file search shows 37 results:
![Screenshot 2023-11-07 at 12 32 21 PM](https://github.com/TACC/Core-Portal/assets/2568355/63b96730-a657-4bbc-9f0c-db7cb8d4c9b2)


Community file search shows 6 results
![Screenshot 2023-11-07 at 12 32 42 PM](https://github.com/TACC/Core-Portal/assets/2568355/8c670791-9a73-468d-8aa0-b40b19dc3bfc)



## UI
NA

## Notes

