### PR TITLE
Handle validation for FORK job type

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -28,6 +28,8 @@ import {
   getCoresPerNodeValidation,
   getTargetPathFieldName,
   updateValuesForQueue,
+  getLogicalQueueValidation,
+  getAllocationValidation,
 } from './AppFormUtils';
 import DataFilesSelectModal from '../../DataFiles/DataFilesModals/DataFilesSelectModal';
 import * as ROUTES from '../../../constants/routes';
@@ -456,20 +458,13 @@ export const AppSchemaForm = ({ app }) => {
               name: Yup.string()
                 .max(64, 'Must be 64 characters or less')
                 .required('Required'),
-              execSystemLogicalQueue: Yup.string()
-                .required('Required')
-                .oneOf(app.exec_sys.batchLogicalQueues.map((q) => q.name)),
+              execSystemLogicalQueue: getLogicalQueueValidation(app),
               nodeCount: getNodeCountValidation(queue, app),
-              coresPerNode: getCoresPerNodeValidation(queue),
-              maxMinutes: getMaxMinutesValidation(queue).required('Required'),
+              coresPerNode: getCoresPerNodeValidation(queue, app),
+              maxMinutes: getMaxMinutesValidation(queue, app).required('Required'),
               archiveSystemId: Yup.string(),
               archiveSystemDir: Yup.string(),
-              allocation: Yup.string()
-                .required('Required')
-                .oneOf(
-                  allocations,
-                  'Please select an allocation from the dropdown.'
-                ),
+              allocation: getAllocationValidation(allocations, app),
             });
             return schema;
           });

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -461,7 +461,9 @@ export const AppSchemaForm = ({ app }) => {
               execSystemLogicalQueue: getLogicalQueueValidation(app),
               nodeCount: getNodeCountValidation(queue, app),
               coresPerNode: getCoresPerNodeValidation(queue, app),
-              maxMinutes: getMaxMinutesValidation(queue, app).required('Required'),
+              maxMinutes: getMaxMinutesValidation(queue, app).required(
+                'Required'
+              ),
               archiveSystemId: Yup.string(),
               archiveSystemDir: Yup.string(),
               allocation: getAllocationValidation(allocations, app),

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -2,7 +2,7 @@ import * as Yup from 'yup';
 import { getSystemName } from 'utils/systems';
 
 export const TARGET_PATH_FIELD_PREFIX = '_TargetPath_';
-export const FORK_JOB_MAX_MINUTES = 60*24;
+export const FORK_JOB_MAX_MINUTES = 60 * 24;
 
 export const getQueueMaxMinutes = (app, queueName) => {
   if (isJobTypeFork(app)) {
@@ -255,11 +255,8 @@ export const getAllocationValidation = (allocations, app) => {
   }
 
   return Yup.string()
-  .required('Required')
-  .oneOf(
-    allocations,
-    'Please select an allocation from the dropdown.'
-  );
+    .required('Required')
+    .oneOf(allocations, 'Please select an allocation from the dropdown.');
 };
 
 export const getLogicalQueueValidation = (app) => {
@@ -268,10 +265,10 @@ export const getLogicalQueueValidation = (app) => {
   }
 
   Yup.string()
-  .required('Required')
-  .oneOf(app.exec_sys.batchLogicalQueues.map((q) => q.name));
+    .required('Required')
+    .oneOf(app.exec_sys.batchLogicalQueues.map((q) => q.name));
 };
 
 export const isJobTypeFork = (app) => {
-  return app.definition.jobType == "FORK";
-}
+  return app.definition.jobType == 'FORK';
+};

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -10,7 +10,7 @@ export const getQueueMaxMinutes = (app, queueName) => {
   }
 
   return app.exec_sys.batchLogicalQueues.find((q) => q.name === queueName)
-    ?.maxMinutes;
+    .maxMinutes;
 };
 
 /**

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -2,10 +2,15 @@ import * as Yup from 'yup';
 import { getSystemName } from 'utils/systems';
 
 export const TARGET_PATH_FIELD_PREFIX = '_TargetPath_';
+export const FORK_JOB_MAX_MINUTES = 60*24;
 
 export const getQueueMaxMinutes = (app, queueName) => {
+  if (isJobTypeFork(app)) {
+    return FORK_JOB_MAX_MINUTES;
+  }
+
   return app.exec_sys.batchLogicalQueues.find((q) => q.name === queueName)
-    .maxMinutes;
+    ?.maxMinutes;
 };
 
 /**
@@ -15,7 +20,10 @@ export const getQueueMaxMinutes = (app, queueName) => {
  * @param {Object} queue
  * @returns {Yup.number()} min/max validation of max minutes
  */
