### PR TITLE
change Digital Rocks to Digital Porous Media

### DIFF
--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewAuthors.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewAuthors.jsx
@@ -24,7 +24,7 @@ const ACMCitation = ({ project, authors }) => {
 
   return (
     <div>
-      {`${authorString}. ${project.title}. `} <em>Digital Rocks Portal</em>{' '}
+      {`${authorString}. ${project.title}. `} <em>Digital Porous Media</em>{' '}
       {` (${createdDate}). ${projectUrl}`}{' '}
     </div>
   );
@@ -69,7 +69,7 @@ const BibTeXCitation = ({ project, authors }) => {
   author = {${authorString}},
   title = {${project.title}},
   year = {${year}},
-  publisher = {Digital Rocks Portal},
+  publisher = {Digital Porous Media},
   doi = {},
   howpublished = {\\url{${projectUrl}}}
 }`}</pre>
@@ -97,8 +97,8 @@ export const MLACitation = ({ project, authors }) => {
 
   return (
     <div>
-      {`${authorString}. "${project.title}."`} <em>Digital Rocks Portal,</em>{' '}
-      {` Digital Rocks Portal, ${createdDate}, ${projectUrl} Accessed ${accessDate}.`}
+      {`${authorString}. "${project.title}."`} <em>Digital Porous Media,</em>{' '}
+      {` Digital Porous Media, ${createdDate}, ${projectUrl} Accessed ${accessDate}.`}
     </div>
   );
 };
@@ -119,7 +119,7 @@ const IEEECitation = ({ project, authors }) => {
   return (
     <div>
       {`[1] ${authorString}, "${project.title}",`}{' '}
-      <em>Digital Rocks Portal,</em>{' '}
+      <em>Digital Porous Media,</em>{' '}
       {` ${year}. [Online]. Available: ${projectUrl}. [Accessed: ${day}-${month}-${year}]`}
     </div>
   );

--- a/server/portal/apps/projects/management/commands/archive_drp_publications.py
+++ b/server/portal/apps/projects/management/commands/archive_drp_publications.py
@@ -6,7 +6,7 @@ import time
 from django.db import close_old_connections
 
 class Command(BaseCommand):
-    help = "Archive Digital Rocks publications."
+    help = "Archive Digital Porous Media publications."
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/server/portal/apps/projects/workspace_operations/datacite_operations.py
+++ b/server/portal/apps/projects/workspace_operations/datacite_operations.py
@@ -41,7 +41,7 @@ def get_datacite_json(pub_graph: nx.DiGraph):
     datacite_json["creators"] = author_attr
     datacite_json["titles"] = [{"title": base_meta["title"]}]
 
-    datacite_json["publisher"] = "Digital Rocks Portal"
+    datacite_json["publisher"] = "Digital Porous Media"
 
     datacite_json["publicationYear"] = datetime.datetime.now().year
 


### PR DESCRIPTION
## Overview
Change any instances of ‘Digital Rocks’ and update it to ‘Digital Porous Media’. 


## Related

* [WC-266](https://tacc-main.atlassian.net/browse/WC-266)

## Changes
The Review Authors page in the publication pipeline has the bulk of the changes. But I searched for all instances of Digital Rocks. The two other places were in Archived Publications and Datacite.


## Testing

1. Go through the publication pipeline to Author Review and note the changes
2. Not sure how to check Archived Publications. 
3. Datasets published to Datacite should now include 'Digital Porous Media' (not sure about old datasets)

## UI

<img width="1057" alt="Screen Shot 2025-07-07 at 1 32 07 PM" src="https://github.com/user-attachments/assets/33a5312c-594a-441a-9c0f-93c762d97746" />


## Notes

