### PR TITLE
Bug/WP-677: Dynamic exec system bug fixes - validation and allocation list

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -268,7 +268,11 @@ export const AppSchemaForm = ({ app }) => {
         defaultHost?.endsWith(s)
       );
     return {
-      allocations: getAllocationList(app, state.allocations),
+      allocations: getAllocationList(
+        app,
+        state.allocations,
+        allocationToExecSysMap
+      ),
       portalAlloc: state.allocations.portal_alloc,
       jobSubmission: state.jobs.submit,
       hasDefaultAllocation:
@@ -312,7 +316,7 @@ export const AppSchemaForm = ({ app }) => {
       },
     });
   };
-
+  const isFirstRender = React.useRef(true);
   const appFields = FormSchema(app);
   const initialAllocation = getDefaultAllocation(allocations, portalAlloc);
   // This additional form state setup is needed for exec system and queue system
@@ -386,10 +390,10 @@ export const AppSchemaForm = ({ app }) => {
     } else if (!allocations.length) {
       jobSubmission.error = true;
       jobSubmission.response = {
-        message: isAppUsingDynamicExecSystem
+        message: isAppUsingDynamicExecSystem(app)
           ? `You need an allocation to run this application.`
           : `You need an allocation on ${getSystemName(
-              app.exec_sys.host
+              app.execSystems[0].host
             )} to run this application.`,
       };
       missingAllocation = true;
@@ -503,7 +507,7 @@ export const AppSchemaForm = ({ app }) => {
         </>
       )}
       <Formik
