### PR TITLE
bug/WA-451: Prevent 'my apps' listing from showing every version of each app

### DIFF
--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -519,7 +519,7 @@ class AppsTrayView(BaseApiView):
         # Only shows enabled versions of apps
         apps_listing = tapis.apps.getApps(
             select="version,id,notes",
-            search="(versionEnabled.eq.true)~(enabled.eq.true)~(version.like.*)",
+            search="(versionEnabled.eq.true)~(enabled.eq.true)",
             listType="MINE",
             limit=-1,
         )


### PR DESCRIPTION
## Overview

Fixes an issue where the 'My Apps' listing was showing every version of every app in the workspace.

## Related

* [WA-451](https://tacc-main.atlassian.net/browse/WA-451)

## Testing

1. Compare the "My Apps" listing between this branch and main, and confirm this branch has no duplicate entries (showing each version of each app shared with you or created by you, and only shows the latest)

