### PR TITLE
bug/WP-408: use archiveSystemId set in app definition as default

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -274,7 +274,7 @@ export const AppSchemaForm = ({ app }) => {
     coresPerNode: app.definition.jobAttributes.coresPerNode,
     maxMinutes: app.definition.jobAttributes.maxMinutes,
     archiveSystemId:
-      defaultSystem || app.definition.jobAttributes.archiveSystemId,
+      app.definition.jobAttributes.archiveSystemId || defaultSystem,
     archiveSystemDir: app.definition.jobAttributes.archiveSystemDir,
     archiveOnAppError: true,
     appId: app.definition.id,
@@ -785,14 +785,19 @@ export const AppSchemaForm = ({ app }) => {
                         description="System into which output files are archived after application execution."
                         name="archiveSystemId"
                         type="text"
-                        placeholder={defaultSystem}
+                        placeholder={
+                          app.definition.archiveSystemId || defaultSystem
+                        }
                       />
                       <FormField
                         label="Archive Directory"
                         description="Directory into which output files are archived after application execution."
                         name="archiveSystemDir"
                         type="text"
-                        placeholder="HOST_EVAL($WORK)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}" // TODOv3: Determine safe root path for archiving https://jira.tacc.utexas.edu/browse/WP-103
+                        placeholder={
+                          app.definition.archiveSystemDir ||
+                          'HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}'
+                        }
                       />
                     </>
                   ) : null}

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -72,11 +72,20 @@ describe('AppSchemaForm', () => {
       ...initialMockState,
     });
 
-    const { getByText } = renderAppSchemaFormComponent(store, {
+    const { getByText, container } = renderAppSchemaFormComponent(store, {
       ...helloWorldAppFixture,
     });
+
+    const archiveSystemId = container.querySelector(
+      'input[name="archiveSystemId"]'
+    );
     await waitFor(() => {
       expect(getByText(/TACC-ACI/)).toBeDefined();
+
+      // use app definition default archive system
+      expect(archiveSystemId.value).toBe(
+        helloWorldAppFixture.definition.jobAttributes.archiveSystemId
+      );
     });
   });
 

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
@@ -26,7 +26,7 @@ export const helloWorldAppFixture = {
       execSystemInputDir: '${JobWorkingDir}',
       execSystemOutputDir: '${JobWorkingDir}/output',
       execSystemLogicalQueue: 'development',
-      archiveSystemId: 'cloud.data',
+      archiveSystemId: 'frontera',
       archiveSystemDir:
         'HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
       archiveOnAppError: true,


### PR DESCRIPTION
## Overview

Use `archiveSystemId` value set in app definition if provided.

## Related

* [WP-408](https://tacc-main.atlassian.net/browse/WP-408)
* [WP-103](https://tacc-main.atlassian.net/browse/WP-103)

## Testing

1. Go to https://cep.test/workbench/applications/opensees-mp-ls6
2. Confirm the "Archive System" field shows `cloud.data`, which is the `archiveSystemId` of this app, instead of `frontera`, which is the default system locally.
