### PR TITLE
add button to download published DRP datasets

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModals.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModals.jsx
@@ -21,6 +21,7 @@ import DataFilesNoFoldersModal from './DataFilesNoFoldersModal';
 import './DataFilesModals.scss';
 import DataFilesFormModal from './DataFilesFormModal';
 import DataFilesPublicationRequestModal from './DataFilesPublicationRequestModal';
+import DataFilesPublicationDownloadModal from './DataFilesPublicationDownloadModal';
 import DataFilesProjectTreeModal from './DataFilesProjectTreeModal';
 import DataFilesProjectDescriptionModal from './DataFilesProjectDescriptionModal';
 import DataFilesViewDataModal from './DataFilesViewDataModal';
@@ -50,6 +51,7 @@ export default function DataFilesModals() {
       <DataFilesFormModal />
       <DataFilesProjectTreeModal />
       <DataFilesPublicationRequestModal />
+      <DataFilesPublicationDownloadModal />
       <DataFilesProjectDescriptionModal />
       <DataFilesViewDataModal />
       <DataFilesProjectCitationModal />

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPublicationDownloadModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPublicationDownloadModal.jsx
@@ -1,0 +1,97 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { Button, DescriptionList, LoadingSpinner, Message } from '_common';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+import styles from './DataFilesPublicationRequestModal.module.scss';
+import { formatDate, formatDateTime } from 'utils/timeFormat';
+import { useFileDetail, useModal } from 'hooks/datafiles';
+
+export function toBytes(bytes) {
+  if (bytes === 0) return '0 bytes';
+  if (!bytes) return '-';
+  const units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
+  const orderOfMagnitude = Math.floor(Math.log(bytes) / Math.log(1024));
+  const precision = orderOfMagnitude === 0 ? 0 : 1;
+  const bytesInUnits = bytes / Math.pow(1024, orderOfMagnitude);
+  return `${bytesInUnits.toFixed(precision)} ${units[orderOfMagnitude]}`;
+}
+
+const DataFilesPublicationDownloadModal = () => {
+  const dispatch = useDispatch();
+  const { toggle: toggleModal, getStatus, getProps } = useModal();
+  const { projectId, system } = getProps('publicationDownload') || {};
+  const archiveProjectId = (projectId ?? '').split('published.')[1];
+
+  const isOpen = getStatus('publicationDownload') ?? false;
+
+  const toggle = useCallback(() => {
+    toggleModal({ operation: 'publicationDownload', props: {} });
+  }, []);
+
+  const archivePath = `/archive/${archiveProjectId}/${archiveProjectId}_archive.zip`;
+  const { isLoading, isError, data } = useFileDetail(
+    'tapis',
+    system,
+    'public',
+    archivePath,
+    isOpen
+  );
+  const archiveSize = data?.length ?? 0;
+  const maxFileSize = 2 * 1024 * 1024 * 1024;
+  useEffect(() => {
+    if (isOpen && archiveSize > maxFileSize) {
+      toggleModal({ operation: 'largeDownload' });
+      toggleModal({ operation: 'publicationDownload', props: {} });
+    }
+  }, [archiveSize, maxFileSize]);
+
+  const downloadFile = () => {
+    dispatch({
+      type: 'DATA_FILES_DOWNLOAD',
+      payload: { file: { system, path: archivePath } },
+    });
+  };
+
+  return (
+    <>
+      <Modal
+        size="lg"
+        isOpen={isOpen}
+        toggle={toggle}
+        className={styles['modal-dialog']}
+      >
+        <ModalHeader toggle={toggle} charCode="&#xe912;">
+          Download Publication {archiveProjectId}
+        </ModalHeader>
+        <ModalBody>
+          {isError && (
+            <Message type="error">
+              The requested data could not be accessed.
+            </Message>
+          )}
+          {isLoading && <LoadingSpinner />}
+          {!!data && !isLoading && !isError && (
+            <>
+              <p>
+                This download is a ZIP file of the complete project dataset. The
+                size of the ZIP file is <strong>{toBytes(data?.length)}</strong>
+                .
+              </p>
+              <p
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <Button onClick={downloadFile}>Download</Button>
+              </p>
+            </>
+          )}
+        </ModalBody>
+      </Modal>
+    </>
+  );
+};
+
+export default DataFilesPublicationDownloadModal;

--- a/client/src/components/Publications/PublicationDetailPublicView.jsx
+++ b/client/src/components/Publications/PublicationDetailPublicView.jsx
@@ -11,6 +11,7 @@ import DataFilesProjectFileListing from '../DataFiles/DataFilesProjectFileListin
 import DataFilesToolbar from '../DataFiles/DataFilesToolbar/DataFilesToolbar';
 import NotificationToast from '../Toasts';
 import DataFilesLargeDownloadModal from '../DataFiles/DataFilesModals/DataFilesLargeDownloadModal';
+import DataFilesPublicationDownloadModal from '../DataFiles/DataFilesModals/DataFilesPublicationDownloadModal';
 
 function PublicationDetailPublicView({ params }) {
   return (
@@ -45,6 +46,7 @@ function PublicationDetailPublicView({ params }) {
       <DataFilesViewDataModal />
       <DataFilesCopyModal />
       <DataFilesLargeDownloadModal />
+      <DataFilesPublicationDownloadModal />
     </div>
   );
 }

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingAddon/DataFilesProjectFileListingAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingAddon/DataFilesProjectFileListingAddon.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button } from '_common';
 import { useDispatch, useSelector } from 'react-redux';
 import styles from './DataFilesProjectFileListingAddon.module.scss';
-import { useSelectedFiles, useSystems } from 'hooks/datafiles';
+import { useModal, useSelectedFiles, useSystems } from 'hooks/datafiles';
 import useDrpDatasetModals from '../utils/hooks/useDrpDatasetModals';
 import { Link } from 'react-router-dom';
 import * as ROUTES from '../../../../constants/routes';
@@ -24,6 +24,8 @@ const DataFilesProjectFileListingAddon = ({ rootSystem, system }) => {
     createPublicationAuthorsModal,
   } = useDrpDatasetModals(projectId, portalName);
 
+  const { toggle: toggleModal } = useModal();
+
   const createPublicationRequestModal = () => {
     dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',
@@ -33,6 +35,12 @@ const DataFilesProjectFileListingAddon = ({ rootSystem, system }) => {
       },
     });
   };
