### PR TITLE
Task/WP-358: sort apps inside category before rendering

### DIFF
--- a/client/src/components/Applications/AppBrowser/AppBrowser.jsx
+++ b/client/src/components/Applications/AppBrowser/AppBrowser.jsx
@@ -81,7 +81,6 @@ const AppBrowser = () => {
           </NavItem>
         ))}
       </Nav>
-      {console.log('console logging categoryDict', categoryDict)}
       <TabContent id="appBrowser-tray" activeTab={activeTab}>
         {Object.keys(categoryDict).map((category) => (
           <TabPane tabId={category} key={`${category}tabPane`}>

--- a/client/src/components/Applications/AppBrowser/AppBrowser.jsx
+++ b/client/src/components/Applications/AppBrowser/AppBrowser.jsx
@@ -18,6 +18,16 @@ const findAppTab = (categoryDict, appId) => {
   );
 };
 
+const sortApps = (apps) => {
+  if (!apps || apps.length === 0) {
+    return [];
+  }
+
+  return apps.sort((a, b) =>
+    (a.label || a.appId).localeCompare(b.label || b.appId)
+  );
+};
+
 const AppBrowser = () => {
   const location = useLocation();
   const { appVersion } = queryString.parse(location.search);
@@ -71,11 +81,12 @@ const AppBrowser = () => {
           </NavItem>
         ))}
       </Nav>
+      {console.log('console logging categoryDict', categoryDict)}
       <TabContent id="appBrowser-tray" activeTab={activeTab}>
         {Object.keys(categoryDict).map((category) => (
           <TabPane tabId={category} key={`${category}tabPane`}>
             <div className="apps-grid-list">
-              {categoryDict[category].map((app) => (
+              {sortApps(categoryDict[category]).map((app) => (
                 <div key={uuidv4()} className="apps-grid-item">
                   <NavLink
                     tag={RRNavLink}

--- a/client/src/components/Applications/AppBrowser/AppBrowser.jsx
+++ b/client/src/components/Applications/AppBrowser/AppBrowser.jsx
@@ -18,16 +18,6 @@ const findAppTab = (categoryDict, appId) => {
   );
 };
 
-const sortApps = (apps) => {
-  if (!apps || apps.length === 0) {
-    return [];
-  }
-
-  return apps.sort((a, b) =>
-    (a.label || a.appId).localeCompare(b.label || b.appId)
-  );
-};
-
 const AppBrowser = () => {
   const location = useLocation();
   const { appVersion } = queryString.parse(location.search);
@@ -85,7 +75,7 @@ const AppBrowser = () => {
         {Object.keys(categoryDict).map((category) => (
           <TabPane tabId={category} key={`${category}tabPane`}>
             <div className="apps-grid-list">
-              {sortApps(categoryDict[category]).map((app) => (
+              {categoryDict[category].map((app) => (
                 <div key={uuidv4()} className="apps-grid-item">
                   <NavLink
                     tag={RRNavLink}

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -444,7 +444,7 @@ class AppsTrayView(BaseApiView):
                 matching_app = next((x for x in sorted(apps_listing, key=lambda y: y.version) if portal_app_id in [x.id, f'{x.id}-{x.version}']), None)
                 if matching_app:
                     tapis_apps.append({**portal_app, 'label': portal_app['label'] or matching_app.notes.label})
-
+            tapis_apps = sorted(tapis_apps, key=lambda app: app['label'] or app['appId'])
             html_apps = list(AppTrayEntry.objects.all().filter(available=True, category=category, appType='html')
                              .order_by(Coalesce('label', 'appId')).values('appId', 'appType', 'html', 'icon', 'label', 'version'))
 

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -444,7 +444,7 @@ class AppsTrayView(BaseApiView):
                 matching_app = next((x for x in sorted(apps_listing, key=lambda y: y.version) if portal_app_id in [x.id, f'{x.id}-{x.version}']), None)
                 if matching_app:
                     tapis_apps.append({**portal_app, 'label': portal_app['label'] or matching_app.notes.label})
-            tapis_apps = sorted(tapis_apps, key=lambda app: app['label'] or app['appId'])
+
             html_apps = list(AppTrayEntry.objects.all().filter(available=True, category=category, appType='html')
                              .order_by(Coalesce('label', 'appId')).values('appId', 'appType', 'html', 'icon', 'label', 'version'))
 
@@ -459,6 +459,7 @@ class AppsTrayView(BaseApiView):
 
                 categoryResult["apps"].append(app)
 
+            categoryResult["apps"] = sorted(categoryResult["apps"], key=lambda app: app['label'] or app['appId'])
             categories.append(categoryResult)
 
         return categories, html_definitions


### PR DESCRIPTION
## Overview

In the /workbench/applications, applications inside each category appeared randomly in order that tapis retrieved it. 

## Related

* [WP-358](https://tacc-main.atlassian.net/browse/WP-358)

## Changes

* used python `sorted` method to sort apps based on app label in backend

## Testing

1. Go to https://cep.test/workbench/applications and confirm the apps inside categories appear alphabetically

## UI

![image](https://github.com/TACC/Core-Portal/assets/54924215/a0475e0f-175e-4295-ba40-71d0e6effcf2)

## Notes

