### PR TITLE
Refactor ReviewAuthors component to use separate citation components

### DIFF
--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewAuthors.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewAuthors.jsx
@@ -15,28 +15,103 @@ import ReorderUserList from '../../utils/ReorderUserList/ReorderUserList';
 import ProjectMembersList from '../../utils/ProjectMembersList/ProjectMembersList';
 import { useSelector } from 'react-redux';
 
-const MLACitation = ({ project, authors }) => {
-  let authorString;
-
-  if (authors.length === 1) {
-    authorString = `${authors[0].last_name}, ${authors[0].first_name}`;
-  } else if (authors.length === 2) {
-    authorString = `${authors[0].last_name}, ${authors[0].first_name}, and ${authors[1].last_name}, ${authors[1].first_name}`;
-  } else {
-    authorString = `${authors[0].last_name}, ${authors[0].first_name}, et al`;
-  }
-
-  const mlaText = `${authorString}. "${project.title}." Digital Rocks Portal `;
+const ACMCitation = ({ project, authors }) => {
+  const authorString = authors.map(a => `${a.first_name} ${a.last_name}`).join(', ');
+  const projectUrl = `https://www.digitalrocksportal.org/projects/${project.projectId.split('-').pop()}`;
+  const createdDate = new Date(project.created).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 
   return (
-    <>
-      <h2>MLA</h2>
-      <div className={styles['citation-box']}>
-        <div>{mlaText}</div>
-      </div>
-    </>
+    <div>
+  {`${authorString}. ${project.title}. `} <em>Digital Rocks Portal</em> {` (${createdDate}). ${projectUrl}`} </div>
   );
 };
+
+const APACitation = ({ project, authors }) => {
+  const authorString = authors
+    .map((a) => `${a.last_name}, ${a.first_name.charAt(0)}.`)
+    .join(', ');
+  const projectUrl = `https://www.digitalrocksportal.org`;
+  const createdDateObj = new Date(project.created);
+  const createdDate = `${createdDateObj.getFullYear()}, ${createdDateObj.toLocaleString('en-US', { month: 'long' })} ${createdDateObj.getDate()}`;
+  const accessDate = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  return (
+    <div>{`${authorString} (${createdDate}). ${project.title}. Retrieved ${accessDate}, from ${projectUrl}`}</div>
+  );
+};
+
+const BibTeXCitation = ({ project, authors }) => {
+  const authorString = authors.map(a => `${a.last_name}, ${a.first_name}`).join(' and ');
+  const projectUrl = `https://www.digitalrocksportal.org/projects/${project.projectId.split('-').pop()}`;
+  const year = new Date(project.created).getFullYear();
+
+  return (
+    <pre>{`@misc{dataset,
+  author = {${authorString}},
+  title = {${project.title}},
+  year = {${year}},
+  publisher = {Digital Rocks Portal},
+  doi = {},
+  howpublished = {\\url{${projectUrl}}}
+}`}</pre>
+  );
+};
+
+const MLACitation = ({ project, authors }) => {
+  const authorString = authors.map(a => `${a.last_name}, ${a.first_name}`).join(', ');
+  const projectUrl = `https://www.digitalrocksportal.org/projects/${project.projectId.split('-').pop()}`;
+  const createdDate = new Date(project.created).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  const accessDate = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+ 
+
+  return (
+    <div>{`${authorString}. "${project.title}."`} <em>Digital Rocks Portal,</em> {` Digital Rocks Portal, ${createdDate}, ${projectUrl} Accessed ${accessDate}.`}</div>
+  );
+};
+
+const IEEECitation = ({ project, authors }) => {
+  const authorString = authors.map(a => `${a.first_name[0]}. ${a.last_name}`).join(', ');
+  const projectUrl = `https://www.digitalrocksportal.org/projects/${project.projectId.split('-').pop()}`;
+  const date = new Date(project.created);
+  const year = date.getFullYear();
+  const day = date.getDate();
+  const month = date.toLocaleString('en-GB', { month: 'short' });
+
+  return (
+    <div>{`[1] ${authorString}, "${project.title}",`} <em>Digital Rocks Portal,</em> {` ${year}. [Online]. Available: ${projectUrl}. [Accessed: ${day}-${month}-${year}]`}</div>
+  );
+};
+
+const Citations = ({ project, authors }) => (
+  <div>
+    <h3>ACM ref</h3>
+    <div className={styles['citation-box']}>
+      <ACMCitation project={project} authors={authors} />
+    </div>
+    
+    <h3>APA</h3>
+    <div className={styles['citation-box']}>
+      <APACitation project={project} authors={authors} />
+    </div>
+
+    <h3>BibTeX</h3>
+    <div className={styles['citation-box']}>
+      <BibTeXCitation project={project} authors={authors} />
+    </div>
+
+    <h3>MLA</h3>
+    <div className={styles['citation-box']}>
+      <MLACitation project={project} authors={authors} />
+    </div>
+
+    <h3>IEEE</h3>
+    <div className={styles['citation-box']}>
+      <IEEECitation project={project} authors={authors} />
+    </div>
+  </div>
+);
+
+
 
 const ReviewAuthors = ({ project, onAuthorsUpdate }) => {
   const [authors, setAuthors] = useState([]);
@@ -102,7 +177,8 @@ const ReviewAuthors = ({ project, onAuthorsUpdate }) => {
     >
       {authors.length > 0 && project && (
         <Section contentLayoutName={'oneColumn'}>
-          <MLACitation project={project} authors={authors} />
+          <Citations project={project} authors={authors} />
+
           {canEdit && (
             <>
               <ReorderUserList


### PR DESCRIPTION
## Overview
Add ACM Ref, APA, BibTex, MLA, and IEEE citations to the "Review Authors and Citation" page.


## Related

* [WP-574](https://tacc-main.atlassian.net/browse/WP-574)

## Changes
 - Created a component for each citation type. Formatted each citation type to match: https://www.digitalrocksportal.org/projects/317/cite/
 - Created a component to display the citations
 - Used css to put a box around each citation

## Testing
1. Click Request Publication
2. Continue to Review Authors and Citation
3. Verify the Citations match the examples from the link above. 

## UI

![Screen Shot 2024-11-05 at 3 44 41 PM](https://github.com/user-attachments/assets/37bc0cb5-fc22-41e5-ba40-01ea2b5ac14d)


## Notes
DOI is missing
Date Published is missing (right now, it is using Date Created)
