### PR TITLE
task/WI-239: Add audit logs for datafiles/projects endpoints

### DIFF
--- a/server/portal/apps/datafiles/handlers/tapis_handlers.py
+++ b/server/portal/apps/datafiles/handlers/tapis_handlers.py
@@ -15,27 +15,27 @@ allowed_actions = {
 }
 
 
-def tapis_get_handler(client, scheme, system, path, operation, **kwargs):
+def tapis_get_handler(client, scheme, system, path, operation, tapis_tracking_id=None, **kwargs):
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied
     op = getattr(operations, operation)
-    return op(client, system, path, **kwargs)
+    return op(client, system, path, tapis_tracking_id=tapis_tracking_id, **kwargs)
 
 
 def tapis_post_handler(client, scheme, system,
-                       path, operation, body=None):
+                       path, operation, body=None, tapis_tracking_id=None):
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied("")
 
     op = getattr(operations, operation)
-    return op(client, system, path, **body)
+    return op(client, system, path, tapis_tracking_id=tapis_tracking_id, **body)
 
 
 def tapis_put_handler(client, scheme, system,
-                      path, operation, body=None):
+                      path, operation, body=None, tapis_tracking_id=None):
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied
 
     op = getattr(operations, operation)
 
-    return op(client, system, path, **body)
+    return op(client, system, path, tapis_tracking_id=tapis_tracking_id, **body)

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -6,6 +6,7 @@ from django.http import JsonResponse, HttpResponseForbidden
 from requests.exceptions import HTTPError
 from tapipy.errors import InternalServerError, UnauthorizedError
 from portal.views.base import BaseApiView
+from portal.utils import get_client_ip
 from portal.libs.agave.utils import service_account
 from portal.apps.datafiles.handlers.tapis_handlers import (tapis_get_handler,
                                                            tapis_put_handler,
@@ -25,7 +26,7 @@ from .utils import notify, NOTIFY_ACTIONS
 import dateutil.parser
 
 logger = logging.getLogger(__name__)
-METRICS = logging.getLogger('metrics.{}'.format(__name__))
+METRICS = logging.getLogger(f"metrics.{__name__}")
 
 
 class SystemListingView(BaseApiView):
@@ -97,15 +98,21 @@ class TapisFilesView(BaseApiView):
                     {'message': 'This data requires authentication to view.'},
                     status=403)
         try:
-            METRICS.info("user:{} op:{} api:tapis scheme:{} "
-                         "system:{} path:{} filesize:{}".format(request.user.username,
-                                                                operation,
-                                                                scheme,
-                                                                system,
-                                                                path,
-                                                                request.GET.get('length')))
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': operation,
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'systemId': system,
+                             'filePath': path,
+                             'query': request.GET.dict()}
+                     })
             response = tapis_get_handler(
-                client, scheme, system, path, operation, **request.GET.dict())
+                client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", **request.GET.dict())
 
             operation in NOTIFY_ACTIONS and \
                 notify(request.user.username, operation, 'success', {'response': response})
@@ -140,14 +147,22 @@ class TapisFilesView(BaseApiView):
             return HttpResponseForbidden("This data requires authentication to view.")
 
         try:
-            METRICS.info("user:{} op:{} api:tapis scheme:{} "
-                         "system:{} path:{} body:{}".format(request.user.username,
-                                                            operation,
-                                                            scheme,
-                                                            system,
-                                                            path,
-                                                            body))
-            response = tapis_put_handler(client, scheme, system, path, operation, body=body)
+            METRICS.info('Data Depot',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': operation,
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'scheme': scheme,
+                             'system': system,
+                             'path': path,
+                             'body': body,
+                         }
+                     })
+            response = tapis_put_handler(client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", body=body)
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc
@@ -163,15 +178,22 @@ class TapisFilesView(BaseApiView):
             return HttpResponseForbidden("This data requires authentication to upload.")
 
         try:
-            METRICS.info("user:{} op:{} api:tapis scheme:{} "
-                         "system:{} path:{} filename:{}".format(request.user.username,
-                                                                operation,
-                                                                scheme,
-                                                                system,
-                                                                path,
-                                                                body['uploaded_file'].name))
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': operation,
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'scheme': scheme,
+                             'system': system,
+                             'path': path,
+                             'body': request.POST.dict()
+                         }})
 
