### PR TITLE
Task/WP-728: Mutation hook: Copy file

### DIFF
--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -54,17 +54,11 @@ export async function copyFileUtil({
     };
   }
 
-  const request = await fetch(url, {
-    method: 'PUT',
+  const response = await apiClient.put(url, body, {
     headers: { 'X-CSRFToken': Cookies.get('csrftoken') || '' },
-    credentials: 'same-origin',
-    body: JSON.stringify(body),
+    withCredentials: true,
   });
-  if (!request.ok) {
-    throw new Error(request.status.toString());
-  }
-  const responseData = await request.json();
-  return responseData;
+  return response.data;
 }
 
 function useCopy() {
@@ -137,6 +131,7 @@ function useCopy() {
             });
           },
           onError: (error) => {
+            console.log('The error is ', error);
             dispatch({
               type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
               payload: { status: 'ERROR', key: file.id, operation: 'copy' },

--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -7,20 +7,34 @@ function useCopy() {
   const { selectedFiles: selected } = useSelectedFiles();
 
   const status = useSelector(
-    (state) => state.files.operationStatus.copy,
+    (state: any) => state.files.operationStatus.copy,
     shallowEqual
   );
 
-  const setStatus = (newStatus) =>
+  const setStatus = (newStatus: string) =>
     dispatch({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
       payload: { operation: 'copy', status: newStatus },
     });
 
-  const copy = ({ srcApi, destApi, destSystem, destPath, name, callback }) => {
+  const copy = ({
+    srcApi,
+    destApi,
+    destSystem,
+    destPath,
+    name,
+    callback,
+  }: {
+    srcApi: string;
+    destApi: string;
+    destSystem: string;
+    destPath: string;
+    name: string;
+    callback: any;
+  }) => {
     const filteredSelected = selected
-      .filter((f) => status[f.id] !== 'SUCCESS')
-      .map((f) => ({ ...f, api: srcApi }));
+      .filter((f: any) => status[f.id] !== 'SUCCESS')
+      .map((f: any) => ({ ...f, api: srcApi }));
     dispatch({
       type: 'DATA_FILES_COPY',
       payload: {

--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -1,5 +1,68 @@
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { useSelectedFiles } from 'hooks/datafiles';
+import Cookies from 'js-cookie';
+import { apiClient } from 'utils/apiClient';
+import { useMutation } from '@tanstack/react-query';
+import truncateMiddle from 'utils/truncateMiddle';
+
+export async function copyFileUtil({
+  api,
+  scheme,
+  system,
+  path,
+  filename,
+  filetype,
+  destApi,
+  destSystem,
+  destPath,
+  destPathName,
+}: {
+  api: string;
+  scheme: string;
+  system: string;
+  path: string;
+  filename: string;
+  filetype: string;
+  destApi: string;
+  destSystem: string;
+  destPath: string;
+  destPathName: string;
+}) {
+  let url: string, body: any;
+  if (api === destApi) {
+    url = `/api/datafiles/${api}/copy/${scheme}/${system}/${path}/`;
+    url = url.replace(/\/{2,}/g, '/');
+    body = {
+      dest_system: destSystem,
+      dest_path: destPath,
+      file_name: filename,
+      filetype,
+      dest_path_name: destPathName,
+    };
+  } else {
+    url = `/api/datafiles/transfer/${filetype}/`;
+    url = url.replace(/\/{2,}/g, '/');
+    body = {
+      src_api: api,
+      dest_api: destApi,
+      src_system: system,
+      dest_system: destSystem,
+      src_path: path,
+      dest_path: destPath,
+      dest_path_name: destPathName,
+      dirname: filename,
+    };
+  }
+
+  const request = await apiClient.put(url, body, {
+    headers: { 'X-CSRFToken': Cookies.get('csrftoken') || '' },
+    withCredentials: true,
+  });
+  if (request.status < 200 || request.status >= 300) {
+    throw new Error(request.status.toString());
+  }
+  return request.data;
+}
 
 function useCopy() {
   const dispatch = useDispatch();
@@ -17,6 +80,7 @@ function useCopy() {
       payload: { operation: 'copy', status: newStatus },
     });
 
+  const { mutate } = useMutation({ mutationFn: copyFileUtil });
   const copy = ({
     srcApi,
     destApi,
@@ -35,16 +99,57 @@ function useCopy() {
     const filteredSelected = selected
       .filter((f: any) => status[f.id] !== 'SUCCESS')
       .map((f: any) => ({ ...f, api: srcApi }));
+    const copyCalls = filteredSelected.map((file: any) => {
+      // Copy File
+      dispatch({
+        type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+        payload: { status: 'RUNNING', key: file.id, operation: 'copy' },
+      });
+      mutate(
+        {
+          api: file.api,
+          scheme: file.scheme,
+          system: file.system,
+          path: file.path,
+          filename: file.name,
+          filetype: file.type,
+          destApi,
+          destSystem,
+          destPath,
+          destPathName: name,
+        },
+        {
+          onSuccess: () => {
+            dispatch({
+              type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+              payload: { status: 'SUCCESS', key: file.id, operation: 'copy' },
+            });
+            dispatch({
+              type: 'DATA_FILES_TOGGLE_MODAL',
+              payload: { operation: 'copy', props: {} },
+            });
+          },
+          onError: (error) => {
+            dispatch({
+              type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+              payload: { status: 'ERROR', key: file.id, operation: 'copy' },
+            });
+          },
+        }
+      );
+    });
+    // Result
+    const result = copyCalls;
     dispatch({
-      type: 'DATA_FILES_COPY',
+      type: 'ADD_TOAST',
       payload: {
-        dest: { system: destSystem, path: destPath, api: destApi, name },
-        src: filteredSelected,
-        reloadCallback: callback,
+        message: `${
+          copyCalls.length > 1 ? `${copyCalls.length} files` : 'File'
+        } copied to ${truncateMiddle(`${destPath}`, 20) || '/'}`,
       },
     });
+    callback();
   };
-
   return { copy, status, setStatus };
 }
 

--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -77,7 +77,9 @@ function useCopy() {
     shallowEqual
   );
 
-  const {scheme} = useSelector((state :any) => state.files.params.FilesListing);
+  const { scheme } = useSelector(
+    (state: any) => state.files.params.FilesListing
+  );
   const setStatus = (newStatus: string) =>
     dispatch({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
@@ -109,7 +111,7 @@ function useCopy() {
         type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
         payload: { status: 'RUNNING', key: file.id, operation: 'copy' },
       });
-      
+
       mutate(
         {
           api: file.api,

--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -105,30 +105,34 @@ function useCopy() {
         type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
         payload: { status: 'RUNNING', key: file.id, operation: 'copy' },
       });
-      mutateAsync({
-        api: file.api,
-        scheme: scheme,
-        system: file.system,
-        path: file.path,
-        filename: file.name,
-        filetype: file.type,
-        destApi,
-        destSystem,
-        destPath,
-        destPathName: name,
-      })
-        .then(() => {
-          dispatch({
-            type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
-            payload: { status: 'SUCCESS', key: file.id, operation: 'copy' },
-          });
-        })
-        .catch((error: any) => {
-          dispatch({
-            type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
-            payload: { status: 'ERROR', key: file.id, operation: 'copy' },
-          });
-        });
+      mutateAsync(
+        {
+          api: file.api,
+          scheme: scheme,
+          system: file.system,
+          path: file.path,
+          filename: file.name,
+          filetype: file.type,
+          destApi,
+          destSystem,
+          destPath,
+          destPathName: name,
+        },
+        {
+          onSuccess: () => {
+            dispatch({
+              type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+              payload: { status: 'SUCCESS', key: file.id, operation: 'copy' },
+            });
+          },
+          onError: (error: any) => {
+            dispatch({
+              type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+              payload: { status: 'ERROR', key: file.id, operation: 'copy' },
+            });
+          },
+        }
+      );
     });
     // Result
     await Promise.all(copyCalls);

--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -54,14 +54,17 @@ export async function copyFileUtil({
     };
   }
 
-  const request = await apiClient.put(url, body, {
+  const request = await fetch(url, {
+    method: 'PUT',
     headers: { 'X-CSRFToken': Cookies.get('csrftoken') || '' },
-    withCredentials: true,
+    credentials: 'same-origin',
+    body: JSON.stringify(body),
   });
-  if (request.status < 200 || request.status >= 300) {
+  if (!request.ok) {
     throw new Error(request.status.toString());
   }
-  return request.data;
+  const responseData = await request.json();
+  return responseData;
 }
 
 function useCopy() {
@@ -74,6 +77,7 @@ function useCopy() {
     shallowEqual
   );
 
+  const {scheme} = useSelector((state :any) => state.files.params.FilesListing);
   const setStatus = (newStatus: string) =>
     dispatch({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
@@ -105,10 +109,11 @@ function useCopy() {
         type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
         payload: { status: 'RUNNING', key: file.id, operation: 'copy' },
       });
+      
       mutate(
         {
           api: file.api,
-          scheme: file.scheme,
+          scheme: scheme,
           system: file.system,
           path: file.path,
           filename: file.name,

--- a/client/src/hooks/datafiles/mutations/useCopy.ts
+++ b/client/src/hooks/datafiles/mutations/useCopy.ts
@@ -80,8 +80,8 @@ function useCopy() {
       payload: { operation: 'copy', status: newStatus },
     });
 
-  const { mutate } = useMutation({ mutationFn: copyFileUtil });
-  const copy = ({
+  const { mutateAsync } = useMutation({ mutationFn: copyFileUtil });
+  const copy = async ({
     srcApi,
     destApi,
     destSystem,
@@ -105,43 +105,37 @@ function useCopy() {
         type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
         payload: { status: 'RUNNING', key: file.id, operation: 'copy' },
       });
-
-      mutate(
-        {
-          api: file.api,
-          scheme: scheme,
-          system: file.system,
-          path: file.path,
-          filename: file.name,
-          filetype: file.type,
-          destApi,
-          destSystem,
-          destPath,
-          destPathName: name,
-        },
-        {
-          onSuccess: () => {
-            dispatch({
-              type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
-              payload: { status: 'SUCCESS', key: file.id, operation: 'copy' },
-            });
-            dispatch({
-              type: 'DATA_FILES_TOGGLE_MODAL',
-              payload: { operation: 'copy', props: {} },
-            });
-          },
-          onError: (error) => {
-            console.log('The error is ', error);
-            dispatch({
-              type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
-              payload: { status: 'ERROR', key: file.id, operation: 'copy' },
-            });
-          },
-        }
-      );
+      mutateAsync({
+        api: file.api,
+        scheme: scheme,
+        system: file.system,
+        path: file.path,
+        filename: file.name,
+        filetype: file.type,
+        destApi,
+        destSystem,
+        destPath,
+        destPathName: name,
+      })
+        .then(() => {
+          dispatch({
+            type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+            payload: { status: 'SUCCESS', key: file.id, operation: 'copy' },
+          });
+        })
+        .catch((error: any) => {
+          dispatch({
+            type: 'DATA_FILES_SET_OPERATION_STATUS_BY_KEY',
+            payload: { status: 'ERROR', key: file.id, operation: 'copy' },
+          });
+        });
     });
     // Result
-    const result = copyCalls;
+    await Promise.all(copyCalls);
+    dispatch({
+      type: 'DATA_FILES_TOGGLE_MODAL',
+      payload: { operation: 'copy', props: {} },
+    });
     dispatch({
       type: 'ADD_TOAST',
       payload: {


### PR DESCRIPTION
## Overview
Updating hooks to use React Query mutations with Typescript. This mutation covers copying a file.


## Related

* [WP-728](https://tacc-main.atlassian.net/browse/WP-728)

## Changes
- useCopy.js to useCopy.ts
- Identify types of payloads
- Wraps dispatch actions inside a mutation

## Testing
- Navigate to the folder where the file is that you would like to copy
- Select the checkbox of the folder
- Click the copy button
- Select the destination directory to copy to

## UI
![image](https://github.com/user-attachments/assets/9bea26e7-7eb9-4c53-8c34-a31df3944c0b)

