### PR TITLE
Bug/WP-420: Search placeholder does not update on navigating to directories

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
@@ -168,7 +168,8 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
     path
   ) {
     if (isAtHomeDir) {
-      return isRootDir ? 'Root' : systemDisplayName;
+      // For WP-420 search placeholder needs to change when going into a new project, was "Root" before. Needs to show current folder instead 
+      return systemDisplayName;
     }
     return getCurrentDirectory(path);
   }

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
@@ -168,7 +168,6 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
     path
   ) {
     if (isAtHomeDir) {
-      // For WP-420 search placeholder needs to change when going into a new project, was "Root" before. Needs to show current folder instead
       return systemDisplayName;
     }
     return getCurrentDirectory(path);

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
@@ -168,7 +168,7 @@ const DataFilesListing = ({ api, scheme, system, path, isPublic }) => {
     path
   ) {
     if (isAtHomeDir) {
-      // For WP-420 search placeholder needs to change when going into a new project, was "Root" before. Needs to show current folder instead 
+      // For WP-420 search placeholder needs to change when going into a new project, was "Root" before. Needs to show current folder instead
       return systemDisplayName;
     }
     return getCurrentDirectory(path);


### PR DESCRIPTION
## Overview
On CEP Shared Workspaces → any workspace title still says "Search Root"


## Related

* [WP-420](https://tacc-main.atlassian.net/browse/WP-420)

## Changes

- Changed the logic that shows "Search Root" to the current working directory folder name instead of Root. The only time that this would occur is on the first project directory navigation. The rest of the navigations into additional sub folders seems correct

## UI
### All Shared Workspaces
![image](https://github.com/user-attachments/assets/740907d7-f54b-4758-983e-9b1607ba783f)

### Navigating into a Shared Workspace Before
![image](https://github.com/user-attachments/assets/c2134e16-c6de-49cf-9e35-08fd81feebc5)

### Navigating into a Shared Workspace After
![image](https://github.com/user-attachments/assets/a37da95d-d39d-42f1-9fd2-334e161963a7)
