### PR TITLE
DRP PPRD Host BURP Scan Fixes

### DIFF
--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -48,6 +48,11 @@ SESSION_COOKIE_AGE = 24*60*60*7  # the number of seconds for only 7 for example
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 # whether the session cookie should be secure (https:// only)
 SESSION_COOKIE_SECURE = True
+# Stop the browser from submitting the cookie in any requests that use an unencrypted HTTP connection.
+CSRF_COOKIE_SECURE = True
+# Prevent the cookie's value from being read or set by client-side JavaScript.
+CSRF_COOKIE_HTTPONLY = True
+#
 CSRF_COOKIE_SAMESITE = 'Strict'
 # for local testing
 CSRF_TRUSTED_ORIGINS = getattr(settings_custom, '_CSRF_TRUSTED_ORIGINS', [])


### PR DESCRIPTION
## Overview

Fixes for two items found in DRP PPRD BURP Security Scan. 

## Related

* [WP-XYZ](https://tacc-main.atlassian.net/browse/WP-XYZ)

## Changes

- Sets the following values to `True`:
- CSRF_COOKIE_SECURE
- CSRF_COOKIE_HTTPONLY

## Testing

1. Look at codebase and see configs in `settings.py`.

## UI

1. No visible test.

## Notes

1. Will require a fresh BURP Scan of the PPRD host to verify these changes resolved issue.
2. These changes will need too get pushed back up into `Core-Portal:main` to properly configure existing and future portals for vulnerability scans.

