### PR TITLE
task/wp-594: Setup internal docs with login access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
 
 ####
 # `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
@@ -9,7 +10,7 @@ DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --ta
 
 .PHONY: build
 build:
-	docker compose -f ./server/conf/docker/docker-compose.yml build
+	$(DOCKER_COMPOSE_CMD) -f ./server/conf/docker/docker-compose.yml build
 
 .PHONY: build-full
 build-full:
@@ -28,12 +29,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	docker compose -f server/conf/docker/docker-compose-dev.all.debug.yml up
+	$(DOCKER_COMPOSE_CMD) -f server/conf/docker/docker-compose-dev.all.debug.yml up
 
 .PHONY: stop
 stop:
-	docker compose -f server/conf/docker/docker-compose-dev.all.debug.yml down
+	$(DOCKER_COMPOSE_CMD) -f server/conf/docker/docker-compose-dev.all.debug.yml down
 
 .PHONY: stop-full
 stop-v:
-	docker compose -f server/conf/docker/docker-compose-dev.all.debug.yml down -v
+	$(DOCKER_COMPOSE_CMD) -f server/conf/docker/docker-compose-dev.all.debug.yml down -v

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --ta
 
 .PHONY: build
 build:
-	docker-compose -f ./server/conf/docker/docker-compose.yml build
+	docker compose -f ./server/conf/docker/docker-compose.yml build
 
 .PHONY: build-full
 build-full:
@@ -28,12 +28,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml up
+	docker compose -f server/conf/docker/docker-compose-dev.all.debug.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml down
+	docker compose -f server/conf/docker/docker-compose-dev.all.debug.yml down
 
 .PHONY: stop-full
 stop-v:
-	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml down -v
+	docker compose -f server/conf/docker/docker-compose-dev.all.debug.yml down -v

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -108,6 +108,7 @@ services:
       - ../../../.:/srv/www/portal
       - ../../static:/var/www/portal/server/static
       - ../../media:/var/www/portal/server/media
+      - ../../docs:/var/www/portal/internal-docs/
     dns:
       - 8.8.8.8
       - 8.8.4.4

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -725,6 +725,12 @@ RECAPTCHA_SITE_KEY = getattr(settings_secret, '_RECAPTCHA_SITE_KEY', None)
 PORTAL_ELEVATED_ROLES = getattr(settings_custom, '_PORTAL_ELEVATED_ROLES', {})
 
 """
+SETTINGS: INTERNAL DOCS
+"""
+INTERNAL_DOCS_ROOT = getattr(settings_custom, '_INTERNAL_DOCS_ROOT', '')
+
+
+"""
 SETTINGS: LOCAL OVERRIDES
 """
 if os.path.isfile(os.path.join(BASE_DIR, 'settings', 'settings_local.py')):

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -728,6 +728,7 @@ PORTAL_ELEVATED_ROLES = getattr(settings_custom, '_PORTAL_ELEVATED_ROLES', {})
 SETTINGS: INTERNAL DOCS
 """
 INTERNAL_DOCS_ROOT = getattr(settings_custom, '_INTERNAL_DOCS_ROOT', '')
+INTERNAL_DOCS_URL = getattr(settings_custom, '_INTERNAL_DOCS_URL', '')
 
 
 """

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -257,3 +257,8 @@ _PORTAL_ELEVATED_ROLES = {
     "usernames": []
   }
 }
+
+##################################
+# PORTAL INTERNAL DOCS SETTINGS
+##################################
+_INTERNAL_DOCS_URL = 'core/internal-docs/'

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -535,3 +535,5 @@ PORTAL_ELEVATED_ROLES = {
     "usernames": []
   }
 }
+
+INTERNAL_DOCS_URL = 'core/internal-docs/'

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -537,3 +537,4 @@ PORTAL_ELEVATED_ROLES = {
 }
 
 INTERNAL_DOCS_URL = 'core/internal-docs/'
+INTERNAL_DOCS_ROOT = ''

--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -118,6 +118,6 @@ urlpatterns = [
     path('core/health-check', health_check),
 
     # internal docs
-    re_path('^core/internal-docs/(?P<path>.*)$', serve_docs)
+    re_path(f'^{settings.INTERNAL_DOCS_URL}(?P<path>.*)$', serve_docs),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -117,7 +117,8 @@ urlpatterns = [
     # health check
     path('core/health-check', health_check),
 
-    # internal docs
-    re_path(f'^{settings.INTERNAL_DOCS_URL}(?P<path>.*)$', serve_docs),
-
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# internal docs
+if settings.INTERNAL_DOCS_URL and settings.INTERNAL_DOCS_ROOT:
+    urlpatterns.append(re_path(f"^{settings.INTERNAL_DOCS_URL}(?P<path>.*)$", serve_docs))

--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -28,6 +28,7 @@ from django.views.generic.base import TemplateView
 from django.urls import path, re_path, include
 from impersonate import views as impersonate_views
 from portal.views.views import health_check
+from portal.views.views import serve_docs
 admin.autodiscover()
 
 urlpatterns = [
@@ -114,7 +115,9 @@ urlpatterns = [
     path('version/', portal_version),
 
     # health check
-    path('core/health-check', health_check)
+    path('core/health-check', health_check),
 
+    # internal docs
+    re_path('^core/internal-docs/(?P<path>.*)$', serve_docs)
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/server/portal/views/views.py
+++ b/server/portal/views/views.py
@@ -44,5 +44,5 @@ def serve_docs(request, path):
             path = os.path.join(path, 'index.html')
         else:
             raise Http404("Directory index not found")
-    
+
     return serve(request, path, document_root=settings.INTERNAL_DOCS_ROOT)


### PR DESCRIPTION
## Overview
This PR to provides docs behind a login.

Following are needed to accomplish that:
* Adjustment to core portal to allow support for login based docs
* A compose which can pull docker image from private hub.

Steps to apply for actual site:
1. In configs, adjust docker compose to add docs sections for internal docs. This run mkdocs build.
2. Add mount path from mkdocs container to core portal container
3. Adjust settings to set the doc root.
4. Adjust cms menu to add new menu item to the docs link.

## Related

[WP-594](https://tacc-main.atlassian.net/browse/WP-594)

## Changes
* Add url mapping to map internal-docs to view. 
* Add method to serve the content
* Settings provide the base path to the docs.


## Testing

1. Setup core portal - run make build, make start, npm run dev. The default compose yml has frontera docs
2. Go to https://cep.test/core/internal-docs/index.html to view docs. It will redirect to login and show docs content.
Video: 
https://github.com/user-attachments/assets/0712fc0c-be74-40ab-add3-2f2329f7651f


## UI


## Notes



