### PR TITLE
WP-398: 'Preview File' button should say 'Download File'

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.jsx
@@ -122,7 +122,7 @@ const DataFilesPreviewModal = () => {
               target={fileType === 'other' ? '' : '_blank'}
             >
               <i className="icon-exit" />
-              <span className="toolbar-button-text">Preview File</span>
+              <span className="toolbar-button-text">Download File</span>
             </Button>
           </div>
         )}

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesPreviewModal.test.js
@@ -69,6 +69,6 @@ describe('Data Files Preview Modal', () => {
     expect(getByText(/File Preview:/)).toBeDefined();
     expect(getByText(/test\.txt/)).toBeDefined();
     expect(getByText('Unable to show preview.')).toBeDefined();
-    expect(getByText(/Preview File/)).toBeDefined();
+    expect(getByText(/Download File/)).toBeDefined();
   });
 });


### PR DESCRIPTION
## Overview

When file cannot be previewed, the button message should say "Download File"

## Related

* [WP-398](https://tacc-main.atlassian.net/browse/WP-398)

## Changes

- Changed 'Preview File' to say 'Download File'
- Updated unit tests to reflect that change

## Testing

1. On the workbench, go to Data Files > Shared Workspaces, and find the workspace titled 'Workspace for test files'
2. In that folder, click the name of the .zip file to open the File Preview modal
3. Make sure the button reads "Download File"

## UI

![Screenshot 2023-12-19 at 3 30 16 PM](https://github.com/TACC/Core-Portal/assets/54924215/7493191d-cc3b-41cb-b8e3-d522aa6047ea)


## Notes

