### PR TITLE
Fix: Workbench drop down menu is cut off on the right.

### DIFF
--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -17,6 +17,9 @@
       font-size: 1.5em;
       vertical-align: middle; /* tweaked to align better */
   }
+  .s-header.navbar {
+    --nav-padding-horz: 60px;
+  }
 </style>
 {% if user.is_authenticated %}
 <li class="nav-item dropdown">

--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -17,9 +17,6 @@
       font-size: 1.5em;
       vertical-align: middle; /* tweaked to align better */
   }
-  .s-header.navbar {
-    --nav-padding-horz: 60px;
-  }
 </style>
 {% if user.is_authenticated %}
 <li class="nav-item dropdown">
@@ -28,7 +25,7 @@
     <span>{{ user.get_username }}</span>
     <span class="sr-only">Toggle Dropdown</span>
   </a>
-  <nav class="dropdown-menu dropdown-menu-right">
+  <nav class="dropdown-menu dropdown-menu-end">
     <a class="dropdown-item" href="{% url 'workbench:dashboard' %}">
       <i class="icon icon-dashboard"></i> My Dashboard
     </a>


### PR DESCRIPTION
## Overview

Workbench user drop down menu is cut off on the right.

## Related

[WP-839](https://tacc-main.atlassian.net/browse/WP-839)

## Changes

User drop-down menu styling fixed

## Testing

1. Log in as Admin user, verify User drop-down menu is not cut off 

## UI


<img width="298" alt="Screenshot 2025-02-25 at 3 38 20 PM" src="https://github.com/user-attachments/assets/723d6009-a4fc-4d45-b5b0-c0052e02b7b6" />

## Notes

