### PR TITLE
WP-371: Additional fix to update key to usernames

### DIFF
--- a/server/portal/apps/projects/views_unit_test.py
+++ b/server/portal/apps/projects/views_unit_test.py
@@ -250,7 +250,7 @@ def test_projects_post_setfacl_job(
             'appArgs': [],
             'schedulerOptions': [],
             'envVariables': [
-                {'key': 'username', 'value': 'username'},
+                {'key': 'usernames', 'value': 'username'},
                 {'key': 'directory', 'value': '/path/to/root/test.project-2'},
                 {'key': 'action', 'value': 'add'},
                 {'key': 'role', 'value': 'writer'},
@@ -455,7 +455,7 @@ def test_project_change_system_role_setfacl_job(
             'appArgs': [],
             'schedulerOptions': [],
             'envVariables': [
-                {'key': 'username', 'value': 'test_user'},
+                {'key': 'usernames', 'value': 'test_user'},
                 {'key': 'directory', 'value': '/path/to/root/PRJ-123'},
                 {'key': 'action', 'value': 'add'},
                 {'key': 'role', 'value': 'writer'},
@@ -608,7 +608,7 @@ def test_members_view_add_setfacl_job(
             'appArgs': [],
             'schedulerOptions': [],
             'envVariables': [
-                {'key': 'username', 'value': 'test_user'},
+                {'key': 'usernames', 'value': 'test_user'},
                 {'key': 'directory', 'value': '/path/to/root/PRJ-123'},
                 {'key': 'action', 'value': 'add'},
                 {'key': 'role', 'value': 'writer'},
@@ -723,7 +723,7 @@ def test_members_view_remove_setfacl_job(
             'appArgs': [],
             'schedulerOptions': [],
             'envVariables': [
-                {'key': 'username', 'value': 'test_user'},
+                {'key': 'usernames', 'value': 'test_user'},
                 {'key': 'directory', 'value': '/path/to/root/PRJ-123'},
                 {'key': 'action', 'value': 'remove'},
                 {'key': 'role', 'value': 'none'},

--- a/server/portal/apps/projects/workspace_operations/shared_workspace_operations.py
+++ b/server/portal/apps/projects/workspace_operations/shared_workspace_operations.py
@@ -93,7 +93,7 @@ def submit_workspace_acls_job(
             "appArgs": [],
             "schedulerOptions": [],
             "envVariables": [
-                {"key": "username", "value": username},
+                {"key": "usernames", "value": username},
                 {
                     "key": "directory",
                     "value": f"{settings.PORTAL_PROJECTS_ROOT_DIR}/{project_name}",


### PR DESCRIPTION
## Overview
Handle key name change from PR https://github.com/TACC/WMA-Tapis-Templates/pull/55


## Related

[WP-371](https://tacc-main.atlassian.net/browse/WP-371)
SetFacl app PR: https://github.com/TACC/WMA-Tapis-Templates/pull/55

## Changes
1. Rename key from username to usernames to match the app update.


## Testing

1. Test workspace - add users.

## UI



## Notes

