### PR TITLE
Task/WC-230 Support download/copy for published DRP files

### DIFF
--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
@@ -94,7 +94,7 @@ const DataFilesToolbar = ({ scheme, api }) => {
   }, [hasCustomDataFilesToolbarChecks, portalName]);
 
   const authenticatedUser = useSelector(
-    (state) => state.authenticatedUser.user.username
+    (state) => state.authenticatedUser?.user?.username
   );
 
   const { query: authenticatedUserQuery } = useSystemRole(
@@ -260,7 +260,8 @@ const DataFilesToolbar = ({ scheme, api }) => {
   );
   const canRename = getFilePermissions('rename', permissionParams) && !isGuest;
   const canMove = getFilePermissions('move', permissionParams) && !isGuest;
-  const canCopy = getFilePermissions('copy', permissionParams);
+  const canCopy =
+    getFilePermissions('copy', permissionParams) && !!authenticatedUser;
   const canTrash = getFilePermissions('trash', permissionParams) && !isGuest;
   const canCompress = getFilePermissions('compress', permissionParams);
   const canExtract = getFilePermissions('extract', permissionParams);

--- a/client/src/components/Publications/PublicationDetailPublicView.jsx
+++ b/client/src/components/Publications/PublicationDetailPublicView.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import CombinedBreadcrumbs from '../DataFiles/CombinedBreadcrumbs/CombinedBreadcrumbs';
 import DataFilesPreviewModal from '../DataFiles/DataFilesModals/DataFilesPreviewModal';
+import DataFilesCopyModal from '../DataFiles/DataFilesModals/DataFilesCopyModal';
 import DataFilesProjectCitationModal from '../DataFiles/DataFilesModals/DataFilesProjectCitationModal';
 import DataFilesProjectTreeModal from '../DataFiles/DataFilesModals/DataFilesProjectTreeModal';
 import DataFilesPublicationAuthorsModal from '../DataFiles/DataFilesModals/DataFilesPublicationAuthorsModal';
 import DataFilesShowPathModal from '../DataFiles/DataFilesModals/DataFilesShowPathModal';
 import DataFilesViewDataModal from '../DataFiles/DataFilesModals/DataFilesViewDataModal';
 import DataFilesProjectFileListing from '../DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing';
+import DataFilesToolbar from '../DataFiles/DataFilesToolbar/DataFilesToolbar';
+import NotificationToast from '../Toasts';
+import DataFilesLargeDownloadModal from '../DataFiles/DataFilesModals/DataFilesLargeDownloadModal';
 
 function PublicationDetailPublicView({ params }) {
   return (
@@ -17,6 +21,8 @@ function PublicationDetailPublicView({ params }) {
         padding: '10px',
       }}
     >
+      <NotificationToast />
+      <DataFilesToolbar api="tapis" scheme="public" />
       <CombinedBreadcrumbs
         api="tapis"
         scheme="projects"
@@ -37,6 +43,8 @@ function PublicationDetailPublicView({ params }) {
       <DataFilesPublicationAuthorsModal />
       <DataFilesProjectCitationModal />
       <DataFilesViewDataModal />
+      <DataFilesCopyModal />
+      <DataFilesLargeDownloadModal />
     </div>
   );
 }


### PR DESCRIPTION
## Overview
Adds the copy/download toolbar to the public view of DRP pubs, and implements the download hook for files too large to preview.

## Related

* [WC-230](https://tacc-main.atlassian.net/browse/WC-230)

## Testing

In the public view (https://cep.test/publications):
1. Try to preview a large file and make sure that the download button in the preview window starts an actual download
2. Inside a publication, use the download button (logged in and logged out) and the copy button (logged in). Copy might take a minute to process because it's done through the async Tapis transfer endpoint.

## UI
![image](https://github.com/user-attachments/assets/20d78a3e-15e4-422a-b9da-88bb14dd3864)



## Notes

