### PR TITLE
bug/WP-390: Fix Public Data view

### DIFF
--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -20,7 +20,7 @@ import * as ROUTES from '../../../constants/routes';
 const DataFilesTablePlaceholder = ({ section, data }) => {
   const { params, error: err, loading } = useFileListing(section);
 
-  const isPublicSystem = params.scheme === 'public';
+  const isPublicSystem = params?.scheme === 'public';
 
   const { api: currentListing, scheme } = params ?? {};
 

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -10,7 +10,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useTable, useBlockLayout } from 'react-table';
 import { FixedSizeList, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useFileListing, useSystems } from 'hooks/datafiles';
 import { LoadingSpinner, SectionMessage } from '_common';
 import './DataFilesTable.scss';
@@ -19,6 +19,9 @@ import * as ROUTES from '../../../constants/routes';
 // What to render if there are no files to display
 const DataFilesTablePlaceholder = ({ section, data }) => {
   const { params, error: err, loading } = useFileListing(section);
+
+  const isPublicSystem = params.scheme === 'public';
+
   const { api: currentListing, scheme } = params ?? {};
 
   const dispatch = useDispatch();
@@ -170,6 +173,14 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
       );
     }
     if (err === '403') {
+      if (isPublicSystem)
+        return (
+          <div className="h-100 listing-placeholder">
+            <SectionMessage type="warning">
+              You must be logged in to view this data.
+            </SectionMessage>
+          </div>
+        );
       return (
         <div className="h-100 listing-placeholder">
           <SectionMessage type="warning">

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.js
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.js
@@ -197,9 +197,7 @@ describe('DataFilesTable', () => {
         </BrowserRouter>
       </Provider>
     );
-    expect(
-      getByText(/You are missing the required allocation for this system./)
-    ).toBeDefined();
+    expect(getByText(/You must be logged in to view this data./)).toBeDefined();
   });
 
   it('should display an error for 400 when the api is Google Drive', async () => {

--- a/client/src/components/PublicData/PublicData.jsx
+++ b/client/src/components/PublicData/PublicData.jsx
@@ -14,6 +14,7 @@ import { useSelectedFiles } from 'hooks/datafiles';
 import DataFilesBreadcrumbs from '../DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs';
 import DataFilesListing from '../DataFiles/DataFilesListing/DataFilesListing';
 import DataFilesPreviewModal from '../DataFiles/DataFilesModals/DataFilesPreviewModal';
+import DataFilesShowPathModal from '../DataFiles/DataFilesModals/DataFilesShowPathModal';
 import { ToolbarButton } from '../DataFiles/DataFilesToolbar/DataFilesToolbar';
 
 import styles from './PublicData.module.css';
@@ -46,7 +47,9 @@ const PublicData = () => {
   useEffect(() => {
     const pathLength = location.pathname.split('/').length;
     if (publicDataSystem.system && pathLength < 6) {
-      history.push(`/public-data/tapis/public/${publicDataSystem.system}/`);
+      history.push(
+        `/public-data/tapis/public/${publicDataSystem.system}${publicDataSystem.homeDir}`
+      );
     }
   }, [publicDataSystem.system]);
 
@@ -67,6 +70,7 @@ const PublicData = () => {
         </Route>
       </Switch>
       <DataFilesPreviewModal />
+      <DataFilesShowPathModal />
     </>
   );
 };

--- a/client/src/components/PublicData/PublicData.test.js
+++ b/client/src/components/PublicData/PublicData.test.js
@@ -16,6 +16,7 @@ const systems = {
       {
         name: 'Public Data',
         system: 'cep.storage.public',
+        homeDir: '/',
         scheme: 'public',
         api: 'tapis',
         icon: null,

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -2,8 +2,7 @@ import json
 import logging
 from portal.apps.users.utils import get_allocations
 from django.conf import settings
-from django.http import JsonResponse, HttpResponseForbidden, HttpResponseRedirect
-from django.urls import reverse
+from django.http import JsonResponse, HttpResponseForbidden
 from requests.exceptions import HTTPError
 from tapipy.errors import InternalServerError
 from portal.views.base import BaseApiView

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -161,7 +161,7 @@ def test_get_system_forbidden(client, regular_user, mock_tapis_client, agave_sto
     mock_tapis_client.systems.get.return_value = agave_storage_system_mock
 
     response = client.get("/api/datafiles/systems/definition/MySystem/")
-    assert response.status_code == 302  # redirect to login
+    assert response.status_code == 401
 
 
 @pytest.fixture


### PR DESCRIPTION
## Overview

- fix show path
- fix public path
- prevent access outside public path, and show message

## Related

* [WP-390](https://jira.tacc.utexas.edu/browse/WP-390)

## Testing

1. Log out of cep.test
2. Go to https://cep.test/public-data/
3. Confirm you are redirected to correct public data path set in `settings_default.py`
4. Go to a directory above the homeDir of public data, like https://cep.test/public-data/tapis/public/cloud.data/corral/tacc/
5. Confirm you get an unauthorized message
6. Click "View Path" and confirm it works as expected

## UI

<img width="1266" alt="Screenshot 2023-11-15 at 3 36 09 PM" src="https://github.com/TACC/Core-Portal/assets/20326896/302368d9-4ec4-4304-859f-9a4146bcacba">
<img width="1237" alt="Screenshot 2023-11-15 at 3 35 56 PM" src="https://github.com/TACC/Core-Portal/assets/20326896/fed5a4a8-342c-43eb-8404-04d596265a04">
