### PR TITLE
docs: clarify cms access and page mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,7 @@ OR
     python3 manage.py collectstatic --noinput
     python3 manage.py createsuperuser  # Unless you will only login with your TACC account
 
-You may optionally create sample pages in the CMS.[^1]
-
-[^1]: First (if you have not already) [log in to the portal](https://cep.test/login). Then, [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser). Finally, follow instructions at https://cep.test/.
+You may optionally create sample pages in the CMS at https://cep.test/.
 
 *NOTE*: TACC VPN or physical connection to the TACC network is required to log-in to CMS using LDAP, otherwise the password set with `python3 manage.py createsuperuser` is used
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ OR
 
 You may optionally create sample pages in the CMS.[^1]
 
-[^1]: First (if you have not already) [log in to the portal](https://cep.test/login), then [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser), finally visit https://cep.test/.
+[^1]: First (if you have not already) [log in to the portal](https://cep.test/login). Then, [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser). Finally, follow instructions at https://cep.test/.
 
 *NOTE*: TACC VPN or physical connection to the TACC network is required to log-in to CMS using LDAP, otherwise the password set with `python3 manage.py createsuperuser` is used
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ OR
     python3 manage.py migrate
     python3 manage.py collectstatic --noinput
 
-To be able to create pages in the CMS: first (if you have not already) [log in to the portal](https://cep.test/login), then [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser), finally visit https://cep.test/.
+You may optionally create sample pages in the CMS.[^1]
+
+[^1]: First (if you have not already) [log in to the portal](https://cep.test/login), then [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser), finally visit https://cep.test/.
 
 *NOTE*: TACC VPN or physical connection to the TACC network is required to log-in to CMS using LDAP, otherwise the password set with `python3 manage.py createsuperuser` is used
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ OR
     docker exec -it core_portal_cms /bin/bash
     python3 manage.py migrate
     python3 manage.py collectstatic --noinput
+    python3 manage.py createsuperuser  # Unless you will only login with your TACC account
 
 You may optionally create sample pages in the CMS.[^1]
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ OR
 -  _Notes: During local development you can also use `npm run dev` to set a live reload watch on your local system that will update the portal code in real-time. Again, make sure that you are using NodeJS LTS and not an earlier version. You will also need the port 3000 available locally._
 
 -  _Notes: If your settings.DEBUG is set to true, you will have to use `npm run dev` to have a functional app. In DEBUG setting, the requests are handled via [vite][3]._
+
 #### Initialize the application in the `core_portal_django` container:
 
     docker exec -it core_portal_django /bin/bash
@@ -149,9 +150,8 @@ OR
     docker exec -it core_portal_cms /bin/bash
     python3 manage.py migrate
     python3 manage.py collectstatic --noinput
-    python3 manage.py createsuperuser
 
-To be able to create pages in the CMS, [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser).
+To be able to create pages in the CMS: first (if you have not already) [log in to the portal](https://cep.test/login), then [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser), finally visit https://cep.test/.
 
 *NOTE*: TACC VPN or physical connection to the TACC network is required to log-in to CMS using LDAP, otherwise the password set with `python3 manage.py createsuperuser` is used
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ OR
     python3 manage.py collectstatic --noinput
     python3 manage.py createsuperuser
 
-Finally, create a home page in the CMS.
+To be able to create pages in the CMS, [set your (automatically-created) CMS user as Staff and Superuser](https://github.com/TACC/Core-CMS/wiki/How-to-Set-Your-User-as-Staff-or-Superuser).
 
 *NOTE*: TACC VPN or physical connection to the TACC network is required to log-in to CMS using LDAP, otherwise the password set with `python3 manage.py createsuperuser` is used
 


### PR DESCRIPTION
## Overview

Remind user they can login to CMS with TACC account. Let user know adding CMS page is optional.

~~If dev wants to create CMS pages, instruct them how to login to CMS. Lead them to do so with TACC account, but permit manual account.~~

<details><summary>Inspiration</summary>

Docs need not encourage dev to _manually_ create a CMS superuser, because they might report [CSRF token problem upon trying to login with it](https://tacc-main.atlassian.net/issues/WP-897). (I had reported that, yet I knew the CMS well.) Do encourage login via TACC user, because (A) that is more akin to login on remote servers, and (B) it is workaround for login aspect of [WP-897](https://tacc-main.atlassian.net/browse/WP-897) bug.

</details>

## Related

* [WP-897](https://tacc-main.atlassian.net/issues/WP-897)

## Changes

* **updates** section about CMS prep

## Testing & UI

See [`README.md` on this branch at "Initialize the CMS […]"](https://github.com/TACC/Core-Portal/blob/docs/readme-how-to-create-cms-create-pages/README.md#initialize-the-cms-in-the-core_portal_cms-container).

> [!IMPORTANT]
> If you follow these steps, I expect adding a page to fail, like shown in [WP-897](https://tacc-main.atlassian.net/issues/WP-897). This PR is documentation, not bug fix.