### PR TITLE
bug/WP-287 Fix Invalid Url Redirect

### DIFF
--- a/client/src/components/Allocations/tests/AllocationsCells.test.js
+++ b/client/src/components/Allocations/tests/AllocationsCells.test.js
@@ -67,11 +67,6 @@ const mockInitialState = {
       results: {},
     },
   },
-  profile: {
-    data: {
-      demographics: {},
-    },
-  },
 };
 const Wrapper = ({ store, children }) => (
   <Provider store={store}>{children}</Provider>

--- a/client/src/components/Allocations/tests/AllocationsTables.test.js
+++ b/client/src/components/Allocations/tests/AllocationsTables.test.js
@@ -27,7 +27,6 @@ describe('Allocations Table', () => {
       <Provider
         store={mockStore({
           allocations: mockInitialState,
-          profile: { data: { demographics: { firstName: '', lastName: '' } } },
         })}
       >
         <MemoryRouter initialEntries={['/workbench/allocations']}>
@@ -56,7 +55,6 @@ describe('Allocations Table', () => {
         ...mockInitialState,
         errors: { listing: new Error('PC Load Letter') },
       },
-      profile: { data: { demographics: { firstName: '', lastName: '' } } },
     });
     rerender(
       <Provider store={storeWithError}>

--- a/client/src/components/Workbench/AppRouter.jsx
+++ b/client/src/components/Workbench/AppRouter.jsx
@@ -19,7 +19,6 @@ function AppRouter() {
 
   useEffect(() => {
     dispatch({ type: 'FETCH_AUTHENTICATED_USER' });
-    dispatch({ type: 'GET_PROFILE_DATA' });
     dispatch({ type: 'FETCH_WORKBENCH' });
     fetchSystems();
   }, []);

--- a/client/src/components/Workbench/index.test.js
+++ b/client/src/components/Workbench/index.test.js
@@ -22,7 +22,6 @@ describe('AppRouter', () => {
     renderComponent(<AppRouter />, store);
     expect(store.getActions()).toEqual([
       { type: 'FETCH_AUTHENTICATED_USER' },
-      { type: 'GET_PROFILE_DATA' },
       { type: 'FETCH_WORKBENCH' },
       { type: 'FETCH_SYSTEMS' },
       { type: 'FETCH_INTRO' },


### PR DESCRIPTION
## Overview

Fixes the bug where in certain cases after logging in the user would be redirected to the /api/profile/data path and see a screen with api data text. 

## Related

* [WP-287](https://jira.tacc.utexas.edu/browse/WP-287)

## Changes

- Removed an extra GET_PROFILE_DATA action that was being dispatched in AppRouter.jsx. 
- Cleaned up tests for Allocations components  by removing unused variables


## Background 

The profile data retrieved is added to the profile state variable. This state is only used in the ManageAccount components and [ManageAccount.jsx](https://github.com/TACC/Core-Portal/blob/main/client/src/components/ManageAccount/ManageAccount.jsx#L36) already has a `GET_PROFILE_DATA` action being dispatched. So the data is available in that component and removing the action from the AppRouter does not have an effect here.

Previously, the `GET_PROFILE_DATA` was added in the AppRouter.jsx as part of [this PR](https://github.com/TACC/Core-Portal/pull/568/files#diff-e47eef81368d0929758f475f22bbdc41e57c9a1bf31a271ff96baaffe6ab5b69) which was using the profile state to retrieve user information to display in Allocations tables (see [AllocationsTable](https://github.com/TACC/Core-Portal/pull/568/files#diff-ac31ba3a0b50d936cf4c687b573d26061c732b69a3768092e6798e684cc5c52b) and [AllocationsTeamViewModal](https://github.com/TACC/Core-Portal/pull/568/files#diff-20f63ee5f2b91e717af72c26830b80829a1d1fd85e3c0e0724ad418fd8906d38R30)). 

In a [later PR](https://github.com/TACC/Core-Portal/pull/679) the usage of profile was removed from the Allocations components (see [AllocationsTable](https://github.com/TACC/Core-Portal/pull/679/files#diff-ac31ba3a0b50d936cf4c687b573d26061c732b69a3768092e6798e684cc5c52b) and [AllocationsTeamViewModal](https://github.com/TACC/Core-Portal/pull/679/files#diff-20f63ee5f2b91e717af72c26830b80829a1d1fd85e3c0e0724ad418fd8906d38L30)) However, that added `GET_PROFILE_DATA` action was not removed. Since the profile information is not being used in the Allocations components, the additional action being dispatched in AppRouter should be safe to remove


## Testing

1. While logged out go to [cep.test/public-data/](cep.test/public-data/)
2. Log In and go through the flow and ensure page gets redirected to the My Account page


For reference, this was the flow before the fix: 


https://github.com/TACC/Core-Portal/assets/23081932/6e826a3d-d66c-4334-9907-7c4b329e108a


## UI



## Notes

