### PR TITLE
Quick: fix impersonation url

### DIFF
--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
 
     # admin.
     path('core/admin/', admin.site.urls),
-    path('core/admin/impersonate/', include('impersonate.urls')),
+    path('core/impersonate/', include('impersonate.urls')),
 
     # terms-and-conditions
     path('terms/', include('termsandconditions.urls')),

--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -26,13 +26,36 @@ from portal.views.views import project_version as portal_version
 from django.views.generic import RedirectView
 from django.views.generic.base import TemplateView
 from django.urls import path, re_path, include
+from impersonate import views as impersonate_views
 admin.autodiscover()
 
 urlpatterns = [
 
     # admin.
     path('core/admin/', admin.site.urls),
-    path('core/impersonate/', include('impersonate.urls')),
+
+    path(
+        'core/admin/impersonate/stop/',
+        impersonate_views.stop_impersonate,
+        name='impersonate-stop',
+    ),
+    path(
+        'core/admin/impersonate/list/',
+        impersonate_views.list_users,
+        {'template': 'impersonate/list_users.html'},
+        name='impersonate-list',
+    ),
+    path(
+        'core/admin/impersonate/search/',
+        impersonate_views.search_users,
+        {'template': 'impersonate/search_users.html'},
+        name='impersonate-search',
+    ),
+    path(
+        'core/admin/impersonate/<int:uid>/',
+        impersonate_views.impersonate,
+        name='impersonate-start',
+    ),
 
     # terms-and-conditions
     path('terms/', include('termsandconditions.urls')),


### PR DESCRIPTION
## Overview

The [django-impersonate](https://pypi.org/project/django-impersonate/) middleware was not functioning properly with the url structure we had in place for some reason.

## Testing

1. Login in one tab with your user, and grant yourself superuser status
2. Login in an incognito tab with another test user
3. Go to https://cep.test/core/impersonate/2 and confirm impersonation works
