### PR TITLE
WP-778: Fix infinite loop for state update in useEffect

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -152,7 +152,6 @@ const HandleDependentFieldChanges = ({ app, formStateUpdateHandler }) => {
   const { values, setValues } = useFormikContext();
   React.useEffect(() => {
     if (previousValues) {
-      let valueUpdated = false;
       let updatedValues = { ...values };
 
       // Set the current allocation
@@ -171,7 +170,6 @@ const HandleDependentFieldChanges = ({ app, formStateUpdateHandler }) => {
           updatedValues,
           formStateUpdateHandler
         );
-        valueUpdated = true;
       }
       if (previousValues.execSystemId !== values.execSystemId) {
         updatedValues = execSystemChangeHandler(
@@ -179,16 +177,16 @@ const HandleDependentFieldChanges = ({ app, formStateUpdateHandler }) => {
           values,
           formStateUpdateHandler
         );
-        valueUpdated = true;
       }
 
       if (
         previousValues.execSystemLogicalQueue !== values.execSystemLogicalQueue
       ) {
         updatedValues = updateValuesForQueue(app, values);
-        valueUpdated = true;
       }
-      if (valueUpdated) setValues(updatedValues);
+      if (JSON.stringify(updatedValues) !== JSON.stringify(values)) {
+        setValues(updatedValues);
+      }
     }
     setPreviousValues(values);
   }, [app, values, setValues, formStateUpdateHandler]);
@@ -926,6 +924,7 @@ export const AppSchemaForm = ({ app }) => {
                   ) : null}
                 </div>
                 <Button
+                  id="submit"
                   attr="submit"
                   size="medium"
                   type="primary"
@@ -936,6 +935,7 @@ export const AppSchemaForm = ({ app }) => {
                   Submit
                 </Button>
                 <Button
+                  id="reset"
                   onClick={handleReset}
                   className="btn-resetForm"
                   type="link"

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -924,7 +924,6 @@ export const AppSchemaForm = ({ app }) => {
                   ) : null}
                 </div>
                 <Button
-                  id="submit"
                   attr="submit"
                   size="medium"
                   type="primary"
@@ -935,7 +934,6 @@ export const AppSchemaForm = ({ app }) => {
                   Submit
                 </Button>
                 <Button
-                  id="reset"
                   onClick={handleReset}
                   className="btn-resetForm"
                   type="link"

--- a/client/src/components/_common/Form/FormField.jsx
+++ b/client/src/components/_common/Form/FormField.jsx
@@ -138,6 +138,7 @@ const FormField = ({
 
             <InputGroup>
               <Button
+                size="middle"
                 type="secondary"
                 onClick={() => setOpenTapisFileModal(true)}
               >


### PR DESCRIPTION
## Overview
* After update to react v18, this infinite loop on dependency checker is happening:
```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, 
but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
```

Also, fixes this warning:
A <Button> that is not `type="link"` and has no `size` is automatically assigned `size="auto"`.
## Related

[WP-778](https://tacc-main.atlassian.net/browse/WP-778)

## Changes

1. Only set state if something changed.

## Testing

1. Go to App Form of any app, use the drop down values - example, change the value of queue from debug to development and back. Change to large and observe the effects on the fields.
2. Also try to use "reset fields to default" and then use the select drop down.

## UI


## Notes

