### PR TITLE
task/WP-320: No new tab when downloading files from My Data

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
@@ -29,6 +29,7 @@ const DataFilesPreviewModal = () => {
   const { href, content, error, fileType, isLoading } = useSelector(
     (state) => state.files.preview
   );
+  console.log(useSelector(state => state.files.preview))
   const hasError = error !== null;
   const previewUsingTextContent = !isLoading && !hasError && content !== null;
   const previewUsingHref = !isLoading && !hasError && !previewUsingTextContent;
@@ -116,7 +117,7 @@ const DataFilesPreviewModal = () => {
             <SectionMessage type="warning" className={styles['error-message']}>
               {error}
             </SectionMessage>
-            <Button className={styles.button} href={href} target="_blank">
+            <Button className={styles.button} href={href} target={fileType === 'other' ? "" : "_blank"}> 
               <i className="icon-exit" />
               <span className="toolbar-button-text">Preview File</span>
             </Button>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
@@ -116,7 +116,11 @@ const DataFilesPreviewModal = () => {
             <SectionMessage type="warning" className={styles['error-message']}>
               {error}
             </SectionMessage>
-            <Button className={styles.button} href={href} target={fileType === 'other' ? "" : "_blank"}> 
+            <Button
+              className={styles.button}
+              href={href}
+              target={fileType === 'other' ? '' : '_blank'}
+            >
               <i className="icon-exit" />
               <span className="toolbar-button-text">Preview File</span>
             </Button>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
@@ -29,7 +29,6 @@ const DataFilesPreviewModal = () => {
   const { href, content, error, fileType, isLoading } = useSelector(
     (state) => state.files.preview
   );
-  console.log(useSelector(state => state.files.preview))
   const hasError = error !== null;
   const previewUsingTextContent = !isLoading && !hasError && content !== null;
   const previewUsingHref = !isLoading && !hasError && !previewUsingTextContent;


### PR DESCRIPTION
## Overview
On downloading files marked 'Other' via preview, trying to preview instead leads to download, but still opens & closes a browser tab before the download is fired. This PR prevents that new tab for this case.


## Related

* [WP-320](https://jira.tacc.utexas.edu/browse/WP-320)

## Changes
- On 'Preview File' button when a file is unable to be displayed in the preview modal, now checks for file type 'Other' to determine if a new tab opens or not


## Testing

1. On the workbench, go to Data Files > Shared Workspaces, and find the workspace titled 'Workspace for test files'
2. In that folder, click the name of the `.zip` file to open the File Preview modal
3. Once the modal loads with the message 'Unable to show preview.', click on the 'Preview File' button
4. Confirm that the .zip file downloads to your browser and no new tab on the browser opens
5. Now repeat with the `.json` file in the folder, and confirm that a new tab opens with the contents of the file shown

## UI


https://github.com/TACC/Core-Portal/assets/43251554/97e42d80-84f8-4804-a94f-a32eee086438



## Notes