-        validateOnMount
+        validateOnMount={isFirstRender.current}
         initialValues={initialValues}
         initialTouched={initialValues}
         validationSchema={(props) => {
@@ -521,7 +525,7 @@ export const AppSchemaForm = ({ app }) => {
               values.execSystemLogicalQueue
             );
             const currentExecSystems = formState.execSystems;
-            const schema = Yup.object({
+            return Yup.object({
               parameterSet: Yup.object({
                 ...Object.assign(
                   {},
@@ -536,14 +540,16 @@ export const AppSchemaForm = ({ app }) => {
               // TODOv3 handle fileInputArrays https://jira.tacc.utexas.edu/browse/WP-81
               name: Yup.string()
                 .max(64, 'Must be 64 characters or less')
-                .required('Required'),
-              execSystemId: getExecSystemIdValidation(
-                app,
-                initialValues.allocation
-              ),
+                .required('Required1'),
+              execSystemId:
+                isJobTypeBATCH(app) && isAppUsingDynamicExecSystem(app)
+                  ? Yup.string()
+                      .required(`A system is required to run this application.`)
+                      .oneOf(app.execSystems?.map((e) => e.id) ?? [])
+                  : Yup.string().notRequired(),
               execSystemLogicalQueue: isJobTypeBATCH(app)
                 ? Yup.string()
-                    .required('Required.')
+                    .required('Required2.')
                     .oneOf(
                       exec_sys?.batchLogicalQueues.map((q) => q.name) ?? []
                     )
@@ -565,15 +571,14 @@ export const AppSchemaForm = ({ app }) => {
                     'You need an allocation with access to at least one system to run this application.',
                     function (value) {
                       const isValidExecSystems =
-                        !isAppUsingDynamicExecSystem ||
-                        (isAppUsingDynamicExecSystem &&
+                        !isAppUsingDynamicExecSystem(app) ||
+                        (isAppUsingDynamicExecSystem(app) &&
                           currentExecSystems.length > 0);
                       return isValidExecSystems;
                     }
                   )
                 : Yup.string().notRequired(),
             });
-            return schema;
           });
         }}
         onSubmit={(values, { setSubmitting, resetForm }) => {
@@ -703,6 +708,7 @@ export const AppSchemaForm = ({ app }) => {
           handleReset,
           resetForm,
           setSubmitting,
+          touched,
         }) => {
           if (
             jobSubmission.response &&
@@ -720,6 +726,9 @@ export const AppSchemaForm = ({ app }) => {
             !hasStorageSystems ||
             jobSubmission.submitting ||
             (app.definition.jobType === 'BATCH' && missingAllocation);
+          React.useEffect(() => {
+            isFirstRender.current = false;
+          }, []);
           return (
             <Form>
               <HandleDependentFieldChanges

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -540,7 +540,7 @@ export const AppSchemaForm = ({ app }) => {
               // TODOv3 handle fileInputArrays https://jira.tacc.utexas.edu/browse/WP-81
               name: Yup.string()
                 .max(64, 'Must be 64 characters or less')
-                .required('Required1'),
+                .required('Required'),
               execSystemId:
                 isJobTypeBATCH(app) && isAppUsingDynamicExecSystem(app)
                   ? Yup.string()
@@ -549,7 +549,7 @@ export const AppSchemaForm = ({ app }) => {
                   : Yup.string().notRequired(),
               execSystemLogicalQueue: isJobTypeBATCH(app)
                 ? Yup.string()
-                    .required('Required2.')
+                    .required('Required.')
                     .oneOf(
                       exec_sys?.batchLogicalQueues.map((q) => q.name) ?? []
                     )

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -541,12 +541,7 @@ export const AppSchemaForm = ({ app }) => {
               name: Yup.string()
                 .max(64, 'Must be 64 characters or less')
                 .required('Required'),
-              execSystemId:
-                isJobTypeBATCH(app) && isAppUsingDynamicExecSystem(app)
-                  ? Yup.string()
-                      .required(`A system is required to run this application.`)
-                      .oneOf(app.execSystems?.map((e) => e.id) ?? [])
-                  : Yup.string().notRequired(),
+              execSystemId: getExecSystemIdValidation(app),
               execSystemLogicalQueue: isJobTypeBATCH(app)
                 ? Yup.string()
                     .required('Required.')
@@ -708,7 +703,6 @@ export const AppSchemaForm = ({ app }) => {
           handleReset,
           resetForm,
           setSubmitting,
-          touched,
         }) => {
           if (
             jobSubmission.response &&

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -447,6 +447,13 @@ describe('AppSchemaForm', () => {
     const { getByText, container } = renderAppSchemaFormComponent(store, {
       ...helloWorldAppFixture,
       execSystems: updatedExecSystems,
+      definition: {
+        ...helloWorldAppFixture.definition,
+        notes: {
+          ...helloWorldAppFixture.definition.notes,
+          dynamicExecSystems: ['maverick99'],
+        },
+      },
     });
 
     console.log(container.innerHTML);
@@ -460,7 +467,10 @@ describe('AppSchemaForm', () => {
     const execSystemDropDown = container.querySelector(
       'select[name="execSystemId"]'
     );
-    expect(execSystemDropDown).toBeNull();
+    const options = execSystemDropDown.querySelectorAll(
+      'option:not([disabled]):not([hidden])'
+    );
+    expect(options.length).toBe(0);
   });
 
   it('does not display exec system and allocation UI for FORK jobs', async () => {

--- a/client/src/components/Applications/AppForm/AppFormUtils.js
+++ b/client/src/components/Applications/AppForm/AppFormUtils.js
@@ -399,16 +399,20 @@ export const isJobTypeBATCH = (app) => {
 };
 
 /**
- * Build list of all allocation if using dynamic exec syste,
- * Otherwise, only provides allocation list matching
+ * If using dynamic exec system,
+ *   build list of all allocations with available hosts.
+ * Otherwise, only provide allocation list matching
  * the execution host.
  * @param {*} app
  * @param {*} allocations
+ * @param {Map(any, any))} map of allocation name to list of exec systems.
  * @returns List of type String
  */
-export const getAllocationList = (app, allocations) => {
+export const getAllocationList = (app, allocations, allocationToExecSysMap) => {
   if (isAppUsingDynamicExecSystem(app)) {
-    return allocations.active.map((alloc) => alloc['projectName']);
+    return [...allocationToExecSysMap.keys()].filter(
+      (alloc) => allocationToExecSysMap.get(alloc).length > 0
+    );
   }
 
   const matchingExecutionHost = Object.keys(allocations.hosts).find(


### PR DESCRIPTION
## Overview
### Root Cause for the bug:
* [ValidateOnMount](https://github.com/jaredpalmer/formik/blob/main/packages/formik/src/Formik.tsx#L432) setting in Formik always uses initialValues.
* Everytime the component re-renders, validateOnMount triggers using initialValues. This is happening in AppForm immediately after value change. After value changes in the form, there are two sets of validators triggers - one is for validateOnMount and another for validateOnChange.
* If the initialValue of allocation is empty (portalAlloc is empty as an example), the validateOnMount causes error on empty allocation. 

### Fix:
* Enable validateOnMount for first render, which is what is intended. Afterwards on change handlers will trigger validation. setValue also triggers validation automatically.


### Allocation change
Do not show allocations without execution hosts.

## Related

* [WP-677](https://tacc-main.atlassian.net/browse/WP-677)

## Changes
* Enable validateOnMount for first render,
* Adjust getAllocationList util to filter out allocations without execution hosts.

## Testing

Local testing: set _PORTAL_ALLOCATION to empty string in settings_custom.py

This change is deployed to dev cep, 3dem pprd and brainmap pprd.
dev.cep: https://dev.cep.tacc.utexas.edu/workbench/applications/hello-world?appVersion=0.0.1
3dem pprd: https://3dem-staging.tacc.utexas.edu/workbench/applications/fiji
brainmap pprd: https://pprd.brainmap.tacc.utexas.edu/workbench/applications/hello-world?appVersion=0.0.1

1. Test applications/hello-world?appVersion=0.0.1 to replicate the error. Flip between the exec systems.
2. Test any other app to check for regression, change the queue.
3. 3DEM: Also, ensure Neuro-nex is not listed in allocations. It does not have any execution hosts.


## UI



## Notes

