### PR TITLE
WP-878: Shared workspaces upload to root folder is failing

### DIFF
--- a/client/src/hooks/datafiles/mutations/useUpload.ts
+++ b/client/src/hooks/datafiles/mutations/useUpload.ts
@@ -22,7 +22,6 @@ export async function uploadUtil({
   let apiPath = !path || path[0] === '/' ? path : `/${path}`;
   if (apiPath === '/') {
     apiPath = '';
-    return { file, path: apiPath };
   }
   const formData = new FormData();
   const fileField = file.get('uploaded_file') as Blob;


### PR DESCRIPTION
## Overview
Upload was no op if file was upload to root folder.


## Related

* [WP-878](https://tacc-main.atlassian.net/browse/WP-878)

## Changes
1. remove incorrect return


## Testing

1. Shared workspaces:
   * Upload to root.
   * Upload to another nested folder.
   * Copy a file
   * Delete a file
2. Work - upload to home folder.

