### PR TITLE
Cron indexer should use home dir as root instead of '/'

### DIFF
--- a/server/portal/apps/search/tasks.py
+++ b/server/portal/apps/search/tasks.py
@@ -51,8 +51,8 @@ def tapis_listing_indexer(self, listing):
 def index_community_data(self, reindex=False):
     for sys in settings.PORTAL_DATAFILES_STORAGE_SYSTEMS:
         if sys['api'] == 'tapis' and sys['scheme'] in ['community', 'public']:
-            logger.info('INDEXING {} SYSTEM'.format(sys['name']))
-            tapis_indexer.apply_async(args=[sys['system']], kwargs={'reindex': reindex})
+            logger.info('INDEXING {} SYSTEM with file path {}'.format(sys['name'], sys.get("homeDir", "/")))
+            tapis_indexer.apply_async(args=[sys['system']], kwargs={'filePath': sys.get("homeDir", "/"), 'reindex': reindex})
 
 
 @shared_task(bind=True, max_retries=3, queue='api')


### PR DESCRIPTION
## Overview
Cron based indexer is using `/` as the path to walk the files.
It should use the system home dir.


## Related

* [WP-684](https://tacc-main.atlassian.net/browse/WP-684)

## Changes
* Get the homeDir from system and use it.


## Testing

1. Add this to settings_local.py
COMMUNITY_INDEX_SCHEDULE = {'hour': '*', 'minute': 15}


2. Check the logs
docker logs core_portal_workers
```
[DJANGO] INFO 2024-08-29 19:20:00,011 UTC tasks portal.apps.search.tasks.index_community_data:54: INDEXING Community Data SYSTEM with file path /corral/tacc/aci/CEP/community
[DJANGO] INFO 2024-08-29 19:20:00,016 UTC tasks portal.apps.search.tasks.index_community_data:54: INDEXING Public Data SYSTEM with file path /corral/tacc/aci/CEP/public
```

Note: there are errors related wma_prtl SSH access, will resolve that separately and a PR is not needed for that, I believe.

## UI



## Notes

