### PR TITLE
task/WI-185: obfuscate Django session IDs in logs

### DIFF
--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from hashlib import sha256
 from portal.apps.users.utils import get_allocations
 from django.conf import settings
 from django.http import JsonResponse, HttpResponseForbidden
@@ -116,8 +117,9 @@ class TapisFilesView(BaseApiView):
                                  'filePath': path,
                                  'query': request.GET.dict()}
                          })
+            session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
             response = tapis_get_handler(
-                client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", **request.GET.dict())
+                client, scheme, system, path, operation, tapis_tracking_id=f"portals.{session_key_hash}", **request.GET.dict())
 
             if operation in NOTIFY_ACTIONS:
                 notify(
@@ -152,13 +154,14 @@ class TapisFilesView(BaseApiView):
                     )
 
                 # If the user has valid system credentials, retry the request
+                session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
                 response = tapis_get_handler(
                     client,
                     scheme,
                     system,
                     path,
                     operation,
-                    tapis_tracking_id=f"portals.{request.session.session_key}",
+                    tapis_tracking_id=f"portals.{session_key_hash}",
                     **request.GET.dict(),
                 )
 
@@ -198,7 +201,8 @@ class TapisFilesView(BaseApiView):
                                  'body': body,
                              }
                          })
-            response = tapis_put_handler(client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", body=body)
+            session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
+            response = tapis_put_handler(client, scheme, system, path, operation, tapis_tracking_id=f"portals.{session_key_hash}", body=body)
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc
@@ -228,8 +232,8 @@ class TapisFilesView(BaseApiView):
                                  'path': path,
                                  'body': request.POST.dict()
                              }})
-
-            response = tapis_post_handler(client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}",  body=body)
+            session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
+            response = tapis_post_handler(client, scheme, system, path, operation, tapis_tracking_id=f"portals.{session_key_hash}",  body=body)
         except Exception as exc:
             operation in NOTIFY_ACTIONS and notify(request.user.username, operation, 'error', {})
             raise exc

--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -5,6 +5,7 @@
 """
 import json
 import logging
+from hashlib import sha256
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.http import JsonResponse
@@ -122,7 +123,8 @@ class ProjectsApiView(BaseApiView):
         title = data['title']
 
         client = request.user.tapis_oauth.client
-        system_id = create_shared_workspace(client, title, request.user.username, tapis_tracking_id=f"portals.{request.session.session_key}")
+        session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
+        system_id = create_shared_workspace(client, title, request.user.username, tapis_tracking_id=f"portals.{session_key_hash}")
 
         METRICS.info(
             "Projects",

--- a/server/portal/apps/projects/views_unit_test.py
+++ b/server/portal/apps/projects/views_unit_test.py
@@ -1,4 +1,5 @@
 import pytest
+from hashlib import sha256
 from portal.apps.projects.managers.base import ProjectsManager
 from portal.apps.search.tasks import tapis_project_listing_indexer
 from portal.libs.elasticsearch.indexes import IndexedProject
@@ -199,7 +200,7 @@ def test_projects_post(
     # 3. standard client creates workspace client.systems.createSystem
     mock_service_account().files.mkdir.assert_called_with(
         systemId="projects.system.name", path="test.project-2",
-        headers={"X-Tapis-Tracking-ID": f"portals.{client.session.session_key}"}
+        headers={"X-Tapis-Tracking-ID": f"portals.{sha256(client.session.session_key.encode()).hexdigest()}"}
     )
     mock_service_account().files.setFacl.assert_called_with(
         systemId="projects.system.name",
@@ -239,7 +240,7 @@ def test_projects_post_setfacl_job(
     # 3. standard client creates workspace client.systems.createSystem
     mock_service_account().files.mkdir.assert_called_with(
         systemId="projects.system.name", path="test.project-2",
-        headers={"X-Tapis-Tracking-ID": f"portals.{client.session.session_key}"}
+        headers={"X-Tapis-Tracking-ID": f"portals.{sha256(client.session.session_key.encode()).hexdigest()}"}
     )
     mock_service_account().files.setFacl.assert_not_called()
     mock_service_account().jobs.submitJob.assert_called_with(

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 import uuid
 import logging
+from hashlib import sha256
 from kombu import Exchange, Queue
 from portal.settings import settings_secret
 
@@ -303,6 +304,8 @@ def portal_filter(record):
     """Log filter that adds portal-specific vars to each entry"""
 
     record.logGuid = uuid.uuid4().hex
+    if record.sessionId is not None:
+        record.sessionId = sha256(record.sessionId.encode()).hexdigest()
     record.portal = PORTAL_NAMESPACE
     record.tenant = TAPIS_TENANT_BASEURL
     return True


### PR DESCRIPTION
## Overview
Hash session IDs before they are written to our metrics logger.


## Related

* [WI-185](https://tacc-main.atlassian.net/browse/WI-185)

## Changes

- Add a log filter that hashes the session key before writing to Splunk.
- Hash session keys passed as tapis-tracking-id headers.



