### PR TITLE
Hotfix: increase axios timeout

### DIFF
--- a/client/src/hooks/datafiles/mutations/useUpload.ts
+++ b/client/src/hooks/datafiles/mutations/useUpload.ts
@@ -4,6 +4,8 @@ import Cookies from 'js-cookie';
 import truncateMiddle from 'utils/truncateMiddle';
 import { useMutation } from '@tanstack/react-query';
 
+apiClient.defaults.timeout = 5 * 60 * 1000; // 5 minutes
+
 export async function uploadUtil({
   api,
   scheme,

--- a/client/src/utils/apiClient.ts
+++ b/client/src/utils/apiClient.ts
@@ -3,7 +3,7 @@ import axios, { AxiosError } from 'axios';
 export type TApiError = AxiosError<{ message?: string }>;
 
 export const apiClient = axios.create({
-  timeout: 30000,
+  timeout: 60 * 1000, // 1 minute
   xsrfHeaderName: 'X-CSRFToken',
   xsrfCookieName: 'csrftoken',
 });


### PR DESCRIPTION
## Overview: ##

Defaults to 1min now for timeout, and increases upload timeouts to 5min

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. Upload a largeish file and confirm it succeeds
2. In `client/src/hooks/datafiles/mutations/useUpload.ts`, change the default timeout to `1000`, 1 second. Upload the same file and watch it fail.