-            response = tapis_post_handler(client, scheme, system, path, operation, body=body)
+            response = tapis_post_handler(client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}",  body=body)
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc
@@ -183,6 +205,19 @@ class GoogleDriveFilesView(BaseApiView):
     def get(self, request, operation=None, scheme=None, system=None,
             path='root'):
         try:
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': operation,
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'googledrive',
+                             'systemId': system,
+                             'filePath': path,
+                             'query': request.GET.dict()}
+                     })
             client = request.user.googledrive_user_token.client
         except AttributeError:
             raise ApiException("Login Required", status=400)
@@ -230,6 +265,17 @@ class TransferFilesView(BaseApiView):
 
         src_client = get_client(request.user, body['src_api'])
         dest_client = get_client(request.user, body['dest_api'])
+        METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': 'transfer',
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'body': body
+                         }
+                     })
 
         try:
             if filetype == 'dir':
@@ -275,6 +321,19 @@ class LinkView(BaseApiView):
         """Given a file, returns a link for a file
         """
         try:
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': 'retrieve-postit',
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'systemId': system,
+                             'filePath': path,
+                             'query': request.GET.dict()}
+                     })
             link = Link.objects.get(tapis_uri=f"{system}/{path}")
         except Link.DoesNotExist:
             return JsonResponse({"data": None, "expiration": None})
@@ -285,6 +344,19 @@ class LinkView(BaseApiView):
         """Delete an existing link for a file
         """
         try:
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': 'delete-postit',
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'systemId': system,
+                             'filePath': path,
+                             'query': request.GET.dict()}
+                     })
             link = Link.objects.get(tapis_uri=f"{system}/{path}")
         except Link.DoesNotExist:
             raise ApiException("Post-it does not exist")
@@ -297,6 +369,19 @@ class LinkView(BaseApiView):
         try:
             Link.objects.get(tapis_uri=f"{system}/{path}")
         except Link.DoesNotExist:
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': 'create-postit',
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'systemId': system,
+                             'filePath': path,
+                             'query': request.GET.dict()}
+                     })
             # Link doesn't exist - proceed with creating one
             postit = self.create_postit(request, scheme, system, path)
             return JsonResponse({"data": postit['data'], "expiration": postit['expiration']})
@@ -307,6 +392,19 @@ class LinkView(BaseApiView):
         """Replace an existing link for a file
         """
         try:
+            METRICS.info('Data Files',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': 'replace-postit',
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'tapis',
+                             'systemId': system,
+                             'filePath': path,
+                             'query': request.GET.dict()}
+                     })
             link = Link.objects.get(tapis_uri=f"{system}/{path}")
             self.delete_link(request, link)
         except Link.DoesNotExist:

--- a/server/portal/libs/agave/operations.py
+++ b/server/portal/libs/agave/operations.py
@@ -40,7 +40,8 @@ def listing(client, system, path, offset=0, limit=100, *args, **kwargs):
     raw_listing = client.files.listFiles(systemId=system,
                                          path=path,
                                          offset=int(offset),
-                                         limit=int(limit))
+                                         limit=int(limit),
+                                         headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
     try:
         # Convert file objects to dicts for serialization.
@@ -176,7 +177,7 @@ def download(client, system, path, max_uses=3, lifetime=600, **kwargs):
     return redeemUrl
 
 
-def mkdir(client, system, path, dir_name):
+def mkdir(client, system, path, dir_name, **kwargs):
     """Create a new directory.
 
     Params
@@ -207,7 +208,7 @@ def mkdir(client, system, path, dir_name):
     return {"result": "OK"}
 
 
-def move(client, src_system, src_path, dest_system, dest_path, file_name=None):
+def move(client, src_system, src_path, dest_system, dest_path, file_name=None, **kwargs):
     """Move a current file to the given destination.
 
     Params
