### PR TITLE
Hotfix WP/402: handle 401 unauthorized Tapis error for pushing keys

### DIFF
--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -105,7 +105,7 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
         .
       </>
     );
-    if (err === '500') {
+    if (err === '500' || err === '401') {
       if (downSystems.includes(currSystemHost)) {
         return (
           <div className="h-100 listing-placeholder">

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -11,7 +11,7 @@ from django.utils.decorators import method_decorator
 from django.urls import reverse
 from django.db.models.functions import Coalesce
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
-from tapipy.errors import BaseTapyException, InternalServerError
+from tapipy.errors import BaseTapyException, InternalServerError, UnauthorizedError
 from portal.views.base import BaseApiView
 from portal.exceptions.api import ApiException
 from portal.apps.licenses.models import LICENSE_TYPES, get_license_info
@@ -107,7 +107,7 @@ class AppsView(BaseApiView):
 
                 try:
                     tapis.files.listFiles(systemId=system_id, path="/")
-                except InternalServerError:
+                except (InternalServerError, UnauthorizedError):
                     success = _test_listing_with_existing_keypair(system_def, request.user)
                     data['systemNeedsKeys'] = not success
                     data['pushKeysSystem'] = system_def
@@ -300,7 +300,7 @@ class JobsView(BaseApiView):
             for system_id in list(set([job_post['archiveSystemId'], job_post['execSystemId']])):
                 try:
                     tapis.files.listFiles(systemId=system_id, path="/")
-                except InternalServerError:
+                except (InternalServerError, UnauthorizedError):
                     system_def = tapis.systems.getSystem(systemId=system_id)
                     success = _test_listing_with_existing_keypair(system_def, request.user)
                     if not success:


### PR DESCRIPTION
## Overview

Tapis has updated new files status codes to reflect more accurately responses from the files service. We will need to update our error handling accordingly:

[Files: Review http status codes for errors · Issue #102 · tapis-project/tapis-files](https://github.com/tapis-project/tapis-files/issues/102)

This PR is a quick fix to get the push keys modal working again. A follow up task will be made to improve overall error handling.

## Related

* [WP-402](https://tacc-main.atlassian.net/browse/WP-402)

## Testing

1. Remove your user credential on Frontera via `client.systems.removeUserCredential(userName=$username, systemId='frontera')`
2. Go to https://cep.test/workbench/applications/paraview?appVersion=5.10.0 and confirm you are prompted to push keys
3. Go to https://cep.test/workbench/data/tapis/private/frontera/ and confirm you are prompted to push keys
