### PR TITLE
bug/WP-976: Improve allocations check for toolbar apps

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesDownloadMessageModal.test.jsx
@@ -22,6 +22,11 @@ vi.mock('hooks/datafiles/mutations/toolbarAppUtils', async (importOriginal) => {
           execSystemId: 'frontera',
         },
       },
+      execSystems: [
+        {
+          host: 'frontera.tacc.utexas.edu'
+        }
+      ]
     }),
   };
 });

--- a/client/src/hooks/datafiles/mutations/toolbarAppUtils.ts
+++ b/client/src/hooks/datafiles/mutations/toolbarAppUtils.ts
@@ -12,14 +12,14 @@ export const getAppUtil = async function fetchAppDefinitionUtil(
   return result.response;
 };
 
-function getAvailableHPCAlloc(activeAllocations: any, appExecSysId: string) {
+function getAvailableHPCAlloc(activeAllocations: any, appExecHostname: string) {
   // Returns the project name of the first available HPC allocation matching the
   // exec system for the app with remaining compute time, or undefined if none found
   for (let activeAlloc of activeAllocations) {
     for (let allocSys of activeAlloc.systems) {
       if (
         allocSys.type === 'HPC' &&
-        allocSys.name.toLowerCase() === appExecSysId
+        allocSys.host === appExecHostname
       ) {
         const availCompute =
           allocSys.allocation.computeAllocated -
@@ -47,7 +47,7 @@ export function getAllocationForToolbarAction(
     return (
       getAvailableHPCAlloc(
         allocationsState.active,
-        appObj.definition.jobAttributes.execSystemId
+        appObj.execSystems[0].host
       ) || null
     );
   }


### PR DESCRIPTION
## Overview



## Related

* [WP-976](https://tacc-main.atlassian.net/browse/WP-976)

## Changes
- Changed allocation check used for both compress + extract toolbar jobs to check against exec system hostname (more reliable than system name)
- Updated test fixture with `execSystems` specified


## Testing

1. Run both compress and extract toolbar jobs from a data files/shared workspace listing and confirm successful submission to Frontera
2. In `settings_custom.py` -> `WORKBENCH_SETTINGS`, update to use `compress-ls6' v0.0.4 and `extract-ls6` v0.0.1 and confirm successful submission to Lonestar6

## UI



## Notes

