### PR TITLE
WP-551: use only strings for app arguments

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -542,9 +542,12 @@ export const AppSchemaForm = ({ app }) => {
                         appFields.parameterSet[parameterSet][k].readOnly
                       )
                         return;
+                      // Convert the value to a string, if necessary
+                      const transformedValue =
+                        typeof v === 'number' ? v.toString() : v;
                       return parameterSet === 'envVariables'
-                        ? { key: k, value: v }
-                        : { name: k, arg: v };
+                        ? { key: k, value: transformedValue }
+                        : { name: k, arg: transformedValue };
                     })
                     .filter((v) => v), // filter out any empty values
                 };

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -430,6 +430,53 @@ describe('AppSchemaForm', () => {
     });
   });
 
+  it('job submission with number field', async () => {
+    const store = mockStore({
+      ...initialMockState,
+    });
+
+    const { getByText, container } = renderAppSchemaFormComponent(
+      store,
+      helloWorldAppFixture
+    );
+    const numberFieldInput = container.querySelector(
+      'input[name="parameterSet.appArgs.Sleep Time"]'
+    );
+    expect(numberFieldInput).toBeInTheDocument();
+    expect(numberFieldInput.type).toBe('number');
+    const newValue = '22';
+    fireEvent.change(numberFieldInput, { target: { value: newValue } });
+
+    const submitButton = getByText(/Submit/);
+    fireEvent.click(submitButton);
+    const payload = {
+      ...helloWorldAppSubmissionPayloadFixture,
+      job: {
+        ...helloWorldAppSubmissionPayloadFixture.job,
+        name: 'hello-world-0.0.1_' + frozenDate + 'T00:00:00',
+      },
+    };
+
+    payload.job.parameterSet.appArgs = payload.job.parameterSet.appArgs.map(
+      (argObj) => {
+        if (argObj.name === 'Sleep Time') {
+          return {
+            ...argObj,
+            arg: newValue,
+          };
+        }
+        return argObj;
+      }
+    );
+
+    await waitFor(() => {
+      expect(store.getActions()).toEqual([
+        { type: 'GET_SYSTEM_MONITOR' },
+        { type: 'SUBMIT_JOB', payload: payload },
+      ]);
+    });
+  });
+
   afterAll(() => {
     timekeeper.reset();
   });


### PR DESCRIPTION
## Overview

For parameterSet, tapis only supports string arguments. See openapi spec [here](https://github.com/tapis-project/tapipy/blob/main/tapipy/resources/openapi_v3-apps.yml#L1686).

Hello World app has a note to indicate that Sleep Time should be rendered as number in App Form. When submitting the job, the value in parameterSet below has Sleep Time as number, it should be json string.
{
    "appArgs": [
        {
            "name": "Greeting",
            "arg": "hello"
        },
        {
            "name": "Target",
            "arg": "world"
        },
        {
            "name": "Sleep Time",
            **"arg": 31**
        }
    ],
}


## Related

* [WP-551](https://tacc-main.atlassian.net/browse/WP-551)

## Changes
If the arg value is integer, change that to string.

## Testing

1. Go to hello world app, change the sleep time to something else and submit job. Job should work.
2. To regression test, change other parameters, change MaxMinutes and submit job. Job submission should work.
3. Run unit test AppSchemaForm with and without fix.

## UI

## Notes

