### PR TITLE
task/WA-392: use portal archive sys and path defaults; use parameterSet notes.label

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -247,7 +247,8 @@ export const AppSchemaForm = ({ app }) => {
     hasStorageSystems,
     downSystems,
     execSystem,
-    defaultSystem,
+    defaultSystemId,
+    defaultArchivePath,
     keyService,
     allocationToExecSysMap,
   } = useSelector((state) => {
@@ -255,7 +256,7 @@ export const AppSchemaForm = ({ app }) => {
       app,
       state.allocations
     );
-    const { defaultHost, configuration, defaultSystem } = state.systems.storage;
+    const { defaultHost, configuration, defaultSystemId } = state.systems.storage;
     const keyService = pushKeysSystem?.defaultAuthnMethod === 'TMS_KEYS';
 
     const hasCorral =
@@ -263,6 +264,11 @@ export const AppSchemaForm = ({ app }) => {
       ['corral.tacc.utexas.edu', 'data.tacc.utexas.edu'].some((s) =>
         defaultHost?.endsWith(s)
       );
+    const defaultSystem = configuration.find(
+      (system) => system.id === defaultSystemId
+    ) || configuration[0]
+    const defaultArchivePath = `${defaultSystem?.homeDir || '$WORK'}/tapis-jobs-archive/${'${JobCreateDate}'}/${'${JobName}-${JobUUID}'}`;
+
     return {
       allocations: getAllocationList(
         app,
@@ -288,7 +294,8 @@ export const AppSchemaForm = ({ app }) => {
           app,
           allocationToExecSysMap.get(state.allocations.portal_alloc) ?? []
         ) ?? '',
-      defaultSystem,
+      defaultSystemId,
+      defaultArchivePath,
       keyService,
       allocationToExecSysMap,
     };
@@ -352,8 +359,8 @@ export const AppSchemaForm = ({ app }) => {
     coresPerNode: app.definition.jobAttributes.coresPerNode,
     maxMinutes: app.definition.jobAttributes.maxMinutes,
     archiveSystemId:
-      app.definition.jobAttributes.archiveSystemId || defaultSystem,
-    archiveSystemDir: app.definition.jobAttributes.archiveSystemDir,
+    defaultSystemId || app.definition.jobAttributes.archiveSystemId,
+    archiveSystemDir: defaultArchivePath || app.definition.jobAttributes.archiveSystemDir,
     archiveOnAppError: true,
     appId: app.definition.id,
     appVersion: app.definition.version,
@@ -552,8 +559,8 @@ export const AppSchemaForm = ({ app }) => {
               maxMinutes: getMaxMinutesValidation(queue, app).required(
                 'Required max minutes'
               ),
-              archiveSystemId: Yup.string(),
-              archiveSystemDir: Yup.string(),
+              archiveSystemId: Yup.string().notRequired(),
+              archiveSystemDir: Yup.string().notRequired(),
               allocation: isJobTypeBATCH(app)
                 ? getAllocationValidation(allocations).test(
                     'exec-systems-check',
@@ -903,7 +910,7 @@ export const AppSchemaForm = ({ app }) => {
                         name="archiveSystemId"
                         type="text"
                         placeholder={
-                          app.definition.archiveSystemId || defaultSystem
+                          defaultSystemId || app.definition.archiveSystemId
                         }
                       />
                       <FormField
@@ -912,8 +919,9 @@ export const AppSchemaForm = ({ app }) => {
                         name="archiveSystemDir"
                         type="text"
                         placeholder={
-                          app.definition.archiveSystemDir ||
-                          'HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}'
+                          defaultArchivePath ||
+                          app.definition.archiveSystemDir
+
                         }
                       />
                     </>

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -256,7 +256,8 @@ export const AppSchemaForm = ({ app }) => {
       app,
       state.allocations
     );
-    const { defaultHost, configuration, defaultSystemId } = state.systems.storage;
+    const { defaultHost, configuration, defaultSystemId } =
+      state.systems.storage;
     const keyService = pushKeysSystem?.defaultAuthnMethod === 'TMS_KEYS';
 
     const hasCorral =
@@ -264,10 +265,12 @@ export const AppSchemaForm = ({ app }) => {
       ['corral.tacc.utexas.edu', 'data.tacc.utexas.edu'].some((s) =>
         defaultHost?.endsWith(s)
       );
-    const defaultSystem = configuration.find(
-      (system) => system.id === defaultSystemId
-    ) || configuration[0]
-    const defaultArchivePath = `${defaultSystem?.homeDir || '$WORK'}/tapis-jobs-archive/${'${JobCreateDate}'}/${'${JobName}-${JobUUID}'}`;
+    const defaultSystem =
+      configuration.find((system) => system.id === defaultSystemId) ||
+      configuration[0];
+    const defaultArchivePath = `${
+      defaultSystem?.homeDir || '$WORK'
+    }/tapis-jobs-archive/${'${JobCreateDate}'}/${'${JobName}-${JobUUID}'}`;
 
     return {
       allocations: getAllocationList(
@@ -359,8 +362,9 @@ export const AppSchemaForm = ({ app }) => {
     coresPerNode: app.definition.jobAttributes.coresPerNode,
     maxMinutes: app.definition.jobAttributes.maxMinutes,
     archiveSystemId:
-    defaultSystemId || app.definition.jobAttributes.archiveSystemId,
-    archiveSystemDir: defaultArchivePath || app.definition.jobAttributes.archiveSystemDir,
+      defaultSystemId || app.definition.jobAttributes.archiveSystemId,
+    archiveSystemDir:
+      defaultArchivePath || app.definition.jobAttributes.archiveSystemDir,
     archiveOnAppError: true,
     appId: app.definition.id,
     appVersion: app.definition.version,
@@ -919,9 +923,7 @@ export const AppSchemaForm = ({ app }) => {
                         name="archiveSystemDir"
                         type="text"
                         placeholder={
-                          defaultArchivePath ||
-                          app.definition.archiveSystemDir
-
+                          defaultArchivePath || app.definition.archiveSystemDir
                         }
                       />
                     </>

--- a/client/src/components/Applications/AppForm/AppForm.test.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.test.jsx
@@ -252,7 +252,7 @@ describe('AppSchemaForm', () => {
           errorMessage: null,
           loading: false,
           defaultHost: '',
-          defaultSystem: '',
+          defaultSystemId: '',
         },
         definitions: {
           list: [],

--- a/client/src/components/Applications/AppForm/AppFormSchema.js
+++ b/client/src/components/Applications/AppForm/AppFormSchema.js
@@ -43,7 +43,7 @@ const FormSchema = (app) => {
         }
 
         const field = {
-          label: param.name ?? param.key,
+          label: param.notes?.label ?? param.name ?? param.key,
           description: param.description,
           required: param.inputMode === 'REQUIRED',
           readOnly: param.inputMode === 'FIXED',

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
@@ -442,7 +442,7 @@ export const helloWorldAppSubmissionPayloadFixture = {
     maxMinutes: 10,
     archiveSystemId: 'frontera',
     archiveSystemDir:
-      '/home/username//tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
+      '/home/username/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
     archiveOnAppError: true,
     appId: 'hello-world',
     appVersion: '0.0.1',

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
@@ -28,7 +28,7 @@ export const helloWorldAppFixture = {
       execSystemLogicalQueue: 'development',
       archiveSystemId: 'frontera',
       archiveSystemDir:
-        'HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
+        '/home/username//tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
       archiveOnAppError: true,
       isMpi: false,
       mpiCmd: null,
@@ -442,7 +442,7 @@ export const helloWorldAppSubmissionPayloadFixture = {
     maxMinutes: 10,
     archiveSystemId: 'frontera',
     archiveSystemDir:
-      'HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
+      '/home/username//tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}',
     archiveOnAppError: true,
     appId: 'hello-world',
     appVersion: '0.0.1',

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -84,7 +84,7 @@ const systemsFixture = {
     //errorMessage: null,
     //loading: false,
     defaultHost: 'frontera.tacc.utexas.edu',
-    defaultSystem: 'frontera',
+    defaultSystemId: 'frontera',
   },
   // This definitions is required for the tests, some can be removed. Referencing datafiles.reducers.js
   definitions: {

--- a/client/src/components/DataFiles/tests/DataFiles.test.jsx
+++ b/client/src/components/DataFiles/tests/DataFiles.test.jsx
@@ -95,7 +95,7 @@ describe('DataFiles', () => {
           errorMessage: null,
           loading: false,
           defaultHost: 'cloud.corral.tacc.utexas.edu',
-          defaultSystem: 'cloud.data',
+          defaultSystemId: 'cloud.data',
         },
         definitions: {
           list: [],

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -5,7 +5,7 @@ export const initialSystemState = {
     errorMessage: null,
     loading: false,
     defaultHost: '',
-    defaultSystem: '',
+    defaultSystemId: '',
   },
   definitions: {
     list: [],
@@ -41,7 +41,7 @@ export function systems(state = initialSystemState, action) {
           ...state.storage,
           configuration: action.payload.system_list,
           defaultHost: action.payload.default_host,
-          defaultSystem: action.payload.default_system,
+          defaultSystemId: action.payload.default_system_id,
           loading: false,
         },
       };

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -51,10 +51,10 @@ class SystemListingView(BaseApiView):
 
             default_system = settings.PORTAL_DATAFILES_DEFAULT_STORAGE_SYSTEM or settings.PORTAL_DATAFILES_STORAGE_SYSTEMS[0]
             if default_system:
-                system_id = default_system.get('system')
-                system_def = request.user.tapis_oauth.client.systems.getSystem(systemId=system_id, select='host')
+                default_system_id = default_system.get('system')
+                system_def = request.user.tapis_oauth.client.systems.getSystem(systemId=default_system_id, select='host')
                 response['default_host'] = system_def.host
-                response['default_system'] = system_id
+                response['default_system_id'] = default_system_id
         else:
             response['system_list'] = [sys for sys in portal_systems if sys['scheme'] == 'public']
 

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -422,7 +422,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
     response = client.get('/api/datafiles/systems/list/')
     assert response.json() == {
         "default_host": "cloud.data.tacc.utexas.edu",
-        "default_system": "cloud.data",
+        "default_system_id": "cloud.data",
         "system_list": [
             {
                 'name': 'My Data (Work)',


### PR DESCRIPTION
## Overview

- By default, use the portal's `PORTAL_DATAFILES_DEFAULT_STORAGE_SYSTEM` setting value to set the `archiveSystemId` and `archiveSystemDir`
- Add's support for the `notes.label` field of app parameter fields.

## Related

* [WA-392](https://tacc-main.atlassian.net/browse/WA-392)

## Testing

1. Go to https://cep.test/workbench/applications/opensees-sp-v35?appVersion=0.0.1 and confirm the default archive settings are those of the portal
2. Go to https://cep.test/workbench/applications/jupyter-hpc-native?appVersion=frontera and confirm the environment label is rendering

## UI

![Screenshot 2025-03-27 at 2 39 59 PM](https://github.com/user-attachments/assets/222b7087-651b-4e2b-a65d-535fdb6557cd)
![Screenshot 2025-03-27 at 2 45 01 PM](https://github.com/user-attachments/assets/d848e829-fbd8-4691-a133-df01a7d9c023)
