### PR TITLE
feat(cms): update from pinned tag to latest tag

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -3,7 +3,7 @@
 ---
 services:
   cms:
-    image: taccwma/core-cms:v4.25.2
+    image: taccwma/core-cms:latest
     volumes:
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini


### PR DESCRIPTION
## Overview / Changes

Pin CMS to latest.

_I will start to tag `latest` (i.e. build `main`) when I release new CMS versions._

<details>

I learned that if I build `main`, then image is tagged `latest`  **and** as the latest version. So, I will build `main` knowing that it updates Core-Portal local dev.

</details>

## Testing

1. Create **fresh** Portal with **fresh** CMS.
2. Verify no need to #1096.

> [!NOTE]
> If login to CMS gives "CSRF verification failed.", blame [WP-897](https://tacc-main.atlassian.net/browse/WP-897) not this PR.

## UI

Skipped.