### PR TITLE
Task/WC-93:  Add toolbar button and modal to display the tree for DRP projects

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModals.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModals.jsx
@@ -19,6 +19,7 @@ import DataFilesDownloadMessageModal from './DataFilesDownloadMessageModal';
 import './DataFilesModals.scss';
 import DataFilesFormModal from './DataFilesFormModal';
 import DataFilesPublicationRequestModal from './DataFilesPublicationRequestModal';
+import DataFilesProjectTreeModal from './DataFilesProjectTreeModal';
 
 export default function DataFilesModals() {
   return (
@@ -41,6 +42,7 @@ export default function DataFilesModals() {
       <DataFilesMakePublicModal />
       <DataFilesDownloadMessageModal />
       <DataFilesFormModal />
+      <DataFilesProjectTreeModal/>
       <DataFilesPublicationRequestModal />
     </>
   );

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectTreeModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectTreeModal.jsx
@@ -1,0 +1,45 @@
+import React, { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+import styles from './DataFilesPublicationRequestModal.module.scss';
+import { ProjectTreeView } from '_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectTreeView';
+
+const DataFilesProjectTreeModal = () => {
+  const { projectId } = useSelector((state) => state.projects.metadata);
+
+  const isOpen = useSelector((state) => state.files.modals.projectTree);
+  const props = useSelector((state) => state.files.modalProps['projectTree']);
+
+  const toggle = useCallback(() => {
+    dispatch({
+      type: 'DATA_FILES_TOGGLE_MODAL',
+      payload: { operation: 'projectTree', props: {} },
+    });
+  }, []);
+
+  const dispatch = useDispatch();
+
+  return (
+    <>
+      <Modal
+        size="lg"
+        isOpen={isOpen}
+        toggle={toggle}
+        className={styles['modal-dialog']}
+      >
+        <ModalHeader toggle={toggle} charCode="&#xe912;">
+          Project Tree
+        </ModalHeader>
+        <ModalBody>
+          {' '}
+          <ProjectTreeView
+            projectId={projectId}
+            readOnly={props?.readOnly ?? true}
+          />
+        </ModalBody>
+      </Modal>
+    </>
+  );
+};
+
+export default DataFilesProjectTreeModal;

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectTreeModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectTreeModal.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
-import styles from './DataFilesPublicationRequestModal.module.scss';
+import styles from './DataFilesProjectTreeModal.module.scss';
 import { ProjectTreeView } from '_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectTreeView';
 
 const DataFilesProjectTreeModal = () => {
@@ -30,7 +30,7 @@ const DataFilesProjectTreeModal = () => {
         <ModalHeader toggle={toggle} charCode="&#xe912;">
           Project Tree
         </ModalHeader>
-        <ModalBody>
+        <ModalBody className={styles['modal-body']}>
           {' '}
           <ProjectTreeView
             projectId={projectId}

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectTreeModal.module.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectTreeModal.module.scss
@@ -1,0 +1,4 @@
+.modal-body {
+    overflow: auto;
+    max-height: 80vh;
+}

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingAddon/DataFilesProjectFileListingAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingAddon/DataFilesProjectFileListingAddon.jsx
@@ -15,8 +15,12 @@ const DataFilesProjectFileListingAddon = ({ rootSystem, system }) => {
 
   const dispatch = useDispatch();
 
-  const { createSampleModal, createOriginDataModal, createAnalysisDataModal } =
-    useDrpDatasetModals(projectId, portalName);
+  const {
+    createSampleModal,
+    createOriginDataModal,
+    createAnalysisDataModal,
+    createTreeModal,
+  } = useDrpDatasetModals(projectId, portalName);
 
   const createPublicationRequestModal = () => {
     dispatch({
@@ -142,6 +146,15 @@ const DataFilesProjectFileListingAddon = ({ rootSystem, system }) => {
           )}
         </>
       )}
+      <>
+        <span className={styles.separator}>|</span>
+        <Button
+          type="link"
+          onClick={() => createTreeModal({ readOnly: !canEditDataset })}
+        >
+          View Project Tree
+        </Button>
+      </>
       {canRequestPublication && (
         <>
           <span className={styles.separator}>|</span>

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectTreeView.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectTreeView.jsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  Button,
+  ShowMore,
+  Section,
+  Icon,
+} from '_common';
+import { TreeItem, TreeView } from '@material-ui/lab';
+import styles from './DataFilesProjectPublishWizard.module.scss';
+import DataDisplay from '../../utils/DataDisplay/DataDisplay';
+import { useDispatch, useSelector } from 'react-redux';
+import { useFileListing } from 'hooks/datafiles';
+import useDrpDatasetModals from '../../utils/hooks/useDrpDatasetModals';
+import { fetchUtil } from 'utils/fetchUtil';
+
+export const ProjectTreeView = ({ projectId, readOnly = false }) => {
+  const [expandedNodes, setExpandedNodes] = useState([]);
+
+  const dispatch = useDispatch();
+  const portalName = useSelector((state) => state.workbench.portalName);
+
+  const [tree, setTree] = useState([]);
+
+  const { dynamicFormModal, previewModal, metadata } = useSelector((state) => ({
+    dynamicFormModal: state.files.modals.dynamicform,
+    previewModal: state.files.modals.preview,
+    metadata: state.projects.metadata,
+  }));
+
+  const fetchTree = useCallback(async () => {
+    if (projectId) {
+      try {
+        const response = await fetchUtil({
+          url: `api/${portalName.toLowerCase()}/tree`,
+          params: {
+            project_id: projectId,
+          },
+        });
+        setTree(response);
+      } catch (error) {
+        console.error('Error fetching tree data:', error);
+        setTree([]);
+      }
+    }
+  }, [portalName, projectId]);
+
+  useEffect(() => {
+    // workaround to get updated data after modal closes
+    if (!dynamicFormModal || !previewModal) {
+      fetchTree();
+    }
+  }, [dynamicFormModal, previewModal, fetchTree]);
+
+  const { params } = useFileListing('FilesListing');
+
+  useEffect(() => {
+    if (tree && tree.length > 0) {
+      setExpandedNodes([tree[0].id]);
+    }
+  }, []);
+
+  const handleNodeToggle = (event, nodeIds) => {
+    // Update the list of expanded nodes
+    setExpandedNodes(nodeIds);
+  };
+
+  const { createSampleModal, createOriginDataModal, createAnalysisDataModal } =
+    useDrpDatasetModals(projectId, portalName, false);
+
+  const onEditData = (node) => {
+    const dataType = node.metadata.data_type;
+    // reconstruct editFile to mimic SelectedFile object
+    const editFile = {
+      id: node.id,
+      uuid: node.uuid,
+      metadata: node.metadata,
+      name: node.metadata.name,
+      system: params.system,
+      type: 'dir',
+      path: node.path,
+    };
+    switch (dataType) {
+      case 'sample':
+        createSampleModal('EDIT_SAMPLE_DATA', editFile);
+        break;
+      case 'digital_dataset':
+        createOriginDataModal('EDIT_ORIGIN_DATASET', editFile);
+        break;
+      case 'analysis_data':
+        createAnalysisDataModal('EDIT_ANALYSIS_DATASET', editFile);
+        break;
+      case 'file':
+        // Dispatch an action to toggle the modal for previewing the file
+        dispatch({
+          type: 'DATA_FILES_TOGGLE_MODAL',
+          payload: {
+            operation: 'preview',
+            props: {
+              api: params.api,
+              scheme: params.scheme,
+              system: params.system,
+              path: node.path,
+              name: node.name,
+              href: `tapis://${params.system}/${node.path}`,
+              length: node.length,
+              metadata: node.metadata,
+              useReloadCallback: false,
+            },
+          },
+        });
+        break;
+      default:
+        break;
+    }
+  };
+
+  const formatDatatype = (data_type) =>
+    data_type
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+
+  const renderTree = (node) => (
+    <>
+      <Section
+        className={styles['section-project-structure']}
+        contentLayoutName="oneColumn"
+      >
+        <div>
+          <TreeItem
+            key={node.id}
+            nodeId={node.id}
+            label={
+              <div className={styles['node-name-div']}>
+                {node.label ?? node.name}
+                {node.metadata.data_type && (
+                  <span className={styles['data-type-box']}>
+                    {formatDatatype(node.metadata.data_type)}
+                  </span>
+                )}
+              </div>
+            }
+            classes={{
+              label: styles['tree-label'],
+            }}
+            onLabelClick={() => handleNodeToggle}
+          >
+            {expandedNodes.includes(node.id) && node.id !== 'NODE_ROOT' && (
+              <div className={styles['metadata-description-div']}>
+                {(!readOnly || node.metadata.data_type === 'file') && (
+                  <Button
+                    className={styles['edit-button']}
+                    type="link"
+                    onClick={() => onEditData(node)}
+                  >
+                    {!readOnly && node.metadata.data_type !== 'file'
+                      ? 'Edit'
+                      : 'View'}
+                  </Button>
+                )}
+                <div className={styles['description']}>
+                  <ShowMore>{node.metadata.description}</ShowMore>
+                  <DataDisplay
+                    data={node.metadata}
+                    excludeKeys={[
+                      'description',
+                      'data_type',
+                      'sample',
+                      'digital_dataset',
+                      'file_objs',
+                    ]}
+                  />
+                </div>
+              </div>
+            )}
+            {Array.isArray(node.fileObjs) &&
+              node.fileObjs.map((fileObj) => renderTree(fileObj))}
+            {Array.isArray(node.children) &&
+              node.children.map((child) => renderTree(child))}
+          </TreeItem>
+        </div>
+      </Section>
+    </>
+  );
+
+  return (
+    tree &&
+    tree.length > 0 && (
+      <TreeView
+        defaultCollapseIcon={<Icon name={'contract'} />}
+        defaultExpandIcon={<Icon name={'expand'} />}
+        expanded={expandedNodes}
+        onNodeToggle={handleNodeToggle}
+      >
+        {tree.map((node) => renderTree(node))}
+      </TreeView>
+    )
+  );
+};

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewProjectStructure.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewProjectStructure.jsx
@@ -1,46 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import {
-  Button,
-  ShowMore,
-  LoadingSpinner,
-  SectionMessage,
-  SectionTableWrapper,
-  DescriptionList,
-  Section,
-  SectionContent,
-  Expand,
-  Icon,
-} from '_common';
-import { TreeItem, TreeView } from '@material-ui/lab';
+import React, { useEffect, useState, useCallback } from 'react';
+import { Button, SectionTableWrapper, Section } from '_common';
 import styles from './DataFilesProjectPublishWizard.module.scss';
-import DataDisplay from '../../utils/DataDisplay/DataDisplay';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFileListing } from 'hooks/datafiles';
-import useDrpDatasetModals from '../../utils/hooks/useDrpDatasetModals';
+import { ProjectTreeView } from './ProjectTreeView';
 
-const ReviewProjectStructure = ({ projectTree }) => {
+export const ReviewProjectStructure = ({ projectTree }) => {
   const dispatch = useDispatch();
 
-  const [expandedNodes, setExpandedNodes] = useState([]);
-
-  const portalName = useSelector((state) => state.workbench.portalName);
   const { projectId } = useSelector((state) => state.projects.metadata);
 
   const { params } = useFileListing('FilesListing');
-
-  useEffect(() => {
-    if (projectTree && projectTree.length > 0) {
-      setExpandedNodes([projectTree[0].id]);
-    }
-  }, []);
-
-  const handleNodeToggle = (event, nodeIds) => {
-    // Update the list of expanded nodes
-    setExpandedNodes(nodeIds);
-  };
-
-  const { createSampleModal, createOriginDataModal, createAnalysisDataModal } =
-    useDrpDatasetModals(projectId, portalName, false);
 
   const canEdit = useSelector((state) => {
     const { members } = state.projects.metadata;
@@ -62,122 +32,6 @@ const ReviewProjectStructure = ({ projectTree }) => {
       payload: { operation: 'editproject', props: {} },
     });
   };
-
-  const onEditData = (node) => {
-    const dataType = node.metadata.data_type;
-    // reconstruct editFile to mimic SelectedFile object
-    const editFile = {
-      id: node.id,
-      uuid: node.uuid,
-      metadata: node.metadata,
-      name: node.metadata.name,
-      system: params.system,
-      type: 'dir',
-      path: node.path,
-    };
-    switch (dataType) {
-      case 'sample':
-        createSampleModal('EDIT_SAMPLE_DATA', editFile);
-        break;
-      case 'digital_dataset':
-        createOriginDataModal('EDIT_ORIGIN_DATASET', editFile);
-        break;
-      case 'analysis_data':
-        createAnalysisDataModal('EDIT_ANALYSIS_DATASET', editFile);
-        break;
-      case 'file':
-        // Dispatch an action to toggle the modal for previewing the file
-        dispatch({
-          type: 'DATA_FILES_TOGGLE_MODAL',
-          payload: {
-            operation: 'preview',
-            props: {
-              api: params.api,
-              scheme: params.scheme,
-              system: params.system,
-              path: node.path,
-              name: node.name,
-              href: `tapis://${params.system}/${node.path}`,
-              length: node.length,
-              metadata: node.metadata,
-              useReloadCallback: false,
-            },
-          },
-        });
-        break;
-      default:
-        break;
-    }
-  };
-
-  const formatDatatype = (data_type) =>
-    data_type
-      .split('_')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-
-  const renderTree = (node) => (
-    <>
-      <Section
-        className={styles['section-project-structure']}
-        contentLayoutName="oneColumn"
-      >
-        <div>
-          <TreeItem
-            key={node.id}
-            nodeId={node.id}
-            label={
-              <div className={styles['node-name-div']}>
-                {node.label ?? node.name}
-                {node.metadata.data_type && (
-                  <span className={styles['data-type-box']}>
-                    {formatDatatype(node.metadata.data_type)}
-                  </span>
-                )}
-              </div>
-            }
-            classes={{
-              label: styles['tree-label'],
-            }}
-            onLabelClick={() => handleNodeToggle}
-          >
-            {expandedNodes.includes(node.id) && node.id !== 'NODE_ROOT' && (
-              <div className={styles['metadata-description-div']}>
-                {(canEdit || node.metadata.data_type === 'file') && (
-                  <Button
-                    className={styles['edit-button']}
-                    type="link"
-                    onClick={() => onEditData(node)}
-                  >
-                    {canEdit && node.metadata.data_type !== 'file'
-                      ? 'Edit'
-                      : 'View'}
-                  </Button>
-                )}
-                <div className={styles['description']}>
-                  <ShowMore>{node.metadata.description}</ShowMore>
-                  <DataDisplay
-                    data={node.metadata}
-                    excludeKeys={[
-                      'description',
-                      'data_type',
-                      'sample',
-                      'digital_dataset',
-                      'file_objs',
-                    ]}
-                  />
-                </div>
-              </div>
-            )}
-            {Array.isArray(node.fileObjs) &&
-              node.fileObjs.map((fileObj) => renderTree(fileObj))}
-            {Array.isArray(node.children) &&
-              node.children.map((child) => renderTree(child))}
-          </TreeItem>
-        </div>
-      </Section>
-    </>
-  );
 
   return (
     <SectionTableWrapper
@@ -223,16 +77,7 @@ const ReviewProjectStructure = ({ projectTree }) => {
           </ul>
         </div>
 
-        {projectTree && projectTree.length > 0 && (
-          <TreeView
-            defaultCollapseIcon={<Icon name={'contract'} />}
-            defaultExpandIcon={<Icon name={'expand'} />}
-            expanded={expandedNodes}
-            onNodeToggle={handleNodeToggle}
-          >
-            {projectTree.map((node) => renderTree(node))}
-          </TreeView>
-        )}
+        <ProjectTreeView projectId={projectId} readOnly={!canEdit} />
       </Section>
     </SectionTableWrapper>
   );

--- a/client/src/components/_custom/drp/utils/hooks/useDrpDatasetModals.js
+++ b/client/src/components/_custom/drp/utils/hooks/useDrpDatasetModals.js
@@ -129,7 +129,25 @@ const useDrpDatasetModals = (
     }
   );
 
-  return { createSampleModal, createOriginDataModal, createAnalysisDataModal };
+  const createTreeModal = useCallback(
+    async ({ readOnly = false }) => {
+      dispatch({
+        type: 'DATA_FILES_TOGGLE_MODAL',
+        payload: {
+          operation: 'projectTree',
+          props: { readOnly },
+        },
+      });
+    },
+    [dispatch]
+  );
+
+  return {
+    createSampleModal,
+    createOriginDataModal,
+    createAnalysisDataModal,
+    createTreeModal,
+  };
 };
 
 export default useDrpDatasetModals;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,6 +5,8 @@
     "paths": {
       "_common/*": ["components/_common/*"],
       "_common": ["components/_common"],
+      "_custom/*": ["components/_custom/*"],
+      "_custom": ["components/_custom"],
       "utils/*": ["utils/*"]
     },
     "useDefineForClassFields": true,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   resolve: {
     alias: {
       _common: resolve(__dirname, 'src/components/_common'),
+      _custom: resolve(__dirname, 'src/components/_custom'),
       hooks: resolve(__dirname, 'src/hooks'),
       utils: resolve(__dirname, 'src/utils'),
       styles: resolve(__dirname, 'src/styles'),


### PR DESCRIPTION
## Overview
Add a toolbar button and modal to display the tree for DRP projects
The project tree in the publication pipeline has been refactored to a reusable component. A `readOnly` prop controls whether the editing UI is rendered alongside each tree node.


## Related

* [WC-93](https://tacc-main.atlassian.net/browse/WC-93)

## Changes



## Testing

1. Open a DRP project in your local environment.
2. Click "View Project Tree" in the menu and confirm that the tree is rendered correctly.

## UI
![image](https://github.com/user-attachments/assets/82708028-1fc1-41e7-b225-16d0ebf7b9db)
(`readOnly=false`)
![image](https://github.com/user-attachments/assets/6ddd93cb-770d-4133-a3e8-45fe5333a754)
(`readOnly=true`)
![image](https://github.com/user-attachments/assets/77b43e9e-56a1-4f2f-b479-35f45c002ebc)





## Notes

