### PR TITLE
Task/WC-239: Dataset form fixes

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesFormModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesFormModal.jsx
@@ -79,7 +79,7 @@ const DataFilesFormModal = () => {
 
       if (field.type === 'link') {
         schema[field.name] = (schema[field.name] || Yup.string())
-          .url(`${field.label} must be a valid URL`)
+          .url(`${field.label} must be a valid URL starting with https://...`)
           .matches(/^https:\/\//, `${field.label} must start with https://`);
       }
 

--- a/client/src/components/_custom/drp/DataFilesProjectEditDescriptionModalAddon/DataFilesProjectEditDescriptionModalAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectEditDescriptionModalAddon/DataFilesProjectEditDescriptionModalAddon.jsx
@@ -68,7 +68,9 @@ const DataFilesProjectEditDescriptionModalAddon = ({ setValidationSchema }) => {
             field.fields.reduce((subAcc, subField) => {
               if (subField.type === 'link') {
                 subAcc[subField.name] = (subAcc[subField.name] || Yup.string())
-                  .url(`${subField.label} must be a valid URL`)
+                  .url(
+                    `${subField.label} must be a valid URL starting with https://...`
+                  )
                   .matches(
                     /^https:\/\//,
                     `${subField.label} must start with https://`
@@ -93,7 +95,7 @@ const DataFilesProjectEditDescriptionModalAddon = ({ setValidationSchema }) => {
         if (field.type === 'link') {
           acc[field.name] = (acc[field.name] || Yup.string())
             .required(`${field.label} is required`)
-            .url(`${field.label} must be a valid URL`)
+            .url(`${field.label} must be a valid URL starting with https://...`)
             .matches(/^https:\/\//, `${field.label} must start with https://`);
         }
       }

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataAddon/DataFilesProjectFileListingMetadataAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataAddon/DataFilesProjectFileListingMetadataAddon.jsx
@@ -57,8 +57,8 @@ const DataFilesProjectFileListingMetadataAddon = ({
   const getProjectModalMetadata = (metadata) => {
     const fields = [
       'related_publications',
-      'related_software',
       'related_datasets',
+      'related_software',
     ];
     return fields.reduce((formattedMetadata, field) => {
       if (metadata[field] && metadata[field].length > 0) {


### PR DESCRIPTION
## Overview
- explain in validation that URLs must start with https://
- render related datasets before software in the modal to keep things consistent.


## Related

* [WC-239](https://tacc-main.atlassian.net/browse/WC-239)


