### PR TITLE
fix: WP-813 CMS customization fails, CMS is old

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,15 @@ After you clone the repository locally, there are several configuration steps re
 
 ##### CMS
 
-- Copy `server/conf/cms/secrets.sample.py` to `server/conf/cms/secrets.py`
+Add CMS settings and secrets:
 
-- To emulate a specific CMS project, copy https://github.com/TACC/Core-CMS-Resources/blob/main/__PROJECT_TO_EMULATE__/settings_custom.py to `server/conf/cms/settings_custom.py`
+```sh
+curl "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@main/taccsite_cms/secrets.example.py" -o server/conf/cms/settings_custom.py
+cp server/conf/cms/secrets.sample.py server/conf/cms/secrets.py
+curl "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@main/taccsite_cms/settings_local.example.py" -o server/conf/cms/settings_local.py
+```
 
-- To override any standard or custom CMS settings, create a `server/conf/cms/settings_local.py`
+To populate or customize the CMS, read [Customize a CMS](./docs/customize-cms.md).
 
 #### Build the image for the portal's django container:
     make build

--- a/docs/customize-cms.md
+++ b/docs/customize-cms.md
@@ -15,8 +15,9 @@ To override any standard or custom CMS settings, edit `server/conf/cms/settings_
 
 > **Note:** If your `settings_custom.py` and `settings_local.py` are directories, then they were not properly created before starting environment. To fix:
 > 1. Run `make stop`.
-> 2. [Add CMS settings.](../README.md#CMS)
-> 3. Run `make start`.
+> 2. Delete directories named `settings_….py`
+> 3. [Add CMS settings.](../README.md#CMS)
+> 4. Run `make start`.
 
 
 ## Advanced

--- a/docs/customize-cms.md
+++ b/docs/customize-cms.md
@@ -1,0 +1,26 @@
+# Customize a CMS
+
+This is all optional. You can develop Core-Portal without CMS customization.
+
+## Basic
+
+To create your own test content, [learn Django CMS as we use it](https://tacc-main.atlassian.net/wiki/x/phdv).
+
+To emulate a specific project's CMS settings:
+1. Visit https://github.com/TACC/Core-Portal-Resources/blob/main/.
+2. Navigate to specific project.
+3. Copy its `cms.settings_custom.py` to your `server/conf/cms/settings_custom.py`.
+
+To override any standard or custom CMS settings, edit `server/conf/cms/settings_local.py`.
+
+> **Note:** If your `settings_custom.py` and `settings_local.py` are directories, then they were not properly created before starting environment. To fix:
+> 1. Run `make stop`.
+> 2. [Add CMS settings.](../README.md#CMS)
+> 3. Run `make start`.
+
+
+## Advanced
+
+To populate content from an existing CMS, follow and adapt instructions to [replicate a CMS database](https://tacc-main.atlassian.net/wiki/x/GwBJAg).
+
+> **Important:** This requires high-level server access or someone to give you a copy of the content.

--- a/server/conf/cms/secrets.sample.py
+++ b/server/conf/cms/secrets.sample.py
@@ -1,12 +1,12 @@
 ########################
-# DJANGO SETTINGS
+# DJANGO
 ########################
 
 SECRET_KEY = 'replacethiswithareallysecureandcomplexsecretkeystring'
 LOGIN_REDIRECT_URL = '/workbench/dashboard/'
 
 ########################
-# ELASTICSEARCH
+# SEARCH
 ########################
 
 ES_AUTH = 'username:password'
@@ -14,23 +14,14 @@ ES_HOSTS = 'http://elasticsearch:9200'
 ES_INDEX_PREFIX = 'cep-dev-{}'
 ES_DOMAIN = 'https://cep.test'
 
-es_engine = 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine'
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': es_engine,
+        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
         'URL': ES_HOSTS,
         'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
         'KWARGS': {'http_auth': ES_AUTH}
     }
 }
-
-########################
-# RECAPTCHA SETTINGS
-########################
-
-RECAPTCHA_PUBLIC_KEY = ''
-RECAPTCHA_PRIVATE_KEY = ''
-SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
 
 ########################
 # REDMINE TRACKER AUTH

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -4,9 +4,11 @@
 version: "3.8"
 services:
   cms:
-    image: taccwma/core-cms:ff737a3
+    image: taccwma/core-cms:latest
     volumes:
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
+      - ../cms/settings_local.py:/code/taccsite_cms/settings_local.py
+      - ../cms/settings_custom.py:/code/taccsite_cms/settings_custom.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini
       - ../../cms/static:/code/static
       - ../../cms/media:/code/media


### PR DESCRIPTION
## Overview & Changes

1. Update CMS settings & secrets documentation.
2. Document CMS customization.
3. Update CMS sample secrets to mimic [TACC/Core-CMS's](https://github.com/TACC/Core-CMS/blob/v4.21.0/taccsite_cms/secrets.example.py).
4. Update CMS image.

## Related

* [WP-813](https://tacc-main.atlassian.net/browse/WP-813)
    <sup>previously [CMD-194](https://tacc-main.atlassian.net/browse/CMD-194)</sup>

## Testing

1. Run `make stop`.
2. Delete any directories named `settings_….py`.
3. Backup your CMS settings & secrets
    <sup>e.g. `cp server/conf/cms/ server/conf/cms-before-WP-813/`</sup>
4. Add CMS settings via new instructions e.g.
    ```sh
    curl "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@main/taccsite_cms/secrets.example.py" -o server/conf/cms/settings_custom.py
    cp server/conf/cms/secrets.sample.py server/conf/cms/secrets.py
    curl "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@main/taccsite_cms/settings_local.example.py" -o server/conf/cms/settings_local.py
    ```
5. Run `make start`.
6. Verify Core-Portal's Core-CMS loads (at https://cep.test/)/

## UI

Skipped.