### PR TITLE
bug/WA-442: Fix apps listing

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -3,7 +3,7 @@
 ---
 services:
   cms:
-    image: taccwma/core-cms:v4.26.1
+    image: taccwma/core-cms:v4.25.2
     volumes:
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -1,10 +1,9 @@
 # This compose file is useful for testing https.
 # The .env file sets ENVVARS for the Docker CLI used by this compose file.
 ---
-version: "3.8"
 services:
   cms:
-    image: taccwma/core-cms:v4.25.2
+    image: taccwma/core-cms:v4.26.1
     volumes:
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini


### PR DESCRIPTION
## Overview

- Fixes an issue with apps not appearing in the apps listing due to the default limit being `100`
- Fixes an issue with the app matching logic to display apps in the portal

## Related

* [WA-442](https://tacc-main.atlassian.net/browse/WA-442)

## Testing

1. Add a new app with app id `jupyter-hpc-native` to the apps tray, and confirm it appears in your apps workbench listing. On `main` branch, it will not appear.

