### PR TITLE
task/WP-367: Adding Public Data CMS Nav and fixing search bar root bug

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
@@ -161,11 +161,24 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
     isRootDir || path.replace(/^\/+/, '') === homeDir?.replace(/^\/+/, '');
 
   // Determine the sectionName with added handling for root directory
-  const sectionName = isAtHomeDir
-    ? isRootDir
-      ? 'Root'
-      : systemDisplayName
-    : getCurrentDirectory(path);
+  function determineSectionName(
+    isAtHomeDir,
+    isRootDir,
+    systemDisplayName,
+    path
+  ) {
+    if (isAtHomeDir) {
+      return isRootDir ? 'Root' : systemDisplayName;
+    }
+    return getCurrentDirectory(path);
+  }
+
+  const sectionName = determineSectionName(
+    isAtHomeDir,
+    isRootDir,
+    systemDisplayName,
+    path
+  );
 
   return (
     <>

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
@@ -153,12 +153,18 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
   const systemDisplayName = useSystemDisplayName({ scheme, system, path });
   const homeDir = selectedSystem?.homeDir;
 
-  // Check if the current path is the home directory itself
-  const isAtHomeDir = path.replace(/^\/+/, '') === homeDir?.replace(/^\/+/, '');
+  // Check if the current path is the root directory
+  const isRootDir = path === '/' || path === '';
 
-  // Determine the sectionName based on the path (if homeDir, use systemDisplayName--else use current dir)
+  // Adjusted check for home directory
+  const isAtHomeDir =
+    isRootDir || path.replace(/^\/+/, '') === homeDir?.replace(/^\/+/, '');
+
+  // Determine the sectionName with added handling for root directory
   const sectionName = isAtHomeDir
-    ? systemDisplayName
+    ? isRootDir
+      ? 'Root'
+      : systemDisplayName
     : getCurrentDirectory(path);
 
   return (

--- a/client/src/components/PublicData/PublicData.jsx
+++ b/client/src/components/PublicData/PublicData.jsx
@@ -18,6 +18,8 @@ import DataFilesShowPathModal from '../DataFiles/DataFilesModals/DataFilesShowPa
 import { ToolbarButton } from '../DataFiles/DataFilesToolbar/DataFilesToolbar';
 
 import styles from './PublicData.module.css';
+import dropdownStyles from '../../styles/components/dropdown-menu.css';
+import CombinedBreadcrumbs from '../DataFiles/CombinedBreadcrumbs/CombinedBreadcrumbs';
 
 const PublicData = () => {
   const history = useHistory();
@@ -98,9 +100,9 @@ const PublicDataListing = ({ canDownload, downloadCallback }) => {
     <Section
       // HACK: Replicate wrapper class gives button correct global style
       // WARNING: Applies unused and redundant `.workbench-content` styles
-      className="workbench-content"
+      className="workbench-content workbench-wrapper"
       header={
-        <DataFilesBreadcrumbs
+        <CombinedBreadcrumbs
           api={api}
           scheme={scheme}
           system={system}


### PR DESCRIPTION
## Overview
Public Data listing: Need a mechanism to navigate folders similar to data files listing


## Related

* [WP-367](https://tacc-main.atlassian.net/browse/WP-367)

## Changes

- Changed component in PublicData from DataFilesBreadcrumbs to CombinedBreadcrumbs (includes dropdown menu)
- Added extra "workbench-wrapper" class to handle styling for dropdown menu in Public Data CMS
- There was also a small bug related to WP-304 where errors were thrown related to system name and the search bar, when in the root directory of Public Data CMS. 
- Fixed the above bug in this PR too. Added new code to DataFilesListing to check if the current path is the root. This now correctly handles the placeholder text in the Search bar when in root. 


## Testing

1. Go to cep.test
2. Go directly to https://cep.test/public-data/
3. Test new dropdown menu navigation and make sure it works.
4. Also navigate to https://cep.test/public-data/tapis/public/cloud.data/ (which is the root) and test the navigation there by going into deeper folders and trying to move around with the dropdown menu
5. Make sure no errors are thrown and that the placeholder text in the Search bar is correct

## UI
![Screenshot 2023-12-08 at 10 06 17 AM](https://github.com/TACC/Core-Portal/assets/50084480/d5f36144-d32f-4b3b-bdf5-dd9b7536c56e)



## Notes
Currently on cep.tacc.utexas.edu, when going to the Public Data CMS, we're displaying the root directory. This is incorrect. We should fix this so that it shows the users the correct path on prod.

Also on the Public Data CMS, the margins are incorrect so the search bar button and the data file listings are running into the margins. We should fix this, as well.

