### PR TITLE
task/WC - 231 & 215 - Publication Metadata Validation

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.jsx
@@ -75,7 +75,7 @@ const DataFilesAddProjectModal = () => {
       type: 'PROJECTS_CREATE',
       payload: {
         title: values.title,
-        description: values.description, // Ensure this is included
+        description: values.description || null,
         members: members.map((member) => ({
           username: member.user.username,
           access: member.access,
@@ -102,9 +102,7 @@ const DataFilesAddProjectModal = () => {
       .max(150, 'Title must be at most 150 characters')
       .required('Please enter a title.'),
     description: Yup.string()
-      .min(200, 'Description must be at least 200 characters')
-      .max(300, 'Description must be at most 300 characters')
-      .required('Please enter a description.'),
+      .max(800, 'Description must be at most 800 characters')
   });
   
 
@@ -136,24 +134,9 @@ const DataFilesAddProjectModal = () => {
                       <em>(Maximum 150 characters)</em>
                     </small>
                     <br />
-                    <small style={{ color: '#666' }}>
-                      <em>The title should be descriptive and distinctive from related publications.</em>
-                    </small>
                   </div>
                 }
-              />
-              <FormField
-                name="description"
-                label={
-                  <div>
-                    Dataset Description{' '}
-                    <br />
-                    <small style={{ color: '#666' }}>
-                      <em>Provide 200-300 words clearly describing the data as an independent output; do not copy related publication abstract.</em>
-                    </small>
-                  </div>
-                }
-                type="textarea"
+                description={'The title should be descriptive and distinctive from related publications.'}
               />
               {DataFilesAddProjectModalAddon && <DataFilesAddProjectModalAddon />}
               <DataFilesProjectMembers members={members} onAdd={onAdd} onRemove={onRemove} />

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescription.module.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescription.module.scss
@@ -1,5 +1,5 @@
 .description-textarea {
-  min-height: 10em;
+  height: auto !important;
 }
 
 .button-container {

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescriptionModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescriptionModal.jsx
@@ -117,6 +117,7 @@ const DataFilesProjectEditDescriptionModal = () => {
                   </div>
                 }
                 type="textarea"
+                rows={5}
                 className={styles['description-textarea']}
               />
               {DataFilesProjectEditDescriptionModalAddon && (

--- a/client/src/components/_common/Form/DynamicForm/DynamicForm.jsx
+++ b/client/src/components/_common/Form/DynamicForm/DynamicForm.jsx
@@ -163,6 +163,7 @@ const DynamicForm = ({ initialFormFields, onChange }) => {
             rows={5}
             description={field?.description}
             required={field?.validation?.required}
+            className={styles['textarea']}
           />
         );
       case 'select':

--- a/client/src/components/_common/Form/DynamicForm/DynamicForm.module.scss
+++ b/client/src/components/_common/Form/DynamicForm/DynamicForm.module.scss
@@ -2,6 +2,10 @@
   font-weight: bold;
 }
 
+.textarea {
+  height: auto !important;
+}
+
 .radio-input {
   margin-left: 1rem;
   margin-bottom: 0rem;

--- a/client/src/components/_common/Form/FormField.scss
+++ b/client/src/components/_common/Form/FormField.scss
@@ -1,14 +1,14 @@
 .form-field__label {
   font-weight: bold;
   margin-top: -5px;
-  margin-bottom: 10px; 
 }
 
 .form-field__help {
+  display: flex;
   font-style: italic;
   font-weight: 400;
   margin-top: -5px; 
-  margin-bottom: 10px; 
+  margin-bottom: 5px;
 }
 
 .form-field__validation-error {

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublish.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublish.jsx
@@ -93,7 +93,7 @@ const DataFilesProjectPublish = ({ rootSystem, system }) => {
       authors: authors,
     };
 
-    if (Object.keys(values).length > 0) {
+    if (values.formSubmitted) {
       dispatch({
         type: 'PROJECTS_CREATE_PUBLICATION_REQUEST',
         payload: data,

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/DataFilesProjectPublishWizard.module.scss
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/DataFilesProjectPublishWizard.module.scss
@@ -104,3 +104,9 @@
   min-width: 200px !important;
   margin: 20px;
 }
+
+.errors-div {
+  width: 100%;
+  margin: 10px 0px;
+  color: red;
+}

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectDescription.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectDescription.jsx
@@ -10,10 +10,12 @@ import styles from './DataFilesProjectPublishWizard.module.scss';
 import { useDispatch, useSelector } from 'react-redux';
 import { formatDate } from 'utils/timeFormat';
 import { formatDataKey } from 'utils/dataKeyFormat';
+import { useFormikContext } from 'formik';
 
 const ProjectDescription = ({ project }) => {
   const dispatch = useDispatch();
   const [data, setData] = useState({});
+  const { errors } = useFormikContext();
 
   const canEdit = useSelector((state) => {
     const { members } = state.projects.metadata;
@@ -40,7 +42,7 @@ const ProjectDescription = ({ project }) => {
     let projectData = {
       Title: project.title,
       Created: formatDate(new Date(project.created)),
-      Abstract: <ShowMore> {project.description} </ShowMore>,
+      Description: <ShowMore> {project.description} </ShowMore>,
       License: project.license ?? 'None',
     };
 
@@ -157,14 +159,43 @@ const ProjectDescription = ({ project }) => {
         </>
       }
     >
+      {Object.keys(errors).length > 0 && (
+        <div className={styles['errors-div']}>
+          <p>Dataset metadata has the following errors:</p>
+          <ul>
+            {Object.keys(errors).map((key) => (
+              <li key={key}>{errors[key]}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <DescriptionList data={data} direction={'vertical'} />
     </SectionTableWrapper>
   );
+};
+
+const validateProjectMetadata = (values) => {
+  const errors = {};
+  
+  if (!values.title) {
+    errors.title = 'Title is required';
+  }
+  
+  if (!values.description) {
+    errors.description = 'Description is required';
+  }
+
+  if (!values.cover_image) {
+    errors.cover_image = 'Cover image is required';
+  }
+  
+  return errors;
 };
 
 export const ProjectDescriptionStep = ({ project }) => ({
   id: 'project_description',
   name: 'Project Description',
   render: <ProjectDescription project={project} />,
-  initialValues: {},
+  validate: validateProjectMetadata,
+  initialValues: project,
 });

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewProjectStructure.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewProjectStructure.jsx
@@ -2,15 +2,15 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { Button, SectionTableWrapper, Section } from '_common';
 import styles from './DataFilesProjectPublishWizard.module.scss';
 import { useDispatch, useSelector } from 'react-redux';
-import { useFileListing } from 'hooks/datafiles';
 import { ProjectTreeView } from './ProjectTreeView';
+import { useFormikContext } from 'formik';
 
 export const ReviewProjectStructure = ({ projectTree }) => {
   const dispatch = useDispatch();
 
   const { projectId } = useSelector((state) => state.projects.metadata);
 
-  const { params } = useFileListing('FilesListing');
+  const { errors } = useFormikContext();
 
   const canEdit = useSelector((state) => {
     const { members } = state.projects.metadata;
@@ -71,21 +71,88 @@ export const ReviewProjectStructure = ({ projectTree }) => {
             <li>Check if the data is rendered.</li>
             <li>Review image metadata for rendering.</li>
             <li>
-              Make sure the relationships between sample, origin data and
+              Make sure the relationships between sample, digital data and
               analysis data are correct in the tree and add if needed.
             </li>
           </ul>
         </div>
-
+        {Object.keys(errors).length > 0 && (
+          <div className={styles['errors-div']}>
+            <p>Dataset structure has the following errors:</p>
+            <ul>
+              {Object.keys(errors).map((key) => (
+                <li key={key}>{errors[key]}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         <ProjectTreeView projectId={projectId} readOnly={!canEdit} />
       </Section>
     </SectionTableWrapper>
   );
 };
 
+const validateFolder = (node) => {
+  const errors = [];
+  
+  const hasFileObjs = (node) => {
+    // Check if the current node has fileObjs
+    if (node.fileObjs && node.fileObjs.length > 0) {
+      return true;
+    }
+    
+    // Check if any children have fileObjs
+    if (node.children && node.children.length > 0) {
+      return node.children.some(child => hasFileObjs(child));
+    }
+    
+    return false;
+  }
+  
+  // Process the current node
+  if (!hasFileObjs(node)) {
+    errors.push(`Entity "${node.label}" (path: ${node.path}) has no files in itself or any of its child entities.`);
+  }
+  
+  // Recursively validate all children
+  if (node.children && node.children.length > 0) {
+    node.children.forEach(child => {
+      const childErrors = validateFolder(child);
+      errors.push(...childErrors);
+    });
+  }
+  
+  return errors;
+}
+
+const validateProjectStructure = (tree) => {
+
+  const validationErrors = [];
+
+  tree.forEach((node) => {
+    const nodeErrors = validateFolder(node);
+    if (nodeErrors.length > 0) {
+      validationErrors.push(...nodeErrors);
+    }
+  })
+
+  const errors = {};
+
+  if (validationErrors.length > 0) {
+    validationErrors.forEach((error, index) => {
+      const errorKey = `folder_${index}`;
+      errors[errorKey] = error;
+    }
+    );
+  }
+
+  return errors;
+}
+
 export const ReviewProjectStructureStep = ({ projectTree }) => ({
   id: 'project_structure',
   name: 'Review Project Structure',
   render: <ReviewProjectStructure projectTree={projectTree} />,
-  initialValues: {},
+  initialValues: projectTree,
+  validate: validateProjectStructure,
 });

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewProjectStructure.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewProjectStructure.jsx
@@ -111,7 +111,7 @@ const validateFolder = (node) => {
   
   // Process the current node
   if (!hasFileObjs(node)) {
-    errors.push(`Entity "${node.label}" (path: ${node.path}) has no files in itself or any of its child entities.`);
+    errors.push(`Entity "${node.label}" (path: /${node.path}) has no files in itself or any of its child entities.`);
   }
   
   // Recursively validate all children

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/SubmitPublicationRequest.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/SubmitPublicationRequest.jsx
@@ -13,7 +13,7 @@ const validationSchema = Yup.object({
 });
 
 const SubmitPublicationRequest = ({ callbackUrl }) => {
-  const { handleChange, handleBlur, values, submitForm, resetForm } =
+  const { handleChange, handleBlur, values, submitForm, resetForm, setValues } =
     useFormikContext();
   const history = useHistory();
 
@@ -45,6 +45,15 @@ const SubmitPublicationRequest = ({ callbackUrl }) => {
       setSubmitDisabled(!valid);
     });
   }, [values]);
+
+
+  const onSubmit = () => {
+    setValues({
+      ...values,
+      formSubmitted: true,
+    });
+    submitForm();
+  }
 
   return (
     <SectionTableWrapper
@@ -94,7 +103,7 @@ const SubmitPublicationRequest = ({ callbackUrl }) => {
             className={styles['submit-button']}
             disabled={submitDisabled}
             isLoading={loading}
-            onClick={submitForm}
+            onClick={onSubmit}
           >
             Submit Publication Request
           </Button>
@@ -111,6 +120,7 @@ export const SubmitPublicationRequestStep = ({ callbackUrl }) => ({
   initialValues: {
     reviewInfo: false,
     reviewRelatedPublications: false,
+    formSubmitted: false,
   },
   validationSchema,
 });


### PR DESCRIPTION
## Overview

- Adds validation for project metadata when publishing
- Adds validation for file/folder structure and ensures there are no empty file less folders 
- Reverts required validation for project description

## Related

* [WC-231](https://tacc-main.atlassian.net/browse/WC-231)
* [WC-215](https://tacc-main.atlassian.net/browse/WC-215)

## Testing

1. Try to  publish a project without title/description/cover image and ensure it doesn't let you progress 
2. Try to create some empty entities (empty digital data, empty analysis data)  and ensure it doesn't let you progress 

## UI

<img width="1577" alt="Screenshot 2025-03-12 at 1 37 19 PM" src="https://github.com/user-attachments/assets/c82bdc9d-a25c-4363-b759-1ecfe92440f0" />

<img width="1577" alt="Screenshot 2025-03-12 at 1 43 33 PM" src="https://github.com/user-attachments/assets/7ca88e5c-6861-45bc-aedc-bb1838450693" />

## Notes

