### PR TITLE
Bug/WP-305: Do not encode sourceUrl field for tapis jobs

### DIFF
--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -889,7 +889,7 @@ export const defaultAllocationSelector = (state) =>
   state.allocations.portal_alloc || state.allocations.active[0].projectName;
 
 const getExtractParams = (file, latestExtract, defaultAllocation) => {
-  const inputFile = encodeURI(`tapis://${file.system}/${file.path}`);
+  const inputFile = `tapis://${file.system}/${file.path}`;
   const archivePath = `${file.path.slice(0, -file.name.length)}`;
   return JSON.stringify({
     job: {
@@ -1000,7 +1000,7 @@ const getCompressParams = (
   defaultAllocation
 ) => {
   const fileInputs = files.map((file) => ({
-    sourceUrl: encodeURI(`tapis://${file.system}/${file.path}`),
+    sourceUrl: `tapis://${file.system}/${file.path}`,
   }));
 
   let archivePath, archiveSystem;


### PR DESCRIPTION
## Overview
Tapis had inconsistency in url encoding requirement. For job submission, sourceUrl was required to be encoded. But, when transfering files the sourceUrl should not be needed. This led to failures in jobs.

Tapis now fixed the bug to not require any encoding in url values in json content. Job submission is json content.
See bug details: https://github.com/tapis-project/tapis-jobs/issues/66

This bug is now in develop branch


## Related

* [WP-305](https://tacc-main.atlassian.net/browse/WP-305)

## Changes
* Remove encodeURI in client side javascript during compress and extract.
* No other logic in server or client is using encodeURI in 3.x.


## Testing

1. Test extract with and without spaces in zip file name
![Screenshot 2024-01-14 at 12 54 53 PM](https://github.com/TACC/Core-Portal/assets/2568355/bf123cba-481a-4315-af76-bcd09c7aa3d4)
2. Test compress with and without spaces in file names. 
![Screenshot 2024-01-11 at 7 35 02 PM](https://github.com/TACC/Core-Portal/assets/2568355/1cdbf124-e8fe-4180-a16a-3d08079f531a)

3. Update test automation

## UI

## Notes

