### PR TITLE
task/WP-957: Compress + extract modal error handling updates

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.jsx
@@ -120,6 +120,12 @@ const DataFilesCompressModal = () => {
                 >
                   Successfully started compress job
                 </InlineMessage>
+                <InlineMessage
+                  isVisible={status.type === 'ERROR'}
+                  type="error"
+                >
+                  {status.message}
+                </InlineMessage>
                 <Button
                   disabled={buttonDisabled}
                   isLoading={status.type === 'RUNNING'}

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.jsx
@@ -57,16 +57,22 @@ const DataFilesExtractModal = () => {
         </p>
       </ModalBody>
       <ModalFooter>
-        <InlineMessage isVisible={status === 'SUCCESS'} type="success">
+        <InlineMessage isVisible={status.type === 'SUCCESS'} type="success">
           Successfully started extract job
         </InlineMessage>
+        <InlineMessage
+          isVisible={status.type === 'ERROR'}
+          type="error"
+        >
+          {status.message}
+        </InlineMessage>        
         <Button
           onClick={extractCallback}
-          disabled={status === 'RUNNING' || status === 'SUCCESS'}
-          isLoading={status === 'RUNNING'}
+          disabled={status.type === 'RUNNING' || status.type === 'SUCCESS'}
+          isLoading={status.type === 'RUNNING'}
           type="primary"
           size="medium"
-          iconNameBefore={status === 'ERROR' ? 'alert' : null}
+          iconNameBefore={status.type === 'ERROR' ? 'alert' : null}
         >
           Extract
         </Button>

--- a/client/src/hooks/datafiles/mutations/useCompress.ts
+++ b/client/src/hooks/datafiles/mutations/useCompress.ts
@@ -78,18 +78,16 @@ function useCompress() {
     }
 
     if (!allocationForCompress) {
-      throw new Error('You need an allocation to compress.', {
-        cause: 'compressError',
-      });
+      setStatus({ type: 'ERROR', message: 'You need an allocation to compress.' });
+      return null;
     }
 
     if (scheme !== 'private' && scheme !== 'projects') {
       defaultPrivateSystem = systems.find((s: any) => s.default);
 
       if (!defaultPrivateSystem) {
-        throw new Error('Folder downloads are unavailable in this portal', {
-          cause: 'compressError',
-        });
+        setStatus({ type: 'ERROR', message: 'Folder downloads are unavailable in this portal.' });
+        return null;
       }
     }
 
@@ -143,7 +141,7 @@ function useCompress() {
             }
           }
         },
-        onError: (response) => {
+        onError: (response: any) => {
           const errorMessage =
             response.cause === 'compressError'
               ? response.message

--- a/client/src/hooks/datafiles/mutations/useExtract.ts
+++ b/client/src/hooks/datafiles/mutations/useExtract.ts
@@ -42,14 +42,11 @@ function useExtract() {
   const { mutateAsync } = useMutation({ mutationFn: submitJobUtil });
 
   const extract = ({ file }: { file: TTapisFile }) => {
-    dispatch({
-      type: 'DATA_FILES_SET_OPERATION_STATUS',
-      payload: { status: 'RUNNING', operation: 'extract' },
-    });
+    setStatus({ type: 'RUNNING' });
+
     if (!allocationForExtract) {
-      throw new Error('You need an allocation to extract.', {
-        cause: 'extractError',
-      });
+      setStatus({ type: 'ERROR', message: 'You need an allocation to extract.' });
+      return null;
     }
 
     const params = getExtractParams(
@@ -76,20 +73,14 @@ function useExtract() {
               },
             });
           } else if (response.status === 'PENDING') {
-            dispatch({
-              type: 'DATA_FILES_SET_OPERATION_STATUS',
-              payload: { status: { type: 'SUCCESS' }, operation: 'extract' },
-            });
+            setStatus({ type: 'SUCCESS' });
             dispatch({
               type: 'ADD_TOAST',
               payload: {
                 message: 'File extraction in progress',
               },
             });
-            dispatch({
-              type: 'DATA_FILES_SET_OPERATION_STATUS',
-              payload: { operation: 'extract', status: {} },
-            });
+            setStatus({});
             dispatch({
               type: 'DATA_FILES_TOGGLE_MODAL',
               payload: { operation: 'extract', props: {} },
@@ -101,13 +92,7 @@ function useExtract() {
             response.cause === 'extractError'
               ? response.message
               : 'An error has occurred.';
-          dispatch({
-            type: 'DATA_FILES_SET_OPERATION_STATUS',
-            payload: {
-              status: { type: 'ERROR', message: errorMessage },
-              operation: 'extract',
-            },
-          });
+          setStatus({ type: 'ERROR', message: errorMessage });
         },
       }
     );

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -105,7 +105,7 @@ export const initialFilesState = {
     trash: {},
     empty: {},
     compress: {},
-    extract: null,
+    extract: {},
     link: {
       method: null,
       url: '',


### PR DESCRIPTION
## Overview
Improves error handling and displaying for compress + extract modals


## Related

* [WP-957](https://tacc-main.atlassian.net/browse/WP-957)

## Changes

- Updated usage of `status` var in extract modal to match usage in `useExtract` mutation (i.e. `status.type === 'ERROR'` instead of `status === 'ERROR'`)
- `useCompress` and `useExtract` mutations now update redux status of matching operations directly instead of throwing `Error` (useMutation does not pick these up in its `onError` clause as they are not within its `mutationFn`)
- Both modals will display the corresponding error's message in the modal upon `ERROR` state

## Testing

*As of 6/30/25, the TACC-ACI project's frontera allocation expired, ends up being useful for this testing*
1. Test both compress and extract data files actions and confirm the job fails from allocation error and displays in the modal as shown below

## UI

<img width="471" alt="image" src="https://github.com/user-attachments/assets/f45276aa-b519-438f-8889-3896ff7a6efb" />


## Notes

