### PR TITLE
Task/WC-166  Sort publication requests by descending date

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPublicationRequestModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPublicationRequestModal.jsx
@@ -13,10 +13,23 @@ const DataFilesPublicationRequestModal = () => {
   const { publicationRequests } =
     useSelector((state) => state.files.modalProps.publicationRequest) || [];
 
+  const compareFn = (req1, req2) => {
+    // sort more recent requests first
+    const date1 = new Date(req1.created_at);
+    const date2 = new Date(req2.created_at);
+    if (date1 < date2) {
+      return 1;
+    }
+    if (date1 > date2) {
+      return -1;
+    }
+    return 0;
+  };
+
   useEffect(() => {
     const data = {};
 
-    publicationRequests?.forEach((request, index) => {
+    publicationRequests?.sort(compareFn).forEach((request, index) => {
       const publicationRequestDataObj = {
         Status: request.status,
         Reviewers: request.reviewers.reduce((acc, reviewer, index) => {
@@ -27,6 +40,7 @@ const DataFilesPublicationRequestModal = () => {
           );
         }, ''),
         Submitted: formatDateTime(new Date(request.created_at)),
+        _order: index,
       };
 
       const heading = `Publication Request ${index + 1}`;

--- a/client/src/components/_common/DescriptionList/DescriptionList.jsx
+++ b/client/src/components/_common/DescriptionList/DescriptionList.jsx
@@ -33,26 +33,45 @@ const DescriptionList = ({ className, data, density, direction }) => {
     shouldTruncateValues ? 'value-truncated' : ''
   }`;
 
+  const compareFn = (entry1, entry2) => {
+    const [, val1] = entry1;
+    const [, val2] = entry2;
+    if ((val1._order ?? 0) < (val2._order ?? 0)) {
+      return -1;
+    }
+    if ((val1._order ?? 0) > (val2._order ?? 0)) {
+      return 1;
+    }
+    return 0;
+  };
+
   return (
     <dl className={`${className} ${containerStyleNames}`} data-testid="list">
-      {Object.entries(data).map(([key, value]) => (
-        <React.Fragment key={key}>
-          <dt className={styles.key} data-testid="key">
-            {key}
-          </dt>
-          {Array.isArray(value) ? (
-            value.map((val) => (
-              <dd className={valueClassName} data-testid="value" key={uuidv4()}>
-                {val}
+      {Object.entries(data)
+        .sort(compareFn)
+        .filter(([key, _]) => !key.startsWith('_'))
+        .map(([key, value]) => (
+          <React.Fragment key={key}>
+            <dt className={styles.key} data-testid="key">
+              {key}
+            </dt>
+            {Array.isArray(value) ? (
+              value.map((val) => (
+                <dd
+                  className={valueClassName}
+                  data-testid="value"
+                  key={uuidv4()}
+                >
+                  {val}
+                </dd>
+              ))
+            ) : (
+              <dd className={valueClassName} data-testid="value">
+                {value}
               </dd>
-            ))
-          ) : (
-            <dd className={valueClassName} data-testid="value">
-              {value}
-            </dd>
-          )}
-        </React.Fragment>
-      ))}
+            )}
+          </React.Fragment>
+        ))}
     </dl>
   );
 };


### PR DESCRIPTION
## Overview
- Updates the `DescriptionList` component to permit sorting by adding a `_order` key. The key is filtered out before rendering the list, so it won't show up in the UI.
- Sorts publication requests in descending date order before passing them to `DescriptionList`.


## Related

* [WC-166](https://tacc-main.atlassian.net/browse/WC-166)

## Changes



## Testing

1. Go to a project with >1 publication requests and check that the requests are sorted in order of descending date.

## UI



## Notes

