### PR TITLE
WP-409: Set members to superuser via TAS

### DIFF
--- a/server/portal/apps/auth/views.py
+++ b/server/portal/apps/auth/views.py
@@ -83,13 +83,13 @@ def launch_setup_checks(user):
             if str(user.username) in groups_and_users["usernames"] or check_user_groups(user, groups_and_users["groups"]):
                 user.is_staff = True
                 user.save()
-                logger.info("user is set to staff")
+                logger.info(f"user {user.username} is set to staff")
 
         elif role == "is_superuser" and not user.is_superuser:
             if str(user.username) in groups_and_users["usernames"] or check_user_groups(user, groups_and_users["groups"]):
                 user.is_superuser = True
                 user.save()
-                logger.info("user is set to superuser")
+                logger.info(f"user {user.username} is set to superuser")
 
 
 def tapis_oauth_callback(request):

--- a/server/portal/apps/auth/views.py
+++ b/server/portal/apps/auth/views.py
@@ -17,7 +17,7 @@ from portal.apps.onboarding.execute import (
     new_user_setup_check
 )
 from portal.apps.search.tasks import index_allocations
-
+from portal.apps.users.utils import check_user_groups
 
 logger = logging.getLogger(__name__)
 METRICS = logging.getLogger(f'metrics.{__name__}')
@@ -76,6 +76,20 @@ def launch_setup_checks(user):
         logger.info("Already onboarded, running non-onboarding steps (e.g. update cached "
                     "allocation information) for %s", user.username)
         index_allocations.apply_async(args=[user.username])
+
+    portal_roles = settings.PORTAL_ELEVATED_ROLES
+    for role, groups_and_users in portal_roles.items():
+        if role == "is_staff" and not user.is_staff:
+            if str(user.username) in groups_and_users["usernames"] or check_user_groups(user, groups_and_users["groups"]):
+                user.is_staff = True
+                user.save()
+                logger.info("user is set to staff")
+
+        elif role == "is_superuser" and not user.is_superuser:
+            if str(user.username) in groups_and_users["usernames"] or check_user_groups(user, groups_and_users["groups"]):
+                user.is_superuser = True
+                user.save()
+                logger.info("user is set to superuser")
 
 
 def tapis_oauth_callback(request):

--- a/server/portal/apps/users/unit_test.py
+++ b/server/portal/apps/users/unit_test.py
@@ -58,7 +58,8 @@ class TestUserApiViews(TestCase):
         self.assertTrue(data["isStaff"])
         self.assertTrue(data["isSuperuser"])
 
-    @patch('portal.apps.users.utils.get_project_users_from_name')    
+    @patch('portal.apps.users.utils.get_project_users_from_name')
+    # test when user is not in TACC-ACI group i.e. not superuser
     def test_auth_view_nosuper(self, mock_get_project_users):
         mock_get_project_users.return_value = []
         self.client.login(username='test', password='test')

