### PR TITLE
fix: WP-895 portal nav position wrong on portal

### DIFF
--- a/server/portal/templates/base.html
+++ b/server/portal/templates/base.html
@@ -41,7 +41,7 @@
     {% block scripts %}{% endblock %}
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js" integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -20,7 +20,7 @@
 </style>
 {% if user.is_authenticated %}
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="icon icon-user"></i>
     <span>{{ user.get_username }}</span>
     <span class="sr-only">Toggle Dropdown</span>


### PR DESCRIPTION
## Overview

Fix position of menu of portal nav on Portal. (It is positioned as expected on CMS.)

## Related

- [WP-895](https://tacc-main.atlassian.net/browse/WP-895)
- expected by https://github.com/TACC/Core-CMS/pull/913
- continues incomplete Bootstrap update from #1030

## Changes

- **updated** Bootstrap and Popper JS

## Testing

1. Run Core-Portal with this Core-CMS.
2. Open CMS page.
3. Verify portal nav dropdown menu location is underneath its toggle.

## UI

https://github.com/user-attachments/assets/c4e8bbd1-72f9-4996-bcc3-5b49548e2278

## Notes

> [!IMPORTANT]
> Other dropdown menu positions work because they rely on Reactstrap for JavaScript.[^1]

> [!TIP]
> The bug of orange underline appearing beneath header is fixed separately in #1068.

[^1]: Wait, so… the HTML-driven load of Bootstrap JavaScript is only for the portal nav dropdown? Maybe. Well, shouldn't that be investigated and, if so, streamlined? Yes, but out of scope of this task, which is already an offshoot of another task, which is already a two-day distraction from my urgent tasks.