### PR TITLE
WP-870: Fix broken file uploads and APCD file submissions

### DIFF
--- a/client/src/hooks/datafiles/mutations/useUpload.test.ts
+++ b/client/src/hooks/datafiles/mutations/useUpload.test.ts
@@ -1,0 +1,82 @@
+import { uploadUtil } from './useUpload';
+import { apiClient } from 'utils/apiClient';
+import Cookies from 'js-cookie';
+import { vi, Mock } from 'vitest';
+
+vi.mock('utils/apiClient');
+Cookies.get = vi.fn().mockImplementation(() => 'test-cookie');
+
+describe('uploadUtil', () => {
+  const api = 'tapis';
+  const scheme = 'private';
+  const system = 'apcd.submissions';
+  const file = new FormData();
+  file.append(
+    'uploaded_file',
+    new Blob(['test content'], { type: 'text/plain' })
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (Cookies.get as Mock).mockReturnValue('mockCsrfToken');
+  });
+
+  it('should construct the correct URL when path is an empty string', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { file: 'mockFile', path: '' },
+    });
+
+    await uploadUtil({ api, scheme, system, path: '', file });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/datafiles/tapis/upload/private/apcd.submissions/',
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: { 'X-CSRFToken': 'mockCsrfToken' },
+        withCredentials: true,
+      })
+    );
+  });
+
+  it('should not call post when path is "/"', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { file: 'mockFile', path: '' },
+    });
+    await uploadUtil({ api, scheme, system, path: '/', file });
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('should construct the correct URL when path is regular folder', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { file: 'mockFile', path: '/subdir' },
+    });
+
+    await uploadUtil({ api, scheme, system, path: 'subdir', file });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/datafiles/tapis/upload/private/apcd.submissions/subdir/',
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: { 'X-CSRFToken': 'mockCsrfToken' },
+        withCredentials: true,
+      })
+    );
+  });
+
+  it('should normalize multiple slashes in the URL', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { file: 'mockFile', path: '/nested/path' },
+    });
+
+    await uploadUtil({ api, scheme, system, path: 'nested//path', file });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/datafiles/tapis/upload/private/apcd.submissions/nested/path/',
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: { 'X-CSRFToken': 'mockCsrfToken' },
+        withCredentials: true,
+      })
+    );
+  });
+});

--- a/client/src/hooks/datafiles/mutations/useUpload.ts
+++ b/client/src/hooks/datafiles/mutations/useUpload.ts
@@ -26,7 +26,7 @@ export async function uploadUtil({
   const fileField = file.get('uploaded_file') as Blob;
   formData.append('uploaded_file', fileField);
   let url = `/api/datafiles/${api}/upload/${scheme}/${system}/${apiPath}/`;
-  url.replace(/\/{2,}/g, '/');
+  url = url.replace(/\/{2,}/g, '/');
   const response = await apiClient.post(url, formData, {
     headers: {
       'X-CSRFToken': Cookies.get('csrftoken') || '',


### PR DESCRIPTION
## Overview
Upload is sending `//` to server and failing in url mapping.


## Related

* [WP-870](https://tacc-main.atlassian.net/browse/WP-870)

## Changes
1. url.replace does not modify in place, fix it.


## Testing

1. Added unit tests
2. go to [dev.apcd and try upload.](https://dev.apcd.tacc.utexas.edu/workbench/data-submission/) and try upload

