### PR TITLE
task/WC-186: Serve published projects on a world-readable page

### DIFF
--- a/client/src/components/DataFiles/CombinedBreadcrumbs/CombinedBreadcrumbs.jsx
+++ b/client/src/components/DataFiles/CombinedBreadcrumbs/CombinedBreadcrumbs.jsx
@@ -20,6 +20,7 @@ CombinedBreadcrumbs.propTypes = {
   path: PropTypes.string.isRequired,
   section: PropTypes.string.isRequired,
   isPublic: PropTypes.bool,
+  basePath: PropTypes.string,
   className: PropTypes.string,
 };
 

--- a/client/src/components/DataFiles/DataFilesDropdown/DataFilesDropdown.jsx
+++ b/client/src/components/DataFiles/DataFilesDropdown/DataFilesDropdown.jsx
@@ -17,6 +17,7 @@ const BreadcrumbsDropdown = ({
   scheme,
   system,
   path,
+  basePath,
   section,
   isPublic,
 }) => {
@@ -36,7 +37,7 @@ const BreadcrumbsDropdown = ({
     : null;
 
   const handleNavigation = (targetPath) => {
-    const basePath = isPublic ? '/public-data' : '/workbench/data';
+    if (!basePath) basePath = isPublic ? '/public-data' : '/workbench/data';
     let url;
 
     if (scheme === 'projects' && targetPath === systemName) {

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.jsx
@@ -45,6 +45,7 @@ const DataFilesListing = ({
   path,
   isPublic,
   rootSystem,
+  basePath,
 }) => {
   // Redux hooks
   const location = useLocation();
@@ -54,7 +55,7 @@ const DataFilesListing = ({
   );
   const sharedWorkspaces = systems.find((e) => e.scheme === 'projects');
   const isPortalProject = scheme === 'projects';
-  const hideSearchBar = isPortalProject && sharedWorkspaces.hideSearchBar;
+  const hideSearchBar = isPortalProject && sharedWorkspaces?.hideSearchBar;
 
   const showViewPath = useSelector(
     (state) =>
@@ -101,6 +102,7 @@ const DataFilesListing = ({
           scheme={scheme}
           href={row.original._links.self.href}
           isPublic={isPublic}
+          basePath={basePath}
           length={row.original.length}
           metadata={row.original.metadata}
         />

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.jsx
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.jsx
@@ -59,6 +59,7 @@ export const FileNavCell = React.memo(
     scheme,
     href,
     isPublic,
+    basePath,
     length,
     metadata,
     rootSystem,
@@ -80,7 +81,7 @@ export const FileNavCell = React.memo(
       });
     };
 
-    const basePath = isPublic ? '/public-data' : '/workbench/data';
+    if (!basePath) basePath = isPublic ? '/public-data' : '/workbench/data';
 
     return (
       <>

--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.jsx
@@ -54,7 +54,7 @@ const DataFilesProjectFileListing = ({ rootSystem, system, path }) => {
       metadata.members
         .filter((member) =>
           member.user
-            ? member.user.username === state.authenticatedUser.user.username
+            ? member.user.username === state.authenticatedUser?.user?.username
             : { access: null }
         )
         .map((currentUser) => currentUser.access === 'owner')[0]
@@ -172,6 +172,7 @@ const DataFilesProjectFileListing = ({ rootSystem, system, path }) => {
         scheme="projects"
         system={system}
         path={path || '/'}
+        basePath="/publications"
         rootSystem={rootSystem}
       />
     </SectionTableWrapper>

--- a/client/src/components/DataFiles/DataFilesPublicationsList/DataFilesPublicationsList.jsx
+++ b/client/src/components/DataFiles/DataFilesPublicationsList/DataFilesPublicationsList.jsx
@@ -14,10 +14,12 @@ import './DataFilesPublicationsList.scss';
 import Searchbar from '_common/Searchbar';
 import { formatDate, formatDateTimeFromValue } from 'utils/timeFormat';
 
-const DataFilesPublicationsList = ({ rootSystem }) => {
+const DataFilesPublicationsList = ({ rootSystem, basePath }) => {
   const { error, loading, publications } = useSelector(
     (state) => state.publications.listing
   );
+
+  const _basePath = basePath ?? '/workbench/data';
 
   const query = queryStringParser.parse(useLocation().search);
 
@@ -38,7 +40,7 @@ const DataFilesPublicationsList = ({ rootSystem }) => {
       type: 'PUBLICATIONS_GET_PUBLICATIONS',
       payload: {
         queryString: query.query_string,
-        system: selectedSystem.system,
+        system: selectedSystem?.system,
       },
     });
   }, [dispatch, query.query_string]);
@@ -60,7 +62,7 @@ const DataFilesPublicationsList = ({ rootSystem }) => {
       Cell: (el) => (
         <Link
           className="data-files-nav-link"
-          to={`/workbench/data/tapis/projects/${rootSystem}/${el.row.original.id}`}
+          to={`${_basePath}/tapis/projects/${selectedSystem?.system}/${el.row.original.id}`}
         >
           {el.value}
         </Link>
@@ -141,6 +143,7 @@ const DataFilesPublicationsList = ({ rootSystem }) => {
           isLoading={loading}
           noDataText={noDataText}
           className="publications-listing"
+          columnMemoProps={[selectedSystem]}
         />
       </div>
     </SectionTableWrapper>

--- a/client/src/components/Publications/PublicationDetailPublicView.jsx
+++ b/client/src/components/Publications/PublicationDetailPublicView.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import CombinedBreadcrumbs from '../DataFiles/CombinedBreadcrumbs/CombinedBreadcrumbs';
+import DataFilesPreviewModal from '../DataFiles/DataFilesModals/DataFilesPreviewModal';
+import DataFilesProjectCitationModal from '../DataFiles/DataFilesModals/DataFilesProjectCitationModal';
+import DataFilesProjectTreeModal from '../DataFiles/DataFilesModals/DataFilesProjectTreeModal';
+import DataFilesPublicationAuthorsModal from '../DataFiles/DataFilesModals/DataFilesPublicationAuthorsModal';
+import DataFilesShowPathModal from '../DataFiles/DataFilesModals/DataFilesShowPathModal';
+import DataFilesViewDataModal from '../DataFiles/DataFilesModals/DataFilesViewDataModal';
+import DataFilesProjectFileListing from '../DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing';
+
+function PublicationDetailPublicView({params}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '10px',
+      }}
+    >
+      <CombinedBreadcrumbs
+        api="tapis"
+        scheme="projects"
+        system={params.system}
+        path={params.path || ''}
+        section="FilesListing"
+        basePath="/publications"
+      />
+      <DataFilesProjectFileListing
+        rootSystem={params.root_system}
+        system={params.system}
+        path={params.path || '/'}
+      />
+      <DataFilesPreviewModal />
+      <DataFilesShowPathModal />
+      <DataFilesProjectTreeModal />
+      <DataFilesPublicationAuthorsModal />
+      <DataFilesProjectCitationModal />
+      <DataFilesViewDataModal />
+    </div>
+  );
+}
+
+export default PublicationDetailPublicView;

--- a/client/src/components/Publications/PublicationsPublicView.jsx
+++ b/client/src/components/Publications/PublicationsPublicView.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import DataFilesPublicationsList from '../DataFiles/DataFilesPublicationsList/DataFilesPublicationsList';
+import DataFilesProjectDescriptionModal from '../DataFiles/DataFilesModals/DataFilesProjectDescriptionModal';
+
+function PublicationsPublicView() {
+  return (
+    <div>
+      <DataFilesPublicationsList basePath="/publications" />
+      <DataFilesProjectDescriptionModal />
+    </div>
+  );
+}
+
+export default PublicationsPublicView

--- a/client/src/components/Workbench/AppRouter.jsx
+++ b/client/src/components/Workbench/AppRouter.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSystems } from 'hooks/datafiles';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 import Workbench from './Workbench';
 import * as ROUTES from '../../constants/routes';
 import TicketStandaloneCreate from '../Tickets/TicketStandaloneCreate';
@@ -9,6 +9,9 @@ import PublicData from '../PublicData/PublicData';
 import RequestAccess from '../RequestAccess/RequestAccess';
 import GoogleDrivePrivacyPolicy from '../ManageAccount/GoogleDrivePrivacyPolicy';
 import SiteSearch from '../SiteSearch';
+import PublicationsPublicView from '../Publications/PublicationsPublicView';
+import PublicationDetailPublicView from '../Publications/PublicationDetailPublicView';
+
 
 function AppRouter() {
   const dispatch = useDispatch();
@@ -45,6 +48,16 @@ function AppRouter() {
       <Route path={ROUTES.WORKBENCH} component={Workbench} />
       <Route path="/tickets/new" component={TicketStandaloneCreate} />
       <Route path="/public-data" component={PublicData} />
+      <Route path="/publications" exact component={PublicationsPublicView}/>
+      <Route path="/publications/tapis/projects/:root_system" exact>
+        <Redirect to="/publications" />
+      </Route>
+      <Route
+        path={`/publications/tapis/projects/:root_system/:system/:path*`}
+        render={({ match: { params } }) => {
+          return <PublicationDetailPublicView params={params}/>;
+        }}
+      />
       <Route path="/request-access" component={RequestAccess} />
       <Route
         path="/googledrive-privacy-policy"

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingAddon/DataFilesProjectFileListingAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingAddon/DataFilesProjectFileListingAddon.jsx
@@ -37,7 +37,7 @@ const DataFilesProjectFileListingAddon = ({ rootSystem, system }) => {
   const { canEditDataset, canRequestPublication, canReviewPublication } =
     useSelector((state) => {
       const { members } = state.projects.metadata;
-      const { username } = state.authenticatedUser.user;
+      const { username } = state.authenticatedUser?.user ?? {};
       const currentUser = members.find(
         (member) => member.user?.username === username
       );

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataTitleAddon/DataFilesProjectFileListingMetadataTitleAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataTitleAddon/DataFilesProjectFileListingMetadataTitleAddon.jsx
@@ -23,7 +23,7 @@ const DataFilesProjectFileListingMetadataTitleAddon = ({
     const userAccess = state.projects.metadata.members
       .filter((member) =>
         member.user
-          ? member.user.username === state.authenticatedUser.user.username
+          ? member.user.username === state.authenticatedUser?.user?.username
           : { access: null }
       )
       .map((currentUser) => {

--- a/server/conf/nginx/nginx.conf
+++ b/server/conf/nginx/nginx.conf
@@ -80,7 +80,7 @@ http {
             alias /srv/www/portal/server/docs;
         }
 
-        location ~ ^/(core|auth|workbench|tickets|googledrive-privacy-policy|public-data|request-access|accounts|api|login|webhooks|search) {
+        location ~ ^/(core|auth|workbench|tickets|googledrive-privacy-policy|public-data|publications|request-access|accounts|api|login|webhooks|search) {
             proxy_pass http://portal_core;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $host;

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -55,7 +55,7 @@ class SystemListingView(BaseApiView):
                 response['default_host'] = system_def.host
                 response['default_system'] = system_id
         else:
-            response['system_list'] = [sys for sys in portal_systems if sys['scheme'] == 'public']
+            response['system_list'] = [sys for sys in portal_systems if sys['scheme'] == 'public' or sys['system'] == settings.PORTAL_PROJECTS_PUBLISHED_ROOT_SYSTEM_NAME]
 
         return JsonResponse(response)
 
@@ -70,6 +70,8 @@ class SystemDefinitionView(BaseApiView):
             # Make sure that we only let unauth'd users see public systems
             public_sys = next((sys for sys in settings.PORTAL_DATAFILES_STORAGE_SYSTEMS if sys['scheme'] == 'public'), None)
             if public_sys and public_sys['system'] == systemId:
+                client = service_account()
+            if systemId.startswith(settings.PORTAL_PROJECTS_PUBLISHED_SYSTEM_PREFIX):
                 client = service_account()
             else:
                 return JsonResponse({'message': 'Unauthorized'}, status=401)
@@ -91,6 +93,8 @@ class TapisFilesView(BaseApiView):
             # Make sure that we only let unauth'd users see public systems
             public_sys = next((sys for sys in settings.PORTAL_DATAFILES_STORAGE_SYSTEMS if sys['scheme'] == 'public'), None)
             if public_sys and public_sys['system'] == system and path.startswith(public_sys['homeDir'].strip('/')):
+                client = service_account()
+            if system and system.startswith(settings.PORTAL_PROJECTS_PUBLISHED_SYSTEM_PREFIX):
                 client = service_account()
             else:
                 return JsonResponse(

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
+from portal.libs.agave.utils import service_account
 from portal.utils.decorators import agave_jwt_login
 from portal.exceptions.api import ApiException
 from portal.views.base import BaseApiView
@@ -157,7 +158,6 @@ class ProjectsApiView(BaseApiView):
 
 
 @method_decorator(agave_jwt_login, name='dispatch')
-@method_decorator(login_required, name='dispatch')
 class ProjectInstanceApiView(BaseApiView):
     """Project Instance API view.
 
@@ -178,8 +178,11 @@ class ProjectInstanceApiView(BaseApiView):
         # Based on url mapping, either system_id or project_id is always available.
         if system_id is not None:
             project_id = system_id.split(f"{settings.PORTAL_PROJECTS_SYSTEM_PREFIX}.")[1]
-
-        client = request.user.tapis_oauth.client
+        
+        if system_id and system_id.startswith(settings.PORTAL_PROJECTS_PUBLISHED_SYSTEM_PREFIX):
+            client = service_account()
+        else:
+            client = request.user.tapis_oauth.client
 
         prj = get_project(client, project_id)
 

--- a/server/portal/urls.py
+++ b/server/portal/urls.py
@@ -103,6 +103,7 @@ urlpatterns = [
                  namespace='googledrive-privacy-policy')),
     path('workbench/', include('portal.apps.workbench.urls', namespace='workbench')),
     path('public-data/', include('portal.apps.public_data.urls', namespace='public')),
+    path('publications/', include('portal.apps.public_data.urls', namespace='publications')),
     path('request-access/', include('portal.apps.request_access.urls', namespace='request_access')),
     path('search/', include('portal.apps.site_search.urls', namespace='site_search')),
 


### PR DESCRIPTION
## Overview

Serve published projects on a world-readable page at `/publications`

## Related

* [WC-186](https://tacc-main.atlassian.net/browse/WC-186)

## Changes
- Add world-readable `/publications` page.
- Update projects UI to work without auth for published projects,
- Update projects/publications backend to remove auth requirement for viewing published projects.


## Testing

1. Visit https://cep.test/publications/ and click through publications and file listings within those publications
2. Repeat in an unauthenticated session

## UI
![image](https://github.com/user-attachments/assets/8fac52f6-8d65-4132-86d2-95f7d6742940)![image](https://github.com/user-attachments/assets/55cab03f-d449-4d8d-a44a-bd8be6f02dba)




## Notes

