### PR TITLE
Quick: Fix workbench publications linking to public area

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.jsx
@@ -16,10 +16,16 @@ import {
 import DataFilesListing from '../DataFilesListing/DataFilesListing';
 import styles from './DataFilesProjectFileListing.module.scss';
 
-const DataFilesProjectFileListing = ({ rootSystem, system, path }) => {
+const DataFilesProjectFileListing = ({
+  rootSystem,
+  system,
+  path,
+  basePath,
+}) => {
   const dispatch = useDispatch();
   const { fetchListing } = useFileListing('FilesListing');
   const { isPublicationSystem, isReviewSystem } = useSystems();
+  if (!basePath) basePath = '/workbench/data';
 
   // logic to render addonComponents for DRP
   const portalName = useSelector((state) => state.workbench.portalName);
@@ -172,7 +178,7 @@ const DataFilesProjectFileListing = ({ rootSystem, system, path }) => {
         scheme="projects"
         system={system}
         path={path || '/'}
-        basePath="/publications"
+        basePath={basePath}
         rootSystem={rootSystem}
       />
     </SectionTableWrapper>

--- a/client/src/components/Publications/PublicationDetailPublicView.jsx
+++ b/client/src/components/Publications/PublicationDetailPublicView.jsx
@@ -8,7 +8,7 @@ import DataFilesShowPathModal from '../DataFiles/DataFilesModals/DataFilesShowPa
 import DataFilesViewDataModal from '../DataFiles/DataFilesModals/DataFilesViewDataModal';
 import DataFilesProjectFileListing from '../DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing';
 
-function PublicationDetailPublicView({params}) {
+function PublicationDetailPublicView({ params }) {
   return (
     <div
       style={{
@@ -29,6 +29,7 @@ function PublicationDetailPublicView({params}) {
         rootSystem={params.root_system}
         system={params.system}
         path={params.path || '/'}
+        basePath="/publications"
       />
       <DataFilesPreviewModal />
       <DataFilesShowPathModal />


### PR DESCRIPTION
## Overview
Fix a bug where clicking into a directory in a project/publication would link out to the `/published` view.

