### PR TITLE
Quick: Ignore oauth urls in token refresh middleware

### DIFF
--- a/server/portal/apps/auth/middleware.py
+++ b/server/portal/apps/auth/middleware.py
@@ -21,9 +21,14 @@ class TapisTokenRefreshMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        ignore_paths = [
+            reverse("portal_auth:tapis_oauth_callback"),
+            reverse("portal_auth:tapis_oauth"),
+            reverse("portal_accounts:logout"),
+            reverse("login"),
+        ]
         if (
-            request.path != reverse("portal_accounts:logout")
-            and request.path != reverse("login")
+            request.path not in ignore_paths
             and not request.path.startswith("/static/")
             and request.user.is_authenticated
         ):


### PR DESCRIPTION
## Overview

Ignore tapis oauth url paths for Tapis Token Refresh Middleware


## Testing

1. Confirm you do not see "Tapis OAuth token expired for user {request.user.username}. Refreshing token" if your token is expired and you go to /login
