### PR TITLE
Add Stampede3 to allocation list and system monitor list

### DIFF
--- a/server/portal/apps/users/tas_to_tacc_resources.json
+++ b/server/portal/apps/users/tas_to_tacc_resources.json
@@ -1,4 +1,9 @@
 {
+    "Stampede3": {
+        "name": "Stampede3",
+        "host": "stampede3.tacc.utexas.edu",
+        "type": "HPC"
+    },
     "Stampede4": {
         "name": "Stampede2",
         "host": "stampede2.tacc.utexas.edu",

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -483,7 +483,7 @@ CELERY_TASK_DEFAULT_EXCHANGE = 'default'
 CELERY_TASK_DEFAULT_ROUTING_KEY = 'default'
 
 """
-SETTINGS: TACC EXECUTION SYSTEMS
+SETTINGS: TACC EXECUTION SYSTEMS.
 """
 TACC_EXEC_SYSTEMS = {
     'corral': {
@@ -492,6 +492,11 @@ TACC_EXEC_SYSTEMS = {
         'home_dir': '/home/{}'
     },
     'stampede2': {
+        'work_dir': '/work2/{}',
+        'scratch_dir': '/scratch/{}',
+        'home_dir': '/home1/{}'
+    },
+    'stampede3': {
         'work_dir': '/work2/{}',
         'scratch_dir': '/scratch/{}',
         'home_dir': '/home1/{}'

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -20,7 +20,7 @@ _WH_BASE_URL = ''
 _LOGIN_REDIRECT_URL = '/remote/login/'
 _LOGOUT_REDIRECT_URL = '/cms/logout/'
 
-_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede2', 'Lonestar6', 'Frontera']
+_SYSTEM_MONITOR_DISPLAY_LIST = ['Stampede3', 'Lonestar6', 'Frontera']
 
 ########################
 # DJANGO SETTINGS LOCAL


### PR DESCRIPTION
## Overview
Stampede3 is part of TACC-ACI allocation and is usable for testing.


## Related

## Changes
* tas_to_tacc_resources.json is matched against available allocations in tas. Need to keep this json updated.
* system monitor list adjustment


## Testing

1. Allocation shows Stampede3
![Screenshot 2024-04-04 at 3 08 35 PM](https://github.com/TACC/Core-Portal/assets/2568355/278f46ac-4a07-4347-a90b-365432b3bd39)


2. System Monitor: TAS is still not updated for Stampede3, so that shows as maintenance. https://tap.tacc.utexas.edu/status does not show stampede3 yet.
![Screenshot 2024-04-04 at 3 11 35 PM](https://github.com/TACC/Core-Portal/assets/2568355/b5d8adb0-6c52-4730-9659-4b0b6e54ce52)


## UI



## Notes

