### PR TITLE
WP-765: Fix job status button to show background

### DIFF
--- a/client/src/components/Jobs/JobsStatus/JobsStatus.jsx
+++ b/client/src/components/Jobs/JobsStatus/JobsStatus.jsx
@@ -92,7 +92,7 @@ function JobsStatus({ status, fancy, jobUuid }) {
   return (
     <div className={styles.root}>
       {fancy && color ? (
-        <Badge clasName={`badge-${color}`} color={null}>
+        <Badge className={`badge-${color}`} color={null}>
           {userStatus}
         </Badge>
       ) : (


### PR DESCRIPTION
## Overview
Fix typo in jsx


## Related

[WP-765](https://tacc-main.atlassian.net/browse/WP-765)

## Changes

## Testing

1. Go to https://cep.test/workbench/history/jobs and check the status button


## UI
**Before**
![Screenshot 2024-11-22 at 10 10 07 AM](https://github.com/user-attachments/assets/e9f25534-3b21-4267-ad2c-7a2ccd39e92f)

**After**
![Screenshot 2024-11-22 at 10 03 02 AM](https://github.com/user-attachments/assets/69834731-36fb-46e5-bb3c-1d846f0a5022)

## Notes

