### PR TITLE
task/WI-295 - Revoke tapis session on logout

### DIFF
--- a/server/portal/apps/accounts/unit_test.py
+++ b/server/portal/apps/accounts/unit_test.py
@@ -1,5 +1,8 @@
 import pytest
 from django.conf import settings
+from unittest import mock
+from django.http import HttpResponseRedirect
+from portal.apps.accounts.views import LogoutView
 
 
 def test_account_redirect(client, authenticated_user):
@@ -38,3 +41,63 @@ def test_profile_data_unexpected(client, authenticated_user, tas_client, tas_use
     response = client.get('/accounts/api/profile/data/')
     assert response.status_code == 500
     assert response.json() == {'message': 'Unable to get profile.'}
+
+
+@pytest.fixture
+def mock_user():
+    class MockAccessToken:
+        access_token = 'fake_token'
+
+    class MockUser:
+        tapis_oauth = MockAccessToken()
+
+        def __str__(self):
+            return 'mockuser'
+
+    return MockUser()
+
+
+@mock.patch('portal.apps.accounts.views.logout')
+@mock.patch('portal.apps.accounts.views.requests.post')
+def test_logout_success(mock_post, mock_logout, requests_mock, mock_user, settings):
+
+    mock_post.return_value.raise_for_status.return_value = None
+
+    request = requests_mock.get('/logout/')
+    request.user = mock_user
+
+    response = LogoutView().dispatch(request)
+
+    mock_post.assert_called_once_with(
+        f"{settings.TAPIS_TENANT_BASEURL}/v3/tokens/revoke",
+        json={'token': 'fake_token'}
+    )
+    mock_logout.assert_called_once_with(request)
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == str(getattr(settings, 'LOGOUT_REDIRECT_URL', '/'))
+
+
+@mock.patch('portal.apps.accounts.views.logout')
+@mock.patch('portal.apps.accounts.views.requests.post')
+def test_logout_token_revoke_failure(mock_logout, requests_mock, mock_user, settings):
+    with pytest.raises(Exception) as e_info:
+
+        request = requests_mock.get('/logout/')
+        request.user = mock_user
+
+        response = LogoutView().dispatch(request)
+
+        assert "Token revocation failed" in str(e_info.value)
+        mock_logout.assert_called_once()
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == str(getattr(settings, 'LOGOUT_REDIRECT_URL', '/'))
+
+
+@mock.patch('portal.apps.accounts.views.requests.post')
+@mock.patch('portal.apps.accounts.views.logger')
+def test_revoke_token_revoke_exception_handled(mock_post, mock_logger):
+    with pytest.raises(Exception):
+        view = LogoutView()
+        view.revoke_token("fake_token")
+        mock_post.assert_called_once()
+        assert mock_logger.exception.called

--- a/server/portal/apps/accounts/unit_test.py
+++ b/server/portal/apps/accounts/unit_test.py
@@ -50,9 +50,7 @@ def mock_user():
 
     class MockUser:
         tapis_oauth = MockAccessToken()
-
-        def __str__(self):
-            return 'mockuser'
+        username = 'mockuser'
 
     return MockUser()
 

--- a/server/portal/apps/accounts/unit_test.py
+++ b/server/portal/apps/accounts/unit_test.py
@@ -60,6 +60,7 @@ def mock_user():
 def factory():
     return RequestFactory()
 
+
 @pytest.mark.django_db
 @mock.patch('portal.apps.accounts.views.logout')
 def test_logout_redirects_correctly_and_logs_out(mock_logout, mock_user, factory, settings):
@@ -77,19 +78,3 @@ def test_logout_redirects_correctly_and_logs_out(mock_logout, mock_user, factory
     assert response.status_code == 302
     assert response.url == expected_url
     mock_logout.assert_called_once_with(request)
-
-
-@mock.patch('portal.apps.accounts.views.logout')
-@mock.patch('portal.apps.accounts.views.requests.post')
-def test_logout_token_revoke_failure(mock_logout, requests_mock, mock_user, settings):
-    with pytest.raises(Exception) as e_info:
-
-        request = requests_mock.get('/logout/')
-        request.user = mock_user
-
-        response = LogoutView().dispatch(request)
-
-        assert "Token revocation failed" in str(e_info.value)
-        mock_logout.assert_called_once()
-        assert isinstance(response, HttpResponseRedirect)
-        assert response.url == str(getattr(settings, 'LOGOUT_REDIRECT_URL', '/'))

--- a/server/portal/apps/accounts/urls.py
+++ b/server/portal/apps/accounts/urls.py
@@ -3,7 +3,7 @@
    :synopsis: Accounts URLs
 """
 from django.urls import re_path
-from django.contrib.auth.views import LogoutView
+from portal.apps.accounts.views import LogoutView
 from portal.apps.accounts.views import accounts
 from portal.apps.accounts import views
 

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -26,12 +26,21 @@ class LogoutView(DjangoLogoutView):
         token = str(request.user.tapis_oauth.access_token)
 
         logger.info('Attempting to revoke JWT token for user: ' + str(request.user))
+
+        token = request.user.tapis_oauth.access_token
+
+        logger.info('Attempting to revoke JWT token for user: ' + request.user.username)
+
         self.revoke_token(token)
 
         logout(request)
 
         redirect = getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
         response = HttpResponseRedirect(redirect)
+
+        redirect_uri = getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
+        response = HttpResponseRedirect(redirect_uri)
+
         return response
 
     def revoke_token(self, token):

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -24,12 +24,12 @@ logger = logging.getLogger(__name__)
 class LogoutView(DjangoLogoutView):
     def dispatch(self, request, *args, **kwargs):
         token = str(request.user.tapis_oauth.access_token)
-        
+
         logger.info('Attempting to revoke JWT token for user: ' + str(request.user))
         self.revoke_token(token)
 
         logout(request)
-               
+
         redirect = getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
         response = HttpResponseRedirect(redirect)
         return response

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -23,24 +23,15 @@ logger = logging.getLogger(__name__)
 
 class LogoutView(DjangoLogoutView):
     def dispatch(self, request, *args, **kwargs):
-        token = str(request.user.tapis_oauth.access_token)
-
-        logger.info('Attempting to revoke JWT token for user: ' + str(request.user))
-
         token = request.user.tapis_oauth.access_token
 
         logger.info('Attempting to revoke JWT token for user: ' + request.user.username)
-
         self.revoke_token(token)
 
         logout(request)
 
-        redirect = getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
-        response = HttpResponseRedirect(redirect)
-
         redirect_uri = getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
         response = HttpResponseRedirect(redirect_uri)
-
         return response
 
     def revoke_token(self, token):

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -17,7 +17,6 @@ from pytas.http import TASClient
 
 from portal.apps.accounts import integrations
 from portal.utils.decorators import handle_uncaught_exceptions
-from portal.apps.auth.models import TapisOAuthToken
 
 logger = logging.getLogger(__name__)
 

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -205,6 +205,7 @@ IMPERSONATE = {
 LOGOUT_REDIRECT_URL = getattr(settings_custom, '_LOGOUT_REDIRECT_URL', '/')
 LOGIN_REDIRECT_URL = getattr(settings_custom, '_LOGIN_REDIRECT_URL', '/')
 LOGIN_URL = '/auth/tapis/'
+TOKEN_REVOKE_ENDPOINT = '/v3/tokens/revoke'
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -205,7 +205,6 @@ IMPERSONATE = {
 LOGOUT_REDIRECT_URL = getattr(settings_custom, '_LOGOUT_REDIRECT_URL', '/')
 LOGIN_REDIRECT_URL = getattr(settings_custom, '_LOGIN_REDIRECT_URL', '/')
 LOGIN_URL = '/auth/tapis/'
-TOKEN_REVOKE_ENDPOINT = '/v3/tokens/revoke'
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/


### PR DESCRIPTION
## Overview
Revokes tapis token using [tapis endpoint ](https://tapis-project.github.io/live-docs/?service=Authenticator#tag/Tokens/operation/revoke_token)


## Related

* [WI-295](https://tacc-main.atlassian.net/browse/WI-295)

## Changes
Overrides the logout view with a function calling the Tapis endpoint which will revoke the user's token.


## Testing

1. Log into cep.test
2. Logout and check logs for "Attempting to revoke JWT token for user" and your username.
3. Make sure that you are redirected to the home page and logged out of the CMS.
4. Try to login again and validate that you are prompted to authenticate with Tapis again.

## Notes
This is a high priority.