@@ -251,7 +252,8 @@ def move(client, src_system, src_path, dest_system, dest_path, file_name=None):
         move_result = client.files.moveCopy(systemId=src_system,
                                             path=src_path,
                                             operation="MOVE",
-                                            newPath=dest_path_full)
+                                            newPath=dest_path_full,
+                                            headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
     if os.path.dirname(src_path) != dest_path or src_path != dest_path:
         tapis_indexer.apply_async(kwargs={'access_token': client.access_token.access_token,
@@ -318,7 +320,8 @@ def copy(client, src_system, src_path, dest_system, dest_path, file_name=None,
         copy_result = client.files.moveCopy(systemId=src_system,
                                             path=src_path,
                                             operation="COPY",
-                                            newPath=dest_path_full)
+                                            newPath=dest_path_full,
+                                            headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     else:
 
         src_url = f'tapis://{src_system}/{src_path}'
@@ -327,7 +330,8 @@ def copy(client, src_system, src_path, dest_system, dest_path, file_name=None,
         copy_response = client.files.createTransferTask(elements=[{
             'sourceURI': src_url,
             'destinationURI': dest_url
-        }])
+        }],
+        headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
         copy_result = {
             'uuid': copy_response.uuid,
@@ -364,12 +368,13 @@ def makepublic(client, src_system, src_path, dest_path='/', *args, **kwargs):
                 *args, **kwargs)
 
 
-def delete(client, system, path):
+def delete(client, system, path, *args, **kwargs):
     return client.files.delete(systemId=system,
-                               path=path)
+                               path=path,
+                               headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
 
-def rename(client, system, path, new_name):
+def rename(client, system, path, new_name, *args, **kwargs):
     """Renames a file. This is performed under the hood by moving the file to
     the same parent folder but with a new name.
 
@@ -390,10 +395,10 @@ def rename(client, system, path, new_name):
     """
     new_path = os.path.dirname(path)
     return move(client, src_system=system, src_path=path,
-                dest_system=system, dest_path=new_path, file_name=new_name)
+                dest_system=system, dest_path=new_path, file_name=new_name, **kwargs)
 
 
-def trash(client, system, path, homeDir):
+def trash(client, system, path, homeDir, *args, **kwargs):
     """Move a file to the .Trash folder.
 
     Params
@@ -423,12 +428,12 @@ def trash(client, system, path, homeDir):
         mkdir(client, system, homeDir, settings.TAPIS_DEFAULT_TRASH_NAME)
 
     resp = move(client, system, path, system,
-                f'{homeDir}/{settings.TAPIS_DEFAULT_TRASH_NAME}', file_name)
+                f'{homeDir}/{settings.TAPIS_DEFAULT_TRASH_NAME}', file_name, **kwargs)
 
     return resp
 
 
-def upload(client, system, path, uploaded_file):
+def upload(client, system, path, uploaded_file, *args, **kwargs):
     """Upload a file.
     Params
     ------
@@ -449,7 +454,10 @@ def upload(client, system, path, uploaded_file):
     uploaded_file.name = increment_file_name(listing=file_listing, file_name=uploaded_file.name)
 
     dest_path = os.path.join(path.strip('/'), uploaded_file.name)
-    response_json = client.files.insert(systemId=system, path=dest_path, file=uploaded_file)
+    response_json = client.files.insert(systemId=system,
+                                        path=dest_path,
+                                        file=uploaded_file,
+                                        headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     tapis_indexer.apply_async(kwargs={'access_token': client.access_token.access_token,
                                       'systemId': system,
                                       'filePath': path,
@@ -482,7 +490,10 @@ def preview(client, system, path, max_uses=3, lifetime=600, **kwargs):
     file_name = path.strip('/').split('/')[-1]
     file_ext = os.path.splitext(file_name)[1].lower()
 
-    postit = client.files.createPostIt(systemId=system, path=path, allowedUses=max_uses, validSeconds=lifetime)
+    postit = client.files.createPostIt(systemId=system,
+                                       path=path, allowedUses=max_uses, 
+                                       validSeconds=lifetime,
+                                       headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
     url = postit.redeemUrl
     txt = None
@@ -521,7 +532,7 @@ def preview(client, system, path, max_uses=3, lifetime=600, **kwargs):
     return {'href': url, 'fileType': file_type, 'content': txt, 'error': error}
 
 
-def download_bytes(client, system, path):
+def download_bytes(client, system, path, *args, **kwargs):
     """Returns a BytesIO object representing the file.
 
     Params

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+import uuid
 import logging
 from kombu import Exchange, Queue
 from portal.settings import settings_secret
@@ -289,9 +290,23 @@ GOOGLE_ANALYTICS_PROPERTY_ID = settings_custom._GOOGLE_ANALYTICS_PROPERTY_ID
 SETTINGS: LOGGING
 """
 
+def portal_filter(record):
+    """Log filter that adds portal-specific vars to each entry"""
+
+    record.logGuid = uuid.uuid4().hex
+    record.portal = PORTAL_NAMESPACE
+    record.tenant = TAPIS_TENANT_BASEURL
+    return True
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    "filters": {
+        "portalFilter": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": portal_filter,
+        },
+    },
     'formatters': {
         'default': {
             'format': '[DJANGO] %(levelname)s %(asctime)s UTC %(module)s '
@@ -302,8 +317,9 @@ LOGGING = {
                       '%(name)s.%(funcName)s:%(lineno)s: %(message)s'
         },
         'metrics': {
-            'format': '[METRICS] %(levelname)s %(asctime)s UTC %(module)s '
-                      '%(name)s.%(funcName)s:%(lineno)s: %(message)s'
+            'format': '[METRICS] %(levelname)s %(module)s %(name)s.%(funcName)s:%(lineno)s:'
+                      ' %(message)s user=%(user)s ip=%(ip)s agent=%(agent)s sessionId=%(sessionId)s op=%(operation)s'
+                      ' info=%(info)s timestamp=%(asctime)s trackingId=portals.%(sessionId)s guid=%(logGuid)s portal=%(portal)s tenant=%(tenant)s'
         },
     },
     'handlers': {
@@ -320,18 +336,11 @@ LOGGING = {
             'backupCount': 5,
             'formatter': 'default',
         },
-        'metrics_console': {
-            'level': 'DEBUG',
+        'metrics': {
+            'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'metrics',
-        },
-        'metrics_file': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': '/var/log/portal/metrics.log',
-            'maxBytes': 1024*1024*5,  # 5 MB
-            'backupCount': 5,
-            'formatter': 'metrics',
+            'filters': ['portalFilter']
         },
     },
     'loggers': {
@@ -345,8 +354,9 @@ LOGGING = {
             'level': 'DEBUG',
         },
         'metrics': {
-            'handlers': ['metrics_console', 'metrics_file'],
-            'level': 'DEBUG',
+            'handlers': ['metrics'],
+            'filters': ['portalFilter'],
+            'level': 'INFO',
         },
         'paramiko': {
             'handlers': ['console'],

--- a/server/portal/utils/__init__.py
+++ b/server/portal/utils/__init__.py
@@ -1,0 +1,11 @@
+"""Utils for use across multiple apps"""
+
+
+def get_client_ip(request):
+    """Extract an IP address from a Django request object."""
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(",")[-1].strip()
+    else:
+        ip = request.META.get("REMOTE_ADDR")
+    return ip


### PR DESCRIPTION
## Overview
Add audit logs and Tapis tracking tokens for Data Files and Projects endpoints


## Related

* [WI-239](https://tacc-main.atlassian.net/browse/WI-239)

## Changes
- Update metrics log format to match Designsafe
- Add metrics logging to Data Files and Projects endpoints
- Add Tapis tracking tokens to Tapipy requests in Data Files.


## Testing

1. In Data Files, perform a listing, file upload, and file rename. Metrics logs should appear that look like: 
```
[METRICS] INFO views metrics.portal.apps.datafiles.views.get:101: Data Files user=jarosenb ip=172.18.0.1 agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 sessionId=ix0ydn7j0cuoehuawt6sv55v6yu5tg9p op=listing info={'api': 'tapis', 'systemId': 'drp.project.review.test', 'filePath': '/', 'query': {'limit': '100', 'nextPageToken': '', 'offset': '0', 'query_string': ''}} timestamp=2025-01-30 19:29:46,132 trackingId=portals.ix0ydn7j0cuoehuawt6sv55v6yu5tg9p guid=6751506153924933a25d9693e97f57db portal=DRP tenant=https://portals.tapis.io
```

## UI



## Notes

