### PR TITLE
WP-835: Click through file location in site search results is failing

### DIFF
--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
@@ -106,12 +106,26 @@ const DataFilesToolbar = ({ scheme, api }) => {
       (scheme === 'private' || scheme === 'projects')
   );
 
+  const hasActiveAllocation = (state) => {
+    return (
+      state.allocations.portal_alloc ||
+      (Array.isArray(state.allocations.active) &&
+        state.allocations.active.length > 0)
+    );
+  };
+
   const showCompress = !!useSelector(
-    (state) => state.workbench.config.extractApp && modifiableUserData
+    (state) =>
+      state.workbench.config.extractApp &&
+      modifiableUserData &&
+      hasActiveAllocation(state)
   );
 
   const showExtract = !!useSelector(
-    (state) => state.workbench.config.compressApp && modifiableUserData
+    (state) =>
+      state.workbench.config.compressApp &&
+      modifiableUserData &&
+      hasActiveAllocation(state)
   );
 
   const showMakePublic = useSelector(

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.jsx
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.test.jsx
@@ -350,4 +350,68 @@ describe('DataFilesToolbar', () => {
       },
     });
   });
+  it('disables compress and extract when allocation is unavailable', () => {
+    const { queryByText } = renderComponent(
+      <DataFilesToolbar scheme="private" api="tapis" />,
+      mockStore({
+        allocations: { portal_alloc: undefined, active: [] },
+        workbench: {
+          config: {
+            extractApp: { id: 'extract', version: '0.0.3' },
+            compressApp: { id: 'compress', version: '0.0.3' },
+          },
+        },
+        files: {
+          params: {
+            FilesListing: {
+              system: 'frontera.home.username',
+              path: 'home/username/hello.zip',
+              scheme: 'private',
+            },
+          },
+          listing: { FilesListing: [] },
+          selected: { FilesListing: [] },
+          operationStatus: { trash: false },
+        },
+        systems: systemsFixture,
+        projects: { metadata: [] },
+        authenticatedUser: { user: { username: 'testuser' } },
+      }),
+      createMemoryHistory()
+    );
+    expect(queryByText(/compress/)).toBeFalsy();
+    expect(queryByText(/extract/)).toBeFalsy();
+  });
+  it('enables compress and extract when allocation is available', () => {
+    const { queryByText } = renderComponent(
+      <DataFilesToolbar scheme="private" api="tapis" />,
+      mockStore({
+        allocations: { portal_alloc: undefined, active: ['foo'] },
+        workbench: {
+          config: {
+            extractApp: { id: 'extract', version: '0.0.3' },
+            compressApp: { id: 'compress', version: '0.0.3' },
+          },
+        },
+        files: {
+          params: {
+            FilesListing: {
+              system: 'frontera.home.username',
+              path: 'home/username/hello.zip',
+              scheme: 'private',
+            },
+          },
+          listing: { FilesListing: [] },
+          selected: { FilesListing: [] },
+          operationStatus: { trash: false },
+        },
+        systems: systemsFixture,
+        projects: { metadata: [] },
+        authenticatedUser: { user: { username: 'testuser' } },
+      }),
+      createMemoryHistory()
+    );
+    expect(queryByText(/compress/)).toBeDefined();
+    expect(queryByText(/extract/)).toBeDefined();
+  });
 });

--- a/client/src/hooks/datafiles/mutations/useCompress.ts
+++ b/client/src/hooks/datafiles/mutations/useCompress.ts
@@ -41,10 +41,18 @@ function useCompress() {
     (state: any) => state.workbench.config.compressApp
   );
 
-  const defaultAllocation = useSelector(
-    (state: any) =>
-      state.allocations.portal_alloc || state.allocations.active[0].projectName
-  );
+  const defaultAllocation = useSelector((state: any) => {
+    if (state.allocations.portal_alloc) {
+      return state.allocations.portal_alloc;
+    }
+    if (
+      Array.isArray(state.allocations.active) &&
+      state.allocations.active.length > 0
+    ) {
+      return state.allocations.active[0].projectName || null;
+    }
+    return null;
+  });
 
   const systems = useSelector(
     (state: any) => state.systems.storage.configuration

--- a/client/src/hooks/datafiles/mutations/useCompress.ts
+++ b/client/src/hooks/datafiles/mutations/useCompress.ts
@@ -82,6 +82,12 @@ function useCompress() {
       defaultPrivateSystem = undefined;
     }
 
+    if (!defaultAllocation) {
+      throw new Error('You need an allocation to compress.', {
+        cause: 'compressError',
+      });
+    }
+
     if (scheme !== 'private' && scheme !== 'projects') {
       defaultPrivateSystem = systems.find((s: any) => s.default);
 

--- a/client/src/hooks/datafiles/mutations/useExtract.ts
+++ b/client/src/hooks/datafiles/mutations/useExtract.ts
@@ -68,6 +68,11 @@ function useExtract() {
       type: 'DATA_FILES_SET_OPERATION_STATUS',
       payload: { status: 'RUNNING', operation: 'extract' },
     });
+    if (!defaultAllocation) {
+      throw new Error('You need an allocation to extract.', {
+        cause: 'extractError',
+      });
+    }
 
     const params = getExtractParams(
       file,

--- a/client/src/hooks/datafiles/mutations/useExtract.ts
+++ b/client/src/hooks/datafiles/mutations/useExtract.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { getExtractParams } from 'utils/getExtractParams';
 import { apiClient } from 'utils/apiClient';
@@ -43,13 +43,23 @@ function useExtract() {
   const extractApp = useSelector(
     (state: any) => state.workbench.config.extractApp
   );
+  const defaultAllocation = useSelector((state: any) => {
+    if (state.allocations.portal_alloc) {
+      return state.allocations.portal_alloc;
+    }
+    if (
+      Array.isArray(state.allocations.active) &&
+      state.allocations.active.length > 0
+    ) {
+      return state.allocations.active[0].projectName || null;
+    }
+    return null;
+  });
 
-  const defaultAllocation = useSelector(
-    (state: any) =>
-      state.allocations.portal_alloc || state.allocations.active[0].projectName
-  );
-
-  const latestExtract = getAppUtil(extractApp.id, extractApp.version);
+  const { data: latestExtract } = useQuery({
+    queryKey: ['extract-app', extractApp.id, extractApp.version],
+    queryFn: () => getAppUtil(extractApp.id, extractApp.version),
+  });
 
   const { mutateAsync } = useMutation({ mutationFn: submitJobUtil });
 


### PR DESCRIPTION
## Overview
* In site search which shows community and public data files, the drill through on the file/folder is leading to error due to empty allocation list.
* Compress and Extract mutation is not handling case where allocation is not fetched yet.


## Related

[WP-835](https://tacc-main.atlassian.net/browse/WP-835)

## Changes
* Handle case where allocation is not fetched or available.
* switch to useQuery for getting extractApp - otherwise every render is requesting the app.


## Testing

1. Site search with keyword to get file listed. Drill through the file and it should the data files listing
2. Extract a zipped file in data files
3. Compress a file/folder in data files.



