### PR TITLE
Quick: Add explicit CORS config to Vite

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
   server: {
     origin: 'cep.test',
     port: 3000,
+    cors: {
+      origin: ['https://cep.test'],
+    },
     hmr: {
       protocol: 'ws',
       host: 'localhost',


### PR DESCRIPTION
## Overview
Addresses an issue where Vite assets weren't loading to do a CORS issue. The `origin` setting has worked for this in the past, but might not be respected as of recent browser/Node updates.
