### PR TITLE
hotfix/WP-949: fix unit tests

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesDownloadMessageModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesDownloadMessageModal.jsx
@@ -28,8 +28,6 @@ const DataFilesDownloadMessageModal = () => {
       })),
     shallowEqual
   );
-  const selected = useMemo(() => selectedFiles, [isOpen]);
-  const formRef = React.useRef();
 
   const onClosed = () => {
     dispatch({ type: 'DATA_FILES_MODAL_CLOSE' });
@@ -61,11 +59,11 @@ const DataFilesDownloadMessageModal = () => {
     });
   };
 
-  const compressCallback = () => {
-    const { filenameDisplay, compressionType } = formRef.current.values;
+  const compressCallback = ({ filenameDisplay, compressionType }) => {
     let containsFolder = false;
     let totalFileSize = 0;
     const maxFileSize = 2 * 1024 * 1024 * 1024;
+
     // Add up the file sizes of all files and shows if the user selected a folder
     for (let i = 0; i < selectedFiles.length; i++) {
       totalFileSize = totalFileSize + selectedFiles[i].length;
@@ -73,6 +71,7 @@ const DataFilesDownloadMessageModal = () => {
         containsFolder = true;
       }
     }
+
     // Run the dispatch if the user does not select any folders...
     if (containsFolder === false) {
       // ...and if the total file size is below 2 GB
@@ -128,7 +127,6 @@ const DataFilesDownloadMessageModal = () => {
         Download
       </ModalHeader>
       <Formik
-        innerRef={formRef}
         initialValues={initialValues}
         validationSchema={validationSchema}
         onSubmit={compressCallback}

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.fixture.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.fixture.js
@@ -43,7 +43,8 @@ const DataFilesDownloadMessageModalFixture = {
         },
         {
           name: 'testFolder',
-          type: 'folder',
+          format: 'folder',
+          type: 'dir',
           path: '/testFolder',
           id: 789,
         },

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
@@ -106,11 +106,6 @@ describe('DataFilesDownloadMessageModal', () => {
       <DataFilesDownloadMessageModal />,
       mockStore({
         ...DataFilesDownloadMessageModalFixture,
-        allocations: {
-          /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
-          portal_alloc: '',
-          active: [],
-        },
         files: {
           ...DataFilesDownloadMessageModalFixture.files,
           selected: { FilesListing: [1, 2, 3] },
@@ -154,11 +149,6 @@ describe('DataFilesDownloadMessageModal', () => {
         // Create the store
         mockStore({
           ...DataFilesDownloadMessageModalFixture,
-          allocations: {
-            /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
-            portal_alloc: '',
-            active: [],
-          },
           files: {
             ...DataFilesDownloadMessageModalFixture.files,
             selected: { FilesListing: [3] },
@@ -201,11 +191,7 @@ describe('DataFilesDownloadMessageModal', () => {
         <DataFilesDownloadMessageModal />,
         mockStore({
           ...DataFilesDownloadMessageModalFixture,
-          allocations: {
-            /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
-            portal_alloc: '',
-            active: [],
-          },
+
         })
       );
 

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
@@ -64,11 +64,6 @@ describe('DataFilesDownloadMessageModal', () => {
 
     const store = mockStore({
       ...DataFilesDownloadMessageModalFixture,
-      allocations: {
-        /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
-        portal_alloc: '',
-        active: [],
-      },
       files: {
         ...DataFilesDownloadMessageModalFixture.files,
         selected: { FilesListing: [4] } /*single folder*/,

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
@@ -7,45 +7,53 @@ import DataFilesDownloadMessageModal from '../DataFilesDownloadMessageModal';
 import { compressAppFixture } from './DataFilesCompressModal.fixture';
 import { fireEvent, screen, waitFor, renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
-import { getAppUtil } from 'hooks/datafiles/mutations/toolbarAppUtils';
+import '@testing-library/jest-dom';
 
-vi.mock('@tanstack/react-query');
-vi.mock('hooks/datafiles/mutations/toolbarAppUtils');
+vi.mock('hooks/datafiles/mutations/toolbarAppUtils', async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...actual, // keep `getDefaultAllocation`
+    getAppUtil: vi.fn().mockResolvedValue({
+      id: 'compress',
+      version: '0.0.1',
+      definition: {
+        jobAttributes: {
+          execSystemId: 'frontera',
+        },
+      },
+    }),
+  };
+});
+
 const mockStore = configureStore();
-
-// Establish a boolean that checks for a folder among selectedFiles
-let containsFolder = false;
-// Create test files for all tests
 
 describe('DataFilesDownloadMessageModal', () => {
   beforeEach(async () => {
     // Clear all mocks before each test
     vi.clearAllMocks();
-
-    getAppUtil.mockResolvedValue(compressAppFixture);
-    useQuery.mockReturnValue({ data: compressAppFixture });
-
-    const { result } = renderHook(() => useQuery('compress-app', getAppUtil));
-    await waitFor(() => result.current.isSuccess);
   });
 
   it('renders the data files download message modal', async () => {
-    const store = mockStore(DataFilesDownloadMessageModalFixture);
+    const foo = {};
+    const store = mockStore({
+      ...DataFilesDownloadMessageModalFixture,
+      allocations: {
+        portal_alloc: '',
+        active: [],
+      } /*TODO fix DataFilesDownloadMessageModalFixture fixture*/,
+    });
+
     const { findAllByText } = renderComponent(
       <DataFilesDownloadMessageModal />,
       store
     );
 
-    await waitFor(() =>
-      expect(
-        findAllByText(
-          /Folders and multiple files must be compressed before downloading./
-        )
-      ).toBeDefined()
-    );
+    await waitFor(async () => {
+      await screen.findByText('Download');
+    });
   });
 
-  // Test to prevent folder downloads
   it('checks for a folder among the selected files', async () => {
     // Mock the dispatch call
     const mockDispatch = vi.fn();
@@ -53,39 +61,45 @@ describe('DataFilesDownloadMessageModal', () => {
     vi.spyOn(require('react-redux'), 'useDispatch').mockReturnValue(
       mockDispatch
     );
-    // Render the Download Message Modal
-    const { getByText } = renderComponent(
-      <DataFilesDownloadMessageModal />,
-      // Create the store
-      mockStore({
-        ...DataFilesDownloadMessageModalFixture,
-        files: {
-          ...DataFilesDownloadMessageModalFixture.files,
-          selected: { FilesListing: [4] },
-        },
-      })
-    );
-    // Click on the Compress button to try and download the folder
-    fireEvent.click(getByText('Compress'));
-    // Wait for the No Folders Modal
-    await waitFor(() => screen.queryByText('No Folders'));
-    // Assign the No Folders Modal to a variable
-    const testModal = screen.queryByText('No Folders');
-    // Test for the containsFolder boolean to be true
-    expect(containsFolder).toBeTruthy;
-    // Test for the Large Download Modal
-    expect(testModal).toBeDefined();
-    // Test for the dispatch call
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'DATA_FILES_TOGGLE_MODAL',
-      payload: {
-        operation: 'largeDownload',
-        props: {},
+
+    const store = mockStore({
+      ...DataFilesDownloadMessageModalFixture,
+      allocations: {
+        /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+        portal_alloc: '',
+        active: [],
       },
+      files: {
+        ...DataFilesDownloadMessageModalFixture.files,
+        selected: { FilesListing: [4] } /*single folder*/,
+      },
+    });
+
+    // Render the Download Message Modal
+    renderComponent(<DataFilesDownloadMessageModal />, store);
+
+    // Wait for modal content
+    const warningMessage = await screen.findByText(
+      /Folders and multiple files must be compressed before downloading./
+    );
+    expect(warningMessage).toBeInTheDocument();
+
+    // Click on the Compress button to try and download the folder
+    const compressButton = await screen.findByText('Compress');
+    fireEvent.click(compressButton);
+
+    await waitFor(() => {
+      // Test for the dispatch call that would toggle a different modal
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'DATA_FILES_TOGGLE_MODAL',
+        payload: {
+          operation: 'noFolders',
+          props: {},
+        },
+      });
     });
   });
 
-  // Test to prevent the compression of multiple files if their total size is greater than 2 GB
   it('prevents the compression of multiple files that total more than 2 GB in size', async () => {
     // Mock the dispatch call
     const mockDispatch = vi.fn();
@@ -93,97 +107,125 @@ describe('DataFilesDownloadMessageModal', () => {
     vi.spyOn(require('react-redux'), 'useDispatch').mockReturnValue(
       mockDispatch
     );
-    const { getByText } = renderComponent(
+    renderComponent(
       <DataFilesDownloadMessageModal />,
       mockStore({
         ...DataFilesDownloadMessageModalFixture,
+        allocations: {
+          /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+          portal_alloc: '',
+          active: [],
+        },
         files: {
           ...DataFilesDownloadMessageModalFixture.files,
-          selected: { FilesListing: [1, 2] },
+          selected: { FilesListing: [1, 2, 3] },
         },
       })
     );
-    // Click on the Compress button to try and download the file
-    fireEvent.click(getByText('Compress'));
-    // Wait for the Large Download Modal
-    await waitFor(() => screen.queryByText('Large Download'));
-    // Assign the Large Download Modal to a variable
-    const testModal = screen.queryByText('Large Download');
-    // Test for the Large Download Modal
-    expect(testModal).toBeDefined();
-    // Test for the dispatch call
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'DATA_FILES_TOGGLE_MODAL',
-      payload: {
-        operation: 'largeDownload',
-        props: {},
-      },
+
+    // Wait for modal content
+    const warningMessage = await screen.findByText(
+      /Folders and multiple files must be compressed before downloading./
+    );
+    expect(warningMessage).toBeInTheDocument();
+
+    // Click on the Compress button to try and download the large files
+    const compressButton = await screen.findByText('Compress');
+    fireEvent.click(compressButton);
+
+    await waitFor(() => {
+      // Test for the dispatch call that would toggle a different modal for large files downloading
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'DATA_FILES_TOGGLE_MODAL',
+        payload: {
+          operation: 'largeDownload',
+          props: {},
+        },
+      });
     });
   });
 
-  // Test to allow the compression/download of one or more files totaling less than 2 GB
   it('allows direct file downloads when the file size is below 2 GB'),
-    () => {
+    async () => {
       // Mock the dispatch action
       const mockDispatch = vi.fn();
       // Create a spy that watches for the dispatch call
       vi.spyOn(require('react-redux'), 'useDispatch').mockReturnValue(
         mockDispatch
       );
-      // Render the Download Message Modal
-      const { getByText } = renderComponent(
+
+      renderComponent(
         <DataFilesDownloadMessageModal />,
         // Create the store
         mockStore({
           ...DataFilesDownloadMessageModalFixture,
+          allocations: {
+            /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+            portal_alloc: '',
+            active: [],
+          },
           files: {
             ...DataFilesDownloadMessageModalFixture.files,
             selected: { FilesListing: [3] },
           },
         })
       );
+
+      const compressButton = await screen.findByText('Compress');
+      fireEvent.click(compressButton);
+
       // Click on the Compress button to try and download the folder
       fireEvent.click(getByText('Compress'));
-      // Test for the dispatch call
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'DATA_FILES_COMPRESS',
-        payload: {
-          file: {
-            name: 'tests.txt',
-            type: 'file',
-            length: testFileSize2,
-            path: '/test3.txt',
-            id: 234,
+
+      await waitFor(() => {
+        // Test for the dispatch call
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'DATA_FILES_COMPRESS',
+          payload: {
+            file: {
+              name: 'tests.txt',
+              type: 'file',
+              length: testFileSize2,
+              path: '/test3.txt',
+              id: 234,
+            },
           },
-        },
+        });
       });
     };
 
-  // Test to toggle modals correctly
-  it('toggles modals correctly'),
-    () => {
+  it('toggles modal correctly'),
+    async () => {
       // Mock the dispatch action
       const mockDispatch = vi.fn();
       // Create a spy that watches for the dispatch call
       vi.spyOn(require('react-redux'), 'useDispatch').mockReturnValue(
         mockDispatch
       );
-      const toggleDataFilesNoFoldersModal = () => {
-        dispatch({
+      renderComponent(
+        <DataFilesDownloadMessageModal />,
+        mockStore({
+          ...DataFilesDownloadMessageModalFixture,
+          allocations: {
+            /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+            portal_alloc: '',
+            active: [],
+          },
+        })
+      );
+
+      const closeButton = await screen.findByLabelText('Close');
+      fireEvent.click(closeButton);
+
+      await waitFor(() => {
+        // Test for the dispatch call that would toggle this modal
+        expect(mockDispatch).toHaveBeenCalledWith({
           type: 'DATA_FILES_TOGGLE_MODAL',
           payload: {
-            operation: 'noFolders',
+            operation: 'downloadMessage',
             props: {},
           },
         });
-      };
-      toggleDataFilesNoFoldersModal();
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'DATA_FILES_TOGGLE_MODAL',
-        payload: {
-          operation: 'noFolders',
-          props: {},
-        },
       });
     };
 });

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
@@ -106,6 +106,11 @@ describe('DataFilesDownloadMessageModal', () => {
       <DataFilesDownloadMessageModal />,
       mockStore({
         ...DataFilesDownloadMessageModalFixture,
+        allocations: {
+          /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+          portal_alloc: '',
+          active: [],
+        },
         files: {
           ...DataFilesDownloadMessageModalFixture.files,
           selected: { FilesListing: [1, 2, 3] },
@@ -149,6 +154,11 @@ describe('DataFilesDownloadMessageModal', () => {
         // Create the store
         mockStore({
           ...DataFilesDownloadMessageModalFixture,
+          allocations: {
+            /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+            portal_alloc: '',
+            active: [],
+          },
           files: {
             ...DataFilesDownloadMessageModalFixture.files,
             selected: { FilesListing: [3] },
@@ -191,7 +201,11 @@ describe('DataFilesDownloadMessageModal', () => {
         <DataFilesDownloadMessageModal />,
         mockStore({
           ...DataFilesDownloadMessageModalFixture,
-
+          allocations: {
+            /*TODO fix DataFilesDownloadMessageModalFixture fixture*/
+            portal_alloc: '',
+            active: [],
+          },
         })
       );
 


### PR DESCRIPTION
## Overview

Fix unit tests.

Dropped checked for other modals (like `Large Download Modal`) as only rendering `DataFilesDownloadMessageModal`

## Related

* [WP-949](https://tacc-main.atlassian.net/browse/WP-949)

## Testing

None
