### PR TITLE
Task/WP-76: Add unit tests for /api/accounts/systems/ route

### DIFF
--- a/client/src/redux/sagas/systems.sagas.test.js
+++ b/client/src/redux/sagas/systems.sagas.test.js
@@ -12,9 +12,9 @@ describe('pushSystemKeys', () => {
     () => {
       // Create a mock form for the fetchUtil call
       const mockForm = {
-        password: '',
-        token: '',
-        hostname: '',
+        password: 'mockPassword',
+        token: 'mockToken',
+        hostname: 'mockHostname',
       };
       expectSaga(pushSystemKeys, {})
         // Sends the call to update the systems modal
@@ -39,7 +39,7 @@ describe('pushSystemKeys', () => {
             props: {},
           },
         });
-      // Check for errors
-      expect(pushSystemKeys).not.toThrowError();
+      // Check for action.payload.onSuccess
+      expect(action.payload).toBe(onSuccess);
     };
 });

--- a/client/src/redux/sagas/systems.sagas.test.js
+++ b/client/src/redux/sagas/systems.sagas.test.js
@@ -1,0 +1,45 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { pushSystemKeys } from 'redux-saga/effects';
+import { fetchUtil } from 'utils/fetchUtil';
+import { vi } from 'vitest';
+
+// Mocks the cross-fetch
+vi.mock('cross-fetch');
+
+// Test the pushSystemKeys function
+describe('pushSystemKeys', () => {
+  it('updates system data'),
+    () => {
+      // Create a mock form for the fetchUtil call
+      const mockForm = {
+        password: '',
+        token: '',
+        hostname: '',
+      };
+      expectSaga(pushSystemKeys, {})
+        // Sends the call to update the systems modal
+        .put({
+          type: 'SYSTEMS_MODAL_UPDATE',
+          payload: {
+            operation: 'pushKeys',
+            props: { submitting: true },
+          },
+        })
+        // Sends the form information to the API url indicated
+        .call(fetchUtil, {
+          url: `/api/accounts/systems/${action.payload.systemId}/keys/`,
+          body: JSON.stringify({ mockForm, action: 'push' }),
+          method: 'PUT',
+        })
+        // Toggles the modal state when successful
+        .put({
+          type: 'SYSTEMS_TOGGLE_MODAL',
+          payload: {
+            operation: 'pushKeys',
+            props: {},
+          },
+        });
+      // Check for errors
+      expect(pushSystemKeys).not.toThrowError();
+    };
+});


### PR DESCRIPTION
## Overview

This is a feature written to test `systems.sagas.js`, thus ensuring that the `pushSystemKeys()` function works as intended.

## Related

* [WP-76](https://tacc-main.atlassian.net/browse/WP-76)

## Changes

I added the `systems.sagas.test.js` file and wrote a test for the `pushSystemKeys()` function.

## Testing

1. In VSCode, navigate to Core-Portal/client/src/redux/sagas/systems.sagas.test.js.
2. In the Terminal, navigate to Core-Portal/client/src/redux/sagas and run this command: `npx vitest run systems.sagas.test.js`.
3. The test should pass.

## UI

![image](https://github.com/user-attachments/assets/2e2740c1-c1a0-49c5-a5ef-99b56d170d44)

## Notes

Further refining of this test may be needed.