### PR TITLE
task/WP-388: fixed text overflow for longer system labels(systemName)

### DIFF
--- a/client/src/components/DataFiles/DataFilesDropdown/DataFilesDropdown.jsx
+++ b/client/src/components/DataFiles/DataFilesDropdown/DataFilesDropdown.jsx
@@ -126,7 +126,9 @@ const BreadcrumbsDropdown = ({
               <span className="multiline-menu-item-wrapper">
                 {scheme === 'projects'
                   ? 'Shared Workspaces'
-                  : systemName || 'Shared Workspaces'}
+                  : (systemName.length > 20
+                      ? systemName.substring(0, 20)
+                      : systemName) || 'Shared Workspaces'}
                 {homeDir ? <small>Root</small> : null}
               </span>
             </DropdownItem>

--- a/client/src/components/DataFiles/DataFilesDropdown/DataFilesDropdown.jsx
+++ b/client/src/components/DataFiles/DataFilesDropdown/DataFilesDropdown.jsx
@@ -126,9 +126,7 @@ const BreadcrumbsDropdown = ({
               <span className="multiline-menu-item-wrapper">
                 {scheme === 'projects'
                   ? 'Shared Workspaces'
-                  : (systemName.length > 20
-                      ? systemName.substring(0, 20)
-                      : systemName) || 'Shared Workspaces'}
+                  : systemName || 'Shared Workspaces'}
                 {homeDir ? <small>Root</small> : null}
               </span>
             </DropdownItem>

--- a/client/src/styles/components/dropdown-menu.css
+++ b/client/src/styles/components/dropdown-menu.css
@@ -13,7 +13,8 @@ Styleguide Components.Dropdown
     border-radius: 0;
     margin-top: 11px;
     padding: 0;
-    width: 200px;
+    min-width: 200px;
+    width: auto;
     vertical-align: top;
   }
   .dropdown-menu::before,


### PR DESCRIPTION
## Overview
The system name (root) in the dropdown menu is not truncated like the path folder names. This is causing a text overflow if the system name is a long string. See example below with Frontera system names/labels. Only an issue if the system name is over 20-char in length.
<img width="729" alt="Screenshot 2023-11-14 at 9 46 41 AM" src="https://github.com/TACC/Core-Portal/assets/50084480/235c43f5-e3cb-462b-896d-9a53dbf1e8d0">

We can use the substring method, like I used for the path folder names below to handle this issue. 
<img width="586" alt="Screenshot 2023-11-14 at 9 52 35 AM" src="https://github.com/TACC/Core-Portal/assets/50084480/f4b1706c-2de7-4629-8452-d37302afb13e">


## Related

* [WP-388](https://jira.tacc.utexas.edu/browse/WP-388)

## Changes

- Added check if systemName was longer than 20 characters--used substring method to grab first 20 chars--otherwise render full systemName (or Shared Workspaces, if applicable)


## Testing

1. Go to server > portal > settings > settings_default.py
2. Locate _PORTAL_DATAFILES_STORAGE_SYSTEMS
3. Change the name field for one of the objects to something like 'name': 'My Data (Frontera Scratch)' 
4. Go to cep.test
5. Look in your Data Files to find the new system label you changed in settings
6. Open the Dropdown menu and check to make sure the long system label is no longer overflowing.
7. Compare with picture below
8. Change the name field back to the original label :) 

## UI
![Screenshot 2023-11-15 at 2 04 05 PM](https://github.com/TACC/Core-Portal/assets/50084480/9cc34c60-385f-4311-a2b7-52b04612449d)



## Notes

