### PR TITLE
Quick: Fix onboardging sql ids

### DIFF
--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -174,14 +174,17 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
     {
         "step": "portal.apps.onboarding.steps.project_membership.ProjectMembershipStep",
         "settings": {
-            # List of TAS project SQL IDs to check membership against for
-            # portal access. Only one is required.
-            "project_sql_id": [12345, 66858],
-            # TAS project SQL Id to set upon approval as the default project
-            # for users in this portal if user does not have membership in any
-            # project in the project_sql_id list.
-            "default_project_sql_id": 66858,
-            # Defaults to 'Accounting' if left blank
+            # `project_sql_id`:
+            #       List of TAS project SQL IDs to check membership against for
+            #       portal access. Only one is required.
+            "project_sql_id": [9192, 66858],
+            # `default_project_sql_id`:
+            #       The TAS project SQL Id to set upon approval as the default project
+            #       for users in this portal if user does not have membership in any
+            #       project in the project_sql_id list.
+            "default_project_sql_id": 66858,  # 66858 is the TACC-ACI-DEMO project SQL ID
+            # `rt_queue`:
+            #       Defaults to 'Accounting' if left blank
             "rt_queue": _RT_QUEUE,
         },
     },


### PR DESCRIPTION
## Overview

Changes a fake onboarding sql id to a real one.

## Testing

1. Reset your "Project Membership" onboarding step
2. Confirm works as normal