### PR TITLE
WP-547: case insensitive email in GET tickets

### DIFF
--- a/server/portal/apps/tickets/rtUtil.py
+++ b/server/portal/apps/tickets/rtUtil.py
@@ -60,7 +60,7 @@ class DjangoRt:
     def hasAccess(self, ticket_id, user=None):
         if user and ticket_id:
             ticket = self.tracker.get_ticket(ticket_id)
-            if user.lower() in map(str.lower, ticket.get('Requestors', '')) or user.lower() in map(str.lower, ticket.get('Cc', '')):
+            if DjangoRt.contains_user(ticket.get('Requestors', ''), user) or DjangoRt.contains_user(ticket.get('Cc', ''), user):
                 return True
 
         return False
@@ -68,3 +68,13 @@ class DjangoRt:
     def getAttachment(self, ticket_id, attachment_id):
         ticketAttachment = self.tracker.get_attachment(ticket_id, attachment_id)
         return ticketAttachment
+
+    @staticmethod
+    def contains_user(ticket_field_data, user):
+        user_lower = user.lower()
+        
+        if isinstance(ticket_field_data, str):
+            return user_lower in ticket_field_data.lower()
+        elif isinstance(ticket_field_data, list):
+            return user_lower in map(str.lower, ticket_field_data)        
+        return user.lower() in ticket_field_data

--- a/server/portal/apps/tickets/rtUtil.py
+++ b/server/portal/apps/tickets/rtUtil.py
@@ -72,9 +72,9 @@ class DjangoRt:
     @staticmethod
     def contains_user(ticket_field_data, user):
         user_lower = user.lower()
-        
+
         if isinstance(ticket_field_data, str):
             return user_lower in ticket_field_data.lower()
         elif isinstance(ticket_field_data, list):
-            return user_lower in map(str.lower, ticket_field_data)        
+            return user_lower in map(str.lower, ticket_field_data)
         return user.lower() in ticket_field_data

--- a/server/portal/apps/tickets/rtUtil.py
+++ b/server/portal/apps/tickets/rtUtil.py
@@ -77,4 +77,4 @@ class DjangoRt:
             return user_lower in ticket_field_data.lower()
         elif isinstance(ticket_field_data, list):
             return user_lower in map(str.lower, ticket_field_data)
-        return user.lower() in ticket_field_data
+        return user_lower in ticket_field_data

--- a/server/portal/apps/tickets/rtUtil.py
+++ b/server/portal/apps/tickets/rtUtil.py
@@ -60,7 +60,7 @@ class DjangoRt:
     def hasAccess(self, ticket_id, user=None):
         if user and ticket_id:
             ticket = self.tracker.get_ticket(ticket_id)
-            if user in ticket.get('Requestors', '') or user in ticket.get('Cc', ''):
+            if user.lower() in map(str.lower, ticket.get('Requestors', '')) or user.lower() in map(str.lower, ticket.get('Cc', '')):
                 return True
 
         return False

--- a/server/portal/apps/tickets/unit_test.py
+++ b/server/portal/apps/tickets/unit_test.py
@@ -77,6 +77,7 @@ def mock_tracker(mocker, rt_ticket):
 
 @pytest.mark.parametrize('rt_ticket', [
     {'id': 1, 'Requestors': ["UserName1@Example.COM", "Username2@Example.com"], 'Cc': []},
+    {'id': 1, 'Requestors': "UserName1@Example.COM,Username2@Example.com", 'Cc': []},
     {'id': 1, 'Requestors': ["username1@example.com", "username2@example.com"], 'Cc': []}], indirect=True)
 def test_rt_hasaccess_requestors_or_cc(mock_tracker):
     rtTester = RtUtilTestable(mock_tracker)
@@ -86,7 +87,9 @@ def test_rt_hasaccess_requestors_or_cc(mock_tracker):
 
 @pytest.mark.parametrize('rt_ticket', [
     {'id': 1, 'Requestors': ["Foo@example.com"], 'Cc': ["UserName1@Example.COM", "username2@example.com"]},
+    {'id': 1, 'Requestors': ["Foo@example.com"], 'Cc': "UserName1@Example.COM,username2@example.com"},
     {'id': 1, 'Requestors': ["Foo@example.com"], 'Cc': ["username1@example.com", "username2@example.com"]},
+    {'id': 1, 'Cc': ["username1@example.com", "username2@example.com"]},
     {'id': 1, 'Requestors': [], 'Cc': ["username1@example.com", "username2@example.com"]}], indirect=True)
 def test_rt_hasaccess_cc(mock_tracker):
     rtTester = RtUtilTestable(mock_tracker)
@@ -97,6 +100,7 @@ def test_rt_hasaccess_cc(mock_tracker):
 @pytest.mark.parametrize('rt_ticket', [
     {'id': 1, 'Requestors': ["foo@example.com"], 'Cc': ["baz@example.com"]},
     {'id': 1, 'Requestors': ["FOO@example.com"], 'Cc': ["BAZ@example.com"]},
+    {'id': 1},
     {'id': 1, 'Requestors': [], 'Cc': []}], indirect=True)
 def test_rt_hasnoaccess(mock_tracker):
     rtTester = RtUtilTestable(mock_tracker)


### PR DESCRIPTION
## Overview
In cases, where email in RT Ticketing system is different case vs email address stored in Core Portal user list, a bug shows up where ticket list shows up, but viewing details of the ticket (get_ticket call) fails on access control in rtUtil.djangoRT module.

When searching for tickets, rtUtil.djangoRT uses Requestors__exact search. For this search, RT uses case insensitive. So, the user is able to see all the tickets.When opening a specific ticket, portal does case sensitive check for access to the ticket in requestors and cc fields.

RT search depends on the DB settings for case sensitivity. Search api `__exact` converts to `=` in sql.


## Related

* [WP-547](https://tacc-main.atlassian.net/browse/WP-547)

## Changes

* update djangoRT.hasAccess to do case insensitive look up for user.
* Checked that no other code in djangoRT does a lookup on user.


## Testing

* Go to dashboard, check the following:
  * Ticket list shows up
  * Click on a ticket - pop up with all the details shows up.
  * reply to an existing ticket and it works.
* Run unit tests with and without the fix.
* Note: changing email case in django.contrib.auth.user_model is not setting request.user.email to upper case, request.user.email is always lower case in my tests.

## UI
## Notes