--- a/server/portal/apps/users/unit_test.py
+++ b/server/portal/apps/users/unit_test.py
@@ -30,7 +30,6 @@ class TestUserApiViews(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.mock_client_patcher.stop()
-        
 
     def setUp(self):
         User = get_user_model()
@@ -45,7 +44,7 @@ class TestUserApiViews(TestCase):
         user.is_staff = False
         user.is_superuser = False
         user.save()
-    
+
     def test_auth_view(self):
         self.client.login(username='test', password='test')
         resp = self.client.get("/api/users/auth/", follow=True)

--- a/server/portal/apps/users/unit_test.py
+++ b/server/portal/apps/users/unit_test.py
@@ -25,11 +25,14 @@ class TestUserApiViews(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.mock_client_patcher = patch('portal.apps.auth.models.TapisOAuthToken.client')
+        cls.mock_check_tacc_aci_membership_patcher =  patch('portal.apps.users.utils.check_tacc_aci_membership')
         cls.mock_client = cls.mock_client_patcher.start()
+        cls.mock_check_tacc_aci_membership = cls.mock_check_tacc_aci_membership_patcher.start()
 
     @classmethod
     def tearDownClass(cls):
         cls.mock_client_patcher.stop()
+        cls.mock_check_tacc_aci_membership_patcher.stop()
 
     def setUp(self):
         User = get_user_model()
@@ -45,9 +48,8 @@ class TestUserApiViews(TestCase):
         user.is_superuser = False
         user.save()
 
-    @patch('portal.apps.users.utils.check_tacc_aci_membership')
-    def test_auth_view(self, mock_check_tacc_aci_membership):
-        mock_check_tacc_aci_membership.return_value = True
+    def test_auth_view(self):
+        self.mock_check_tacc_aci_membership.return_value = True
         self.client.login(username='test', password='test')
         resp = self.client.get("/api/users/auth/", follow=True)
         data = resp.json()
@@ -58,9 +60,8 @@ class TestUserApiViews(TestCase):
         self.assertTrue(data["isStaff"])
         self.assertTrue(data["isSuperuser"])
 
-    @patch('portal.apps.users.utils.check_tacc_aci_membership')
-    def test_auth_view_nonsuper(self, mock_check_tacc_aci_membership):
-        mock_check_tacc_aci_membership.return_value = False
+    def test_auth_view_nosuper(self):
+        self.mock_check_tacc_aci_membership.return_value = False
         self.client.login(username='test', password='test')
         resp = self.client.get("/api/users/auth/", follow=True)
         data = resp.json()

--- a/server/portal/apps/users/unit_test.py
+++ b/server/portal/apps/users/unit_test.py
@@ -53,6 +53,7 @@ class TestUserApiViews(TestCase):
         # should only return user data system and community
         self.assertTrue(data["username"] == 'test')
         self.assertTrue(data["email"] == "test@test.com")
+        self.assertFalse(data["isStaff"])
 
     def test_auth_view_noauth(self):
         resp = self.client.get("/api/users/auth/", follow=True)

--- a/server/portal/apps/users/unit_test.py
+++ b/server/portal/apps/users/unit_test.py
@@ -30,6 +30,7 @@ class TestUserApiViews(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.mock_client_patcher.stop()
+        
 
     def setUp(self):
         User = get_user_model()
@@ -44,10 +45,8 @@ class TestUserApiViews(TestCase):
         user.is_staff = False
         user.is_superuser = False
         user.save()
-
-    @patch('portal.apps.users.utils.get_project_users_from_name')
-    def test_auth_view(self, mock_get_project_users):
-        mock_get_project_users.return_value = [{'username': 'test'}]
+    
+    def test_auth_view(self):
         self.client.login(username='test', password='test')
         resp = self.client.get("/api/users/auth/", follow=True)
         data = resp.json()
@@ -55,22 +54,6 @@ class TestUserApiViews(TestCase):
         # should only return user data system and community
         self.assertTrue(data["username"] == 'test')
         self.assertTrue(data["email"] == "test@test.com")
-        self.assertTrue(data["isStaff"])
-        self.assertTrue(data["isSuperuser"])
-
-    @patch('portal.apps.users.utils.get_project_users_from_name')
-    # test when user is not in TACC-ACI group i.e. not superuser
-    def test_auth_view_nosuper(self, mock_get_project_users):
-        mock_get_project_users.return_value = []
-        self.client.login(username='test', password='test')
-        resp = self.client.get("/api/users/auth/", follow=True)
-        data = resp.json()
-        self.assertEqual(resp.status_code, 200)
-        # should only return user data system and community
-        self.assertTrue(data["username"] == 'test')
-        self.assertTrue(data["email"] == "test@test.com")
-        self.assertFalse(data["isStaff"])
-        self.assertFalse(data["isSuperuser"])
 
     def test_auth_view_noauth(self):
         resp = self.client.get("/api/users/auth/", follow=True)

--- a/server/portal/apps/users/utils.py
+++ b/server/portal/apps/users/utils.py
@@ -259,3 +259,13 @@ def remove_user(project_id, user_id):
     if resp['status'] != 'success':
         raise ApiException("Failed to delete user: '{}'".format(resp['message']))
     return resp['result']
+
+
+def check_tacc_aci_membership(username):
+    project_users = get_project_users_from_name("TACC-ACI")
+    # Check if username is in TACC-ACI group
+    for user in project_users:
+        if user['username'] == str(username):
+            return True
+
+    return False

--- a/server/portal/apps/users/utils.py
+++ b/server/portal/apps/users/utils.py
@@ -261,11 +261,12 @@ def remove_user(project_id, user_id):
     return resp['result']
 
 
-def check_tacc_aci_membership(username):
-    project_users = get_project_users_from_name("TACC-ACI")
-    # Check if username is in TACC-ACI group
-    for user in project_users:
-        if user['username'] == str(username):
-            return True
+def check_user_groups(username, groups):
+    for group in groups:
+        project_users = get_project_users_from_name(group)
+        # Check if username is in one of the group in the groups array
+        for user in project_users:
+            if user['username'] == str(username):
+                return True
 
     return False

--- a/server/portal/apps/users/utils.py
+++ b/server/portal/apps/users/utils.py
@@ -262,11 +262,7 @@ def remove_user(project_id, user_id):
 
 
 def check_user_groups(username, groups):
-    for group in groups:
-        project_users = get_project_users_from_name(group)
-        # Check if username is in one of the group in the groups array
-        for user in project_users:
-            if user['username'] == str(username):
-                return True
-
-    return False
+    return any(
+        user['username'] == str(username)
+        for group in groups for user in get_project_users_from_name(group)
+    )

--- a/server/portal/apps/users/views.py
+++ b/server/portal/apps/users/views.py
@@ -19,7 +19,7 @@ from elasticsearch_dsl import Q
 from portal.libs.elasticsearch.docs.base import IndexedFile
 from pytas.http import TASClient
 from portal.apps.users.utils import (get_allocations, get_user_data, get_per_user_allocation_usage,
-                                     add_user, remove_user, get_project_from_id, get_project_users_from_id, check_user_groups)
+                                     add_user, remove_user, get_project_from_id, get_project_users_from_id)
 
 logger = logging.getLogger(__name__)
 
@@ -29,19 +29,6 @@ class AuthenticatedView(BaseApiView):
     def get(self, request):
         if request.user.is_authenticated:
             u = request.user
-            portal_roles = settings.PORTAL_ELEVATED_ROLES
-            if portal_roles is not None:
-                for role, groups_and_users in portal_roles.items():
-                    if role == "staff" and not u.is_staff:
-                        if str(u.username) in groups_and_users["usernames"] or check_user_groups(u, groups_and_users["groups"]):
-                            u.is_staff = True
-                            u.save()
-
-                    elif role == "superuser" and not u.is_superuser:
-                        if str(u.username) in groups_and_users["usernames"] or check_user_groups(u, groups_and_users["groups"]):
-                            u.is_superuser = True
-                            u.save()
-                            logger.info("user is set to superuser")
 
             out = {
                 "first_name": u.first_name,
@@ -52,7 +39,6 @@ class AuthenticatedView(BaseApiView):
                     "expires_in": u.tapis_oauth.expires_in,
                 },
                 "isStaff": u.is_staff,
-                "isSuperuser": u.is_superuser,
             }
 
             return JsonResponse(out)

--- a/server/portal/apps/users/views.py
+++ b/server/portal/apps/users/views.py
@@ -157,7 +157,6 @@ class TeamView(BaseApiView):
         : rtype: dict
         """
         usernames = get_project_users_from_id(project_id)
-        logger.info(f"Project users: {usernames}")
 
         return JsonResponse({'response': usernames}, safe=False)
 

--- a/server/portal/apps/users/views.py
+++ b/server/portal/apps/users/views.py
@@ -31,9 +31,9 @@ class AuthenticatedView(BaseApiView):
             u = request.user
             is_tacc_aci_member = check_tacc_aci_membership(u)
 
-            if (check_tacc_aci_membership(u)):
-                u.is_staff = is_tacc_aci_member
-                u.is_superuser = is_tacc_aci_member
+            if is_tacc_aci_member:
+                u.is_staff = True
+                u.is_superuser = True
                 u.save()
 
             out = {
@@ -47,8 +47,6 @@ class AuthenticatedView(BaseApiView):
                 "isStaff": u.is_staff,
                 "isSuperuser": u.is_superuser,
             }
-
-            print("out before returning", out)
 
             return JsonResponse(out)
         return JsonResponse({'message': 'Unauthorized'}, status=401)

--- a/server/portal/apps/users/views.py
+++ b/server/portal/apps/users/views.py
@@ -19,7 +19,7 @@ from elasticsearch_dsl import Q
 from portal.libs.elasticsearch.docs.base import IndexedFile
 from pytas.http import TASClient
 from portal.apps.users.utils import (get_allocations, get_user_data, get_per_user_allocation_usage,
-                                     add_user, remove_user, get_project_from_id, get_project_users_from_id, check_tacc_aci_membership)
+                                     add_user, remove_user, get_project_from_id, get_project_users_from_id, check_user_groups)
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +29,19 @@ class AuthenticatedView(BaseApiView):
     def get(self, request):
         if request.user.is_authenticated:
             u = request.user
-            is_tacc_aci_member = check_tacc_aci_membership(u)
+            portal_roles = settings.PORTAL_ELEVATED_ROLES
+            if portal_roles is not None:
+                for role, groups_and_users in portal_roles.items():
+                    if role == "staff" and not u.is_staff:
+                        if str(u.username) in groups_and_users["usernames"] or check_user_groups(u, groups_and_users["groups"]):
+                            u.is_staff = True
+                            u.save()
 
-            if is_tacc_aci_member:
-                u.is_staff = True
-                u.is_superuser = True
-                u.save()
+                    elif role == "superuser" and not u.is_superuser:
+                        if str(u.username) in groups_and_users["usernames"] or check_user_groups(u, groups_and_users["groups"]):
+                            u.is_superuser = True
+                            u.save()
+                            logger.info("user is set to superuser")
 
             out = {
                 "first_name": u.first_name,

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -717,6 +717,8 @@ SETTINGS: RECAPTCHA
 RECAPTCHA_SECRET_KEY = getattr(settings_secret, '_RECAPTCHA_SECRET_KEY', None)
 RECAPTCHA_SITE_KEY = getattr(settings_secret, '_RECAPTCHA_SITE_KEY', None)
 
+PORTAL_ELEVATED_ROLES = getattr(settings_custom, '_PORTAL_ELEVATED_ROLES', None)
+
 """
 SETTINGS: LOCAL OVERRIDES
 """

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -717,7 +717,7 @@ SETTINGS: RECAPTCHA
 RECAPTCHA_SECRET_KEY = getattr(settings_secret, '_RECAPTCHA_SECRET_KEY', None)
 RECAPTCHA_SITE_KEY = getattr(settings_secret, '_RECAPTCHA_SITE_KEY', None)
 
-PORTAL_ELEVATED_ROLES = getattr(settings_custom, '_PORTAL_ELEVATED_ROLES', None)
+PORTAL_ELEVATED_ROLES = getattr(settings_custom, '_PORTAL_ELEVATED_ROLES', {})
 
 """
 SETTINGS: LOCAL OVERRIDES

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -263,11 +263,11 @@ _WORKBENCH_SETTINGS = {
 }
 
 _PORTAL_ELEVATED_ROLES = {
-  "staff": {
+  "is_staff": {
     "groups": [],
     "usernames": []
   },
-  "superuser": {
+  "is_superuser": {
     "groups": [],
     "usernames": []
   }

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -261,3 +261,14 @@ _WORKBENCH_SETTINGS = {
     },
     "jobsv2Title": "Historic Jobs"
 }
+
+_PORTAL_ELEVATED_ROLES = {
+  "staff": {
+    "groups": [],
+    "usernames": []
+  },
+  "superuser": {
+    "groups": [],
+    "usernames": []
+  }
+}

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -246,3 +246,14 @@ _WORKBENCH_SETTINGS = {
     "ticketAttachmentMaxSize": 3145728,
     "jobsv2Title": "Historic Jobs"
 }
+
+_PORTAL_ELEVATED_ROLES = {
+  "staff": {
+    "groups": [],
+    "usernames": []
+  },
+  "superuser": {
+    "groups": [],
+    "usernames": []
+  }
+}

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -248,12 +248,12 @@ _WORKBENCH_SETTINGS = {
 }
 
 _PORTAL_ELEVATED_ROLES = {
-  "staff": {
-    "groups": [],
+  "is_staff": {
+    "groups": ["TACC-ACI"],
     "usernames": []
   },
-  "superuser": {
-    "groups": [],
+  "is_superuser": {
+    "groups": ["TACC-ACI"],
     "usernames": []
   }
 }

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -526,11 +526,11 @@ WORKBENCH_SETTINGS = {
 }
 
 PORTAL_ELEVATED_ROLES = {
-  "staff": {
+  "is_staff": {
     "groups": [],
     "usernames": []
   },
-  "superuser": {
+  "is_superuser": {
     "groups": [],
     "usernames": []
   }

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -524,3 +524,15 @@ WH_BASE_URL = "https://testserver"
 WORKBENCH_SETTINGS = {
     "debug": False
 }
+
+
+PORTAL_ELEVATED_ROLES = {
+  "staff": {
+    "groups": [],
+    "usernames": []
+  },
+  "superuser": {
+    "groups": [],
+    "usernames": []
+  }
+}

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -525,7 +525,6 @@ WORKBENCH_SETTINGS = {
     "debug": False
 }
 
-
 PORTAL_ELEVATED_ROLES = {
   "staff": {
     "groups": [],


### PR DESCRIPTION
## Overview

Staff and Superuser can be set in through the `_PORTAL_ELEVATED_ROLES` object in `settings_default.py` or `settings_custom.py` for per-portal configuration. Either the TAS group or TACC id can be used. 

```
_PORTAL_ELEVATED_ROLES = {
  "staff": {
    "groups": [],
    "usernames": []
  },
  "superuser": {
    "groups": [],
    "usernames": []
  }
}
```

## Related

* [WP-409](https://tacc-main.atlassian.net/browse/WP-409)

## Changes

- added a new dict object `_PORTAL_ELEVATED_ROLES` object in `settings_default.py` and imported it to `settings.py` 
- updated 'get' method to loop through the PORTAL_ELEVATED_ROLES to check if user's username or TAS groups is in the dict object. Skips if role is already applied to the user.
- updated unit tests to reflect new dict object in `settings.py`

## Testing

1. Remove staff and superuser status, and add your username to the `_PORTAL_ELEVATED_ROLES` dict
2. Open Network tab and check response of `api/users/auth/` endpoint and verify the response 
    ```
    "isStaff": true,
    "isSuperuser": true
    ``` 
3. Repeat the above 2 steps for TAS group by adding `TACC-ACI` or other TAS groups you may be on. 

## UI

No visible UI change except for the Onboarding Admin view for superusers

![image](https://github.com/TACC/Core-Portal/assets/54924215/198430c5-11ea-473d-89bf-446cb3e3f321)


## Notes