-export const getMaxMinutesValidation = (queue) => {
+export const getMaxMinutesValidation = (queue, app) => {
+  if (isJobTypeFork(app)) {
+    return Yup.number().max(FORK_JOB_MAX_MINUTES);
+  }
   return Yup.number()
     .min(
       queue.minMinutes,
@@ -82,7 +90,11 @@ export const createMaxRunTimeRegex = (maxRunTime) => {
  * @param {Object} queue
  * @returns {Yup.number()} min/max validation of node count
  */
-export const getNodeCountValidation = (queue) => {
+export const getNodeCountValidation = (queue, app) => {
+  if (isJobTypeFork(app)) {
+    return Yup.number().integer().min(1).max(1);
+  }
+
   return Yup.number()
     .integer('Node Count must be an integer.')
     .min(
@@ -102,8 +114,8 @@ export const getNodeCountValidation = (queue) => {
  * @param {Object} queue
  * @returns {Yup.number()} min/max validation of coresPerNode
  */
-export const getCoresPerNodeValidation = (queue) => {
-  if (queue.maxCoresPerNode === -1) {
+export const getCoresPerNodeValidation = (queue, app) => {
+  if (queue?.maxCoresPerNode === -1 || isJobTypeFork(app)) {
     return Yup.number().integer();
   }
   return Yup.number()
@@ -236,3 +248,30 @@ export const checkAndSetDefaultTargetPath = (targetPathFieldValue) => {
 
   return targetPathFieldValue;
 };
+
+export const getAllocationValidation = (allocations, app) => {
+  if (isJobTypeFork(app)) {
+    return Yup.string();
+  }
+
+  return Yup.string()
+  .required('Required')
+  .oneOf(
+    allocations,
+    'Please select an allocation from the dropdown.'
+  );
+};
+
+export const getLogicalQueueValidation = (app) => {
+  if (isJobTypeFork(app)) {
+    return Yup.string();
+  }
+
+  Yup.string()
+  .required('Required')
+  .oneOf(app.exec_sys.batchLogicalQueues.map((q) => q.name));
+};
+
+export const isJobTypeFork = (app) => {
+  return app.definition.jobType == "FORK";
+}


### PR DESCRIPTION
## Overview
Job submission for FORK type job is not failing.
Concepts like queues, allocation, node and core count do not apply to FORK job type. 
Errors seen in dev console.
```
index.ec69ba6e.js:32 TypeError: Cannot read properties of undefined (reading 'maxMinutes')
    at getQueueMaxMinutes (index.e90d3a4d.js:98:81851)
    at children (index.e90d3a4d.js:98:141791)
    at Formik (index.e90d3a4d.js:43:61737)
    at jd (index.ec69ba6e.js:30:53016)
    at H_ (index.ec69ba6e.js:34:8745)
    at b_ (index.ec69ba6e.js:34:950)
    at nL (index.ec69ba6e.js:34:878)
    at jo (index.ec69ba6e.js:34:732)
    at Qc (index.ec69ba6e.js:32:10899)
    at index.ec69ba6e.js:30:38809
```
## Related

* [WP-946](https://tacc-main.atlassian.net/browse/WP-946)

## Changes
* Adjust validation for : Node Count, Core Count, Max Minutes, Batch Logical Queue limits and allocation.


## Testing

1. Open https://cep.test/workbench/applications/qgis_express. Job Form shows up and job submission works.
2. Test a batch job for regression: https://cep.test/workbench/applications/hello-world?appVersion=0.0.1 

## UI

## Notes

