### PR TITLE
useEffect to handle rendered message behvaior

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Related
 
-* [WP-XYZ](https://jira.tacc.utexas.edu/browse/WP-XYZ)
+* [WP-XYZ](https://tacc-main.atlassian.net/browse/WP-XYZ)
 
 ## Changes
 

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -15,7 +15,7 @@ import parse from 'html-react-parser';
 import './AppForm.scss';
 import SystemsPushKeysModal from '_common/SystemsPushKeysModal';
 import PropTypes from 'prop-types';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { getSystemName } from 'utils/systems';
 import FormSchema from './AppFormSchema';
 import {
@@ -188,22 +188,7 @@ AppInfo.propTypes = {
 };
 
 export const AppSchemaForm = ({ app }) => {
-  const history = useHistory();
-  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const dispatch = useDispatch();
-  useEffect(() => {
-    setShowSuccessMessage(false);
-
-    const unlisten = history.listen(() => {
-      setShowSuccessMessage(false);
-      jobSubmission.error = null;
-      jobSubmission.response = null;
-    });
-
-    return () => {
-      unlisten();
-    };
-  }, [showSuccessMessage, history]);
 
   useEffect(() => {
     dispatch({ type: 'GET_SYSTEM_MONITOR' });
@@ -608,7 +593,6 @@ export const AppSchemaForm = ({ app }) => {
           ) {
             setSubmitting(false);
             resetForm(initialValues);
-            setShowSuccessMessage(true);
             const formTop = document.getElementById('appBrowser-wrapper');
             formTop.scrollIntoView({ behavior: 'smooth' });
             dispatch({ type: 'TOGGLE_SUBMITTING' });

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -15,7 +15,7 @@ import parse from 'html-react-parser';
 import './AppForm.scss';
 import SystemsPushKeysModal from '_common/SystemsPushKeysModal';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { getSystemName } from 'utils/systems';
 import FormSchema from './AppFormSchema';
 import {
@@ -188,7 +188,23 @@ AppInfo.propTypes = {
 };
 
 export const AppSchemaForm = ({ app }) => {
+  const history = useHistory();
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const dispatch = useDispatch();
+  useEffect(() => {
+    setShowSuccessMessage(false);
+
+    const unlisten = history.listen(() => {
+      setShowSuccessMessage(false);
+      jobSubmission.error = null;
+      jobSubmission.response = null;
+    });
+
+    return () => {
+      unlisten();
+    };
+  }, [showSuccessMessage, history]);
+
   useEffect(() => {
     dispatch({ type: 'GET_SYSTEM_MONITOR' });
   }, [dispatch]);
@@ -387,6 +403,7 @@ export const AppSchemaForm = ({ app }) => {
           </SectionMessage>
         </div>
       )}
+
       {jobSubmission.response && (
         <>
           {jobSubmission.error ? (
@@ -591,6 +608,7 @@ export const AppSchemaForm = ({ app }) => {
           ) {
             setSubmitting(false);
             resetForm(initialValues);
+            setShowSuccessMessage(true);
             const formTop = document.getElementById('appBrowser-wrapper');
             formTop.scrollIntoView({ behavior: 'smooth' });
             dispatch({ type: 'TOGGLE_SUBMITTING' });

--- a/client/src/redux/sagas/apps.sagas.js
+++ b/client/src/redux/sagas/apps.sagas.js
@@ -18,15 +18,7 @@ const getCurrentApp = (state) => state.app;
 
 function* getApp(action) {
   const { appId, appVersion } = action.payload;
-  const currentApp = yield select(getCurrentApp);
 
-  if (
-    currentApp.definition.id === appId &&
-    currentApp.definition.version === appVersion &&
-    !currentApp.systemNeedsKeys
-  ) {
-    return;
-  }
   yield put({ type: 'FLUSH_SUBMIT' });
   yield put({ type: 'GET_APP_START' });
   try {


### PR DESCRIPTION
## Overview

After job submission, the success message will hang at the top of the screen even if you navigate away and back to the app (without refreshing the browser).

Direction
To replicate:

1. submit a job (i.e. [paraview](https://cep.tacc.utexas.edu/workbench/applications/paraview?appVersion=5.10.0))
2. Click the "Allocations" button on the left hand sidebar
3. Go back to the "Applications" view on the left hand sidebar
4. Click Visualization -> Paraview
![image](https://github.com/TACC/Core-Portal/assets/54924215/e4e07e88-14d2-4bad-8dc3-0bf8cf090eb0)


## Related

* [WP-59](https://tacc-main.atlassian.net/browse/WP-59)

## Changes

- added a useEffect and useHistory to listen for navigation changes and reset the jobSubmission properties
- removed logic to not reload an app if it's already `currentApp` exists https://github.com/TACC/Core-Portal/blob/6bfc782bef08164ecfb03cefa0036f345032de7a/client/src/redux/sagas/apps.sagas.js#L23-L27

## Testing

1. Submit paraview job and navigate to allocations and go back to the paraview app. The message should go away.
6. Confirm other error message still shows and doesn't go away (for example the Matlab license in the screenshot below)

## UI
Message reset after changing tabs
![image](https://github.com/TACC/Core-Portal/assets/54924215/fb5fed08-1b56-4d7d-8aab-561c44a471bc)
Other error message still renders correctly
![image](https://github.com/TACC/Core-Portal/assets/54924215/6563aa4d-f2a1-4178-9891-521da4eaefbe)



## Notes

I investigated this behavior and have included [comment](https://tacc-main.atlassian.net/browse/WP-59?focusedCommentId=17830) on why this might be happening on the Jira ticket WP-59. Sal mentioned other solution which might work - "It may be possible to only use get_app, but we'll need to ensure we can handle the request properly on the backend to look for html in the database for the app record instead of sending a request to tapis for html apps." I tried other methods to reset the message after app loads successfully, added a useEffect hook for LOAD_APP & GET_APP dispatchers but this solution seemed to work the best. 

Update:
After suggestions from Sal, I updated the logic on `app.sagas.js` to reload an app everytime it is clicked so the issue above issue is solved.