### PR TITLE
WI-15: Add health check for site status

### DIFF
--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -27,6 +27,7 @@ from django.views.generic import RedirectView
 from django.views.generic.base import TemplateView
 from django.urls import path, re_path, include
 from impersonate import views as impersonate_views
+from portal.views.views import health_check
 admin.autodiscover()
 
 urlpatterns = [
@@ -111,5 +112,9 @@ urlpatterns = [
 
     # version check.
     path('version/', portal_version),
+
+    # health check
+    path('core/health-check', health_check)
+
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/server/portal/views/unit_test.py
+++ b/server/portal/views/unit_test.py
@@ -5,6 +5,8 @@ from portal.exceptions.api import ApiException
 from portal.libs.exceptions import PortalLibException
 import requests
 import json
+from portal.views.views import health_check
+
 
 # route to be used for testing purposes
 API_ROUTE = '/api/system-monitor/'
@@ -110,3 +112,8 @@ def test_exception(client, api_method_mock):
     response = client.get(API_ROUTE)
     assert response.status_code == 500
     assert json.loads(response.content) == {'message': 'Something went wrong here...'}
+
+def test_health_check(client, ):
+    response = client.get('/core/health-check')
+    assert response.status_code == 200
+    assert json.loads(response.content) == {'status': 'healthy'}

--- a/server/portal/views/unit_test.py
+++ b/server/portal/views/unit_test.py
@@ -5,7 +5,6 @@ from portal.exceptions.api import ApiException
 from portal.libs.exceptions import PortalLibException
 import requests
 import json
-from portal.views.views import health_check
 
 
 # route to be used for testing purposes

--- a/server/portal/views/unit_test.py
+++ b/server/portal/views/unit_test.py
@@ -112,7 +112,8 @@ def test_exception(client, api_method_mock):
     assert response.status_code == 500
     assert json.loads(response.content) == {'message': 'Something went wrong here...'}
 
-def test_health_check(client, ):
+
+def test_health_check(client):
     response = client.get('/core/health-check')
     assert response.status_code == 200
     assert json.loads(response.content) == {'status': 'healthy'}

--- a/server/portal/views/views.py
+++ b/server/portal/views/views.py
@@ -1,5 +1,5 @@
 import logging
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 
 logger = logging.getLogger(__name__)
 
@@ -23,3 +23,7 @@ def project_version(request):
         version = 'UNKNOWN'
 
     return HttpResponse(version, content_type='text/plain')
+
+def health_check(request):
+    health_status = {'status': 'healthy'}
+    return JsonResponse(health_status)

--- a/server/portal/views/views.py
+++ b/server/portal/views/views.py
@@ -24,6 +24,7 @@ def project_version(request):
 
     return HttpResponse(version, content_type='text/plain')
 
+
 def health_check(request):
     health_status = {'status': 'healthy'}
     return JsonResponse(health_status)


### PR DESCRIPTION
## Overview
To have a monitoring website, a non-authenticated endpoint is needed. This health-check endpoint provides a mechanism to share status. 

## Related

* [WI-15](https://tacc-main.atlassian.net/browse/WI-15)

## Changes
/core/health-check endpoint will provide ping status to validate nginx, uwsgi, django worker is up or not.
A 200 status shows the portal is up. Anything else shows the portal is down.

In future this can be expanded to provide additional status (DB, ES, etc). 

## Testing

1. curl https://cep.test/core/health-check
{"status": "healthy"}
2. Unit test to ensure this endpoint is not removed accidently.

## UI
N/A
## Notes

