### PR TITLE
Close upload modal after successful upload

### DIFF
--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -561,6 +561,10 @@ export function* uploadFiles(action) {
     });
 
   yield call(action.payload.reloadCallback);
+  yield put({
+    type: 'DATA_FILES_TOGGLE_MODAL',
+    payload: { operation: 'upload', props: {} },
+  });
 }
 
 export function* uploadFile(api, scheme, system, path, file, index, metadata) {


### PR DESCRIPTION
## Overview
Close the file upload modal after all uploads have completed.


## Related

* [WC-130](https://tacc-main.atlassian.net/browse/WC-130)

## Changes



## Testing

1. Upload a file and check that the modal closes after the upload succeeds.

## UI



## Notes

