### PR TITLE
Requested Changes [post-workshop] for the "Add Dataset" View

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.jsx
@@ -75,7 +75,7 @@ const DataFilesAddProjectModal = () => {
       type: 'PROJECTS_CREATE',
       payload: {
         title: values.title,
-        description: values.description || null,
+        description: values.description, // Ensure this is included
         members: members.map((member) => ({
           username: member.user.username,
           access: member.access,
@@ -84,7 +84,7 @@ const DataFilesAddProjectModal = () => {
         onCreate,
       },
     });
-  };
+  };  
 
   const onAdd = (newUser) => {
     setMembers([...members, newUser]);
@@ -101,7 +101,12 @@ const DataFilesAddProjectModal = () => {
       .min(3, 'Title must be at least 3 characters')
       .max(150, 'Title must be at most 150 characters')
       .required('Please enter a title.'),
+    description: Yup.string()
+      .min(200, 'Description must be at least 200 characters')
+      .max(300, 'Description must be at most 300 characters')
+      .required('Please enter a description.'),
   });
+  
 
   return (
     <>
@@ -113,7 +118,7 @@ const DataFilesAddProjectModal = () => {
       >
         {' '}
         <Formik
-          initialValues={{ title: '' }}
+          initialValues={{ title: '', description: '' }}
           onSubmit={addproject}
           validationSchema={validationSchema}
         >
@@ -122,7 +127,7 @@ const DataFilesAddProjectModal = () => {
               Add {sharedWorkspacesDisplayName}
             </ModalHeader>
             <ModalBody>
-              <FormField
+            <FormField
                 name="title"
                 label={
                   <div>
@@ -130,17 +135,28 @@ const DataFilesAddProjectModal = () => {
                     <small>
                       <em>(Maximum 150 characters)</em>
                     </small>
+                    <br />
+                    <small style={{ color: '#666' }}>
+                      <em>The title should be descriptive and distinctive from related publications.</em>
+                    </small>
                   </div>
                 }
               />
-              {DataFilesAddProjectModalAddon && (
-                <DataFilesAddProjectModalAddon />
-              )}
-              <DataFilesProjectMembers
-                members={members}
-                onAdd={onAdd}
-                onRemove={onRemove}
+              <FormField
+                name="description"
+                label={
+                  <div>
+                    Dataset Description{' '}
+                    <br />
+                    <small style={{ color: '#666' }}>
+                      <em>Provide 200-300 words clearly describing the data as an independent output; do not copy related publication abstract.</em>
+                    </small>
+                  </div>
+                }
+                type="textarea"
               />
+              {DataFilesAddProjectModalAddon && <DataFilesAddProjectModalAddon />}
+              <DataFilesProjectMembers members={members} onAdd={onAdd} onRemove={onRemove} />
             </ModalBody>
             <ModalFooter>
               {error ? (

--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.jsx
@@ -101,7 +101,7 @@ const DataFilesProjectMembers = ({
   };
 
   const memberColumn = {
-    Header: 'Members',
+    Header: 'Authors',
     headerStyle: { textAlign: 'left' },
     accessor: 'user',
     className: 'project-members__cell',


### PR DESCRIPTION
## Overview



## Related

* [Wc-191](https://tacc-main.atlassian.net/browse/Wc-191)

## Changes
Add the following placeholder text to the identified input field: 

- [x] Dataset Title: “The title should be descriptive and distinctive from related publications.”

- [x] Description: “Provide 200-300 words clearly describing the data as an independent output; do not copy related publication abstract.”

- [x] The label “Members” should be changed to “Authors”. 

PI question about the Add Dataset view: We are not clear what is the meaning of the “Role”, especially since here we cannot add anyone else.


## Testing

1. click "+Add" --> choose "Dataset"
2. Check modal for expected changes

## UI

<img width="600" alt="Screen Shot 2025-02-25 at 11 45 35 AM" src="https://github.com/user-attachments/assets/f6b00d25-f0c6-4733-8820-ddc04bc3c098" />


## Notes

changing "members" to "authors" will reflect everywhere DataFilesProjectMembers.jsx is used.

