### PR TITLE
Bug/WP-380: Remove id prefix filter on workspace search

### DIFF
--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -84,7 +84,6 @@ class ProjectsApiView(BaseApiView):
 
             search = search.query(ngram_query | wildcard_query)
             search = search.extra(from_=int(offset), size=int(limit))
-            search = search.filter('prefix', **{'id': f'{settings.PORTAL_PROJECTS_SYSTEM_PREFIX}'})
 
             res = search.execute()
             hits = list(map(lambda hit: hit.id, res))


### PR DESCRIPTION
## Overview
Workspace search has id field with system id, project id and actual id used in construction of id. There is a id prefix post-filter on search, which is not working on indexed content in frontera.

There is filtering on results to ensure the results are within the list of projects available to the user. The index searched is specific to a system. So, the extra id based prefix filter does not add value, and the prefix filter on the id field is not working on Frontera.

## Related

* [WP-380](https://jira.tacc.utexas.edu/browse/WP-380)

## Changes

Remove the id based prefix filter.

## Testing

1.

## UI



## Notes

