### PR TITLE
Task/WC-148: Toast notification when changing project owner

### DIFF
--- a/client/src/redux/sagas/projects.sagas.js
+++ b/client/src/redux/sagas/projects.sagas.js
@@ -144,6 +144,13 @@ export function* setMember(action) {
       type: 'PROJECTS_SET_MEMBER_SUCCESS',
       payload: metadata,
     });
+    if (data.action === 'transfer_ownership')
+      yield put({
+        type: 'ADD_TOAST',
+        payload: {
+          message: `Project ownership transferred to ${data.newOwner}.`,
+        },
+      });
     yield put({
       type: 'PROJECTS_GET_LISTING',
       payload: {


### PR DESCRIPTION
## Overview
Show a toast notification when changing the owner of a project.


## Related

* [WC-148](https://tacc-main.atlassian.net/browse/WC-148)

## Changes



## Testing

1. Change the owner of a project you administer. You should see a toast notification with the name of the new owner.

## UI



## Notes

