### PR TITLE
WP-781: FIx UI formatting issues

### DIFF
--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -94,14 +94,23 @@ const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
 
   return (
     <Modal isOpen={isOpen} toggle={toggle} size="lg" onClosed={resetCard}>
-      <ModalHeader className="pe-3 has-MuiTabs" toggle={toggle} charCode="&#xe912;">
+      <ModalHeader
+        className="pe-3 has-MuiTabs"
+        toggle={toggle}
+        charCode="&#xe912;"
+      >
         <Tabs
           style={{ marginBottom: '-8px' }}
           value={selectedTab}
           onChange={handleTabChange}
         >
           <Tab style={{ width: '160px', color: '#222222' }} label="View Team" />
-          {isManager && <Tab style={{ width: '160px', color: '#222222' }} label="Manage Team" />}
+          {isManager && (
+            <Tab
+              style={{ width: '160px', color: '#222222' }}
+              label="Manage Team"
+            />
+          )}
         </Tabs>
       </ModalHeader>
       <ModalBody className={selectedTab === 0 ? 'd-flex p-0' : 'pb-0'}>

--- a/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
+++ b/client/src/components/Allocations/AllocationsModals/AllocationsTeamViewModal/AllocationsTeamViewModal.jsx
@@ -94,14 +94,14 @@ const AllocationsTeamViewModal = ({ isOpen, toggle }) => {
 
   return (
     <Modal isOpen={isOpen} toggle={toggle} size="lg" onClosed={resetCard}>
-      <ModalHeader className="has-MuiTabs" toggle={toggle} charCode="&#xe912;">
+      <ModalHeader className="pe-3 has-MuiTabs" toggle={toggle} charCode="&#xe912;">
         <Tabs
           style={{ marginBottom: '-8px' }}
           value={selectedTab}
           onChange={handleTabChange}
         >
           <Tab style={{ width: '160px', color: '#222222' }} label="View Team" />
-          {isManager && <Tab label="Manage Team" />}
+          {isManager && <Tab style={{ width: '160px', color: '#222222' }} label="Manage Team" />}
         </Tabs>
       </ModalHeader>
       <ModalBody className={selectedTab === 0 ? 'd-flex p-0' : 'pb-0'}>

--- a/client/src/components/_common/TextCopyField/TextCopyField.jsx
+++ b/client/src/components/_common/TextCopyField/TextCopyField.jsx
@@ -53,7 +53,7 @@ const TextCopyField = ({ value, placeholder, displayField }) => {
             data-testid="textarea"
             readOnly
           />
-          <div className={styles['button-container']}>
+          <div className="input-group-text ms-auto p-0 my-2 bg-transparent border-0">
             <CopyToClipboard text={value}>
               <Button {...clipboardProps}>Copy</Button>
             </CopyToClipboard>


### PR DESCRIPTION
## Overview
With update to bootstrap, started see these issues:
* Copy button in TextCopyField modal is aligned to the left instead of right
* Close button in Allocation Modal does not have padding.


## Related

[WP-781](https://tacc-main.atlassian.net/browse/WP-781)

## Changes
* Use appropriate bootstrap classes to fix this.


## Testing

1. Go to Data Files and see View Full Path modal
2. Go to Allocation and view Allocation Modal for an allocation

## UI
**View Full Path**
Before
![Screenshot 2025-01-09 at 10 09 31 AM](https://github.com/user-attachments/assets/d9d2e1cb-c9d6-406f-8d40-1af9bc14895d)

After 

![Screenshot 2025-01-09 at 10 08 47 AM](https://github.com/user-attachments/assets/7aea854b-aa55-4631-be7c-92fd3bf6581b)

**Allocation Modal**

Before: 
![Screenshot 2025-01-09 at 10 30 22 AM](https://github.com/user-attachments/assets/1093040a-c06e-4964-99e1-cfe7917af2a9)


After:
![Screenshot 2025-01-09 at 10 30 11 AM](https://github.com/user-attachments/assets/1d6271a9-1329-4795-bc51-49de21ab3b90)





## Notes

