### PR TITLE
Task/WC-155: Email project authors when publication request is accepted/rejected.

### DIFF
--- a/server/portal/apps/publications/views.py
+++ b/server/portal/apps/publications/views.py
@@ -12,7 +12,7 @@ from django.utils.decorators import method_decorator
 from portal.exceptions.api import ApiException
 from portal.views.base import BaseApiView
 from portal.apps.projects.workspace_operations.shared_workspace_operations import create_publication_workspace
-from portal.apps.projects.workspace_operations.project_publish_operations import copy_graph_and_files_for_review_system, publish_project, update_and_cleanup_review_project
+from portal.apps.projects.workspace_operations.project_publish_operations import copy_graph_and_files_for_review_system, publish_project, update_and_cleanup_review_project, send_publication_accept_email, send_publication_reject_email
 from portal.apps.projects.models.metadata import ProjectsMetadata
 from django.db import transaction
 from portal.apps.notifications.models import Notification
@@ -220,6 +220,8 @@ class PublicationPublishView(BaseApiView):
         if not full_project_id:
             raise ApiException("Missing project ID", status=400)
         
+        send_publication_accept_email.apply_async(args=[full_project_id])
+        
         if is_review:
             project_id = full_project_id.split(f"{settings.PORTAL_PROJECTS_REVIEW_SYSTEM_PREFIX}.")[1]
         else: 
@@ -313,6 +315,8 @@ class PublicationRejectView(BaseApiView):
 
         if not full_project_id:
             raise ApiException("Missing project ID", status=400)
+        
+        send_publication_reject_email.apply_async(args=[full_project_id])
         
         update_and_cleanup_review_project(full_project_id, PublicationRequest.Status.REJECTED)
 

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -756,6 +756,16 @@ RECAPTCHA_SITE_KEY = getattr(settings_secret, '_RECAPTCHA_SITE_KEY', None)
 PORTAL_ELEVATED_ROLES = getattr(settings_custom, '_PORTAL_ELEVATED_ROLES', {})
 
 """
+SETTINGS: EMAIL
+"""
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = getattr(settings_custom, '_SMTP_HOST', 'localhost')
+EMAIL_PORT = getattr(settings_custom, '_SMTP_PORT', 25)
+EMAIL_HOST_USER = getattr(settings_custom, '_SMTP_USER', '')
+EMAIL_HOST_PASSWORD = getattr(settings_custom, '_SMTP_PASSWORD', '')
+DEFAULT_FROM_EMAIL = getattr(settings_custom, '_DEFAULT_FROM_EMAIL', '')
+
+"""
 SETTINGS: INTERNAL DOCS
 """
 INTERNAL_DOCS_ROOT = getattr(settings_custom, '_INTERNAL_DOCS_ROOT', '')

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -273,3 +273,7 @@ _PORTAL_ELEVATED_ROLES = {
     "usernames": []
   }
 }
+
+
+_SMTP_HOST = "relay.tacc.utexas.edu"
+_DEFAULT_FROM_EMAIL="no-reply@digitalrocksportal.org"


### PR DESCRIPTION
## Overview
Adds Django email config and tasks to email authors when their publication request is accepted/rejected.


## Related

* [WC-155](https://tacc-main.atlassian.net/browse/WC-155)

## Testing

1. Add the `_DEFAULT_FROM_EMAIL` setting to your local settings_custom file.
2. [PPRD ONLY] Accept/reject a publication you are an author on and check that a confirmation email is sent. 

There are security issues around using relay.tacc from a dev machine, so SMTP_HOST shouldn't be set to relay.tacc there.

## Notes

