### PR TITLE
Bug/WP-384: workspace search: handle scenario where id is missing in results

### DIFF
--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -86,7 +86,7 @@ class ProjectsApiView(BaseApiView):
             search = search.extra(from_=int(offset), size=int(limit))
 
             res = search.execute()
-            hits = list(map(lambda hit: hit.id, res))
+            hits = [hit.id for hit in res if hasattr(hit, 'id') and hit.id is not None]
             listing = []
             # Filter search results to projects specific to user
             if hits:


### PR DESCRIPTION
## Overview
There are documents in the projects index which are old and do not have same schema as the search expects.
Some of those do not have id field.


## Related

* [WP-384](https://jira.tacc.utexas.edu/browse/WP-384)

## Changes
* Handle scenario where id is missing.



## Testing

### Setup for testing:
* exec into portal: docker exec -it core_portal_django bash
* Add 2 projects to index which could cause problems.

   * project with no "id" field
```
curl -H "Content-Type: application/json" -X POST http://core_portal_elasticsearch:9200/cep-dev-projects/_doc -d '
{"name": "CEP-foo","host": "cloud.data.tacc.utexas.edu","updated": "2023-11-11T00:00:00","owner": {"username": "foo","first_name": "foo","last_name": "foo","email": "foo@tacc.utexas.edu"},"title": "testfoo","description": "foo"}'
```
 * project does not exist in tapis
 ```
curl -H "Content-Type: application/json" -X POST http://core_portal_elasticsearch:9200/cep-dev-projects/_doc -d '
{"id":"cep.project.CEP-foo1","path":"/corral-repl/tacc/aci/CEP/projects/CEP-foo1", "name": "CEP-foo1","host": "cloud.data.tacc.utexas.edu","updated": "2023-11-11T00:00:00","owner": {"username": "foo","first_name": "foo","last_name": "foo","email": "foo@tacc.utexas.edu"},"title": "testfoo1 buggy search","description": "foo"}'
```

### Test
Go to shared workspaces
1) Without the fix, repro the error. search for test keyword. Below error is seen in UI
![Screenshot 2023-11-09 at 5 43 09 PM](https://github.com/TACC/Core-Portal/assets/2568355/841f6731-14a5-40ac-80ea-795d7938f64a)

2) With the fix, search for test keyword. Both the above added projects are not seen in results and the UI does not show error.

3) Search for keyword from projects from your list, it should show up project results.

4) Search for a keyword not in project list, the results should be empty and not an error message in UI.

## UI



## Notes

