### PR TITLE
docs(server): remove outdated comment

### DIFF
--- a/server/portal/templates/includes/header.html
+++ b/server/portal/templates/includes/header.html
@@ -22,8 +22,6 @@
 
 
       {% include "includes/nav_cms.html" with className="navbar-nav" only %}
-
-      {# NOTE: As of 2020-12, search is only available with a Portal #}
       {% include "includes/nav_search.html" with className="form-inline  ml-auto" only %}
       {# FAQ: Unlike CMS and User Guide, we must pass `user` #}
       {% include "includes/nav_portal.html" with className="navbar-nav" user=user settings=settings only %}

--- a/server/portal/templates/includes/header.html
+++ b/server/portal/templates/includes/header.html
@@ -22,6 +22,7 @@
 
 
       {% include "includes/nav_cms.html" with className="navbar-nav" only %}
+
       {% include "includes/nav_search.html" with className="form-inline  ml-auto" only %}
       {# FAQ: Unlike CMS and User Guide, we must pass `user` #}
       {% include "includes/nav_portal.html" with className="navbar-nav" user=user settings=settings only %}


### PR DESCRIPTION
## Overview

As of https://github.com/TACC/Core-CMS/pull/604, the Core-CMS can use a search other than Portal.

## Related

None

## Changes

- **deleted** a comment in a template

## Testing

Skipped

## UI

N/A

## Notes

CMS uses Google search on [ECEP](https://ecepalliance.org/) and [TACC](https://tacc.utexas.edu/) sites.