+
+  const togglePublicationDownloadModal = () =>
+    toggleModal({
+      operation: 'publicationDownload',
+      props: { projectId, system, metadata },
+    });
 
   const { canEditDataset, canRequestPublication, canReviewPublication } =
     useSelector((state) => {
@@ -196,6 +204,14 @@ const DataFilesProjectFileListingAddon = ({ rootSystem, system }) => {
           <span className={styles.separator}>|</span>
           <Button type="link" onClick={createPublicationRequestModal}>
             View Publication Requests
+          </Button>
+        </>
+      )}
+      {isPublicationSystem(rootSystem) && (
+        <>
+          <span className={styles.separator}>|</span>
+          <Button type="link" onClick={togglePublicationDownloadModal}>
+            Download Dataset
           </Button>
         </>
       )}

--- a/client/src/hooks/datafiles/index.js
+++ b/client/src/hooks/datafiles/index.js
@@ -4,3 +4,4 @@ export { default as useFileListing } from './useFileListing';
 export { default as useAddonComponents } from './useAddonComponents';
 export { default as useSystems } from './useSystems';
 export { default as useModal } from './useModal';
+export { default as useFileDetail } from './useFileDetail';

--- a/client/src/hooks/datafiles/useFileDetail.ts
+++ b/client/src/hooks/datafiles/useFileDetail.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from 'utils/apiClient';
+import { TTapisFile } from 'utils/types';
+
+async function getFileDetail(
+  api: string,
+  system: string,
+  path: string,
+  scheme: string = 'private',
+  { signal }: { signal: AbortSignal }
+) {
+  const res = await apiClient.get<{ data: TTapisFile }>(
+    `/api/datafiles/${api}/detail/${scheme}/${system}/${path}`,
+    { signal }
+  );
+  return res.data.data;
+}
+
+function useFileDetail(
+  api: string,
+  system: string,
+  scheme: string,
+  path: string,
+  enabled: boolean = true
+) {
+  return useQuery({
+    queryKey: ['datafiles', 'fileListing', 'detail', api, scheme, system, path],
+    queryFn: ({ signal }) =>
+      getFileDetail(api, system, path, scheme, { signal }),
+    enabled: !!path && enabled,
+    retry: false,
+  });
+}
+
+export default useFileDetail;

--- a/server/portal/apps/datafiles/handlers/tapis_handlers.py
+++ b/server/portal/apps/datafiles/handlers/tapis_handlers.py
@@ -6,11 +6,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 allowed_actions = {
-    'private': ['listing', 'search', 'copy', 'download', 'mkdir',
+    'private': ['listing', 'search', 'copy', 'download', 'mkdir', 'detail',
                 'move', 'rename', 'trash', 'preview', 'upload', 'makepublic', 'delete'],
-    'public': ['listing', 'search', 'copy', 'download', 'preview'],
-    'community': ['listing', 'search', 'copy', 'download', 'preview'],
-    'projects': ['listing', 'search', 'copy', 'download', 'mkdir',
+    'public': ['listing', 'search', 'copy', 'download', 'preview', 'detail'],
+    'community': ['listing', 'search', 'copy', 'download', 'preview', 'detail'],
+    'projects': ['listing', 'search', 'copy', 'download', 'mkdir', 'detail',
                  'move', 'rename', 'trash', 'preview', 'upload', 'makepublic', 'update_metadata']
 }
 


### PR DESCRIPTION
## Overview
Add a button to download the ZIP archive of a DRP publication.
## Related

* [WC-245](https://tacc-main.atlassian.net/browse/WC-245)

## Changes



## Testing

1. Look at a publication (either in Data files or in the unauthenticated public view) and click "Download Dataset" in the top right
2. Check that a GET request is fired for details about `/archive/{PROJECT_ID}/{PROJECT_ID}_archive.zip/`. You will probably see an error at this point since most publications have not been archived yet.

## UI

<img width="324" alt="image" src="https://github.com/user-attachments/assets/59539570-83f6-43b9-aa4a-d7440244ba10" />
<img width="820" alt="image" src="https://github.com/user-attachments/assets/eed3a2c3-8f27-43c7-ac41-f813cbd9a539" />



## Notes

