### PR TITLE
fix: footer (if visible) might not show at bottom

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -103,3 +103,8 @@ body > .content {
   top: 0;
   bottom: 0;
 }
+
+body > footer {
+    position: sticky;
+    top: 100vh;
+}

--- a/server/portal/templates/includes/footer.html
+++ b/server/portal/templates/includes/footer.html
@@ -1,3 +1,4 @@
 {% load static %}
 <footer class="container-fluid">
+    Test
 </footer>


### PR DESCRIPTION
## Overview

Footer (if visible) shows in the middle of a tall viewport.

## Related

* required by https://github.com/TACC/Core-Portal/pull/1137

## Changes

* add styles

## Testing

1. Add test content in footer.
2. ... never mind.

This is not believe-able to test.[^1]

[^1]: Style does not load soon enough to move footer to bottom of page. I could add styles early, but it would be as `<style>` tag[^2], because Core-Portal does not support static files (beyond CMS).[^3] When styles do load, footer would already be at bottom, because of CSS layout tricks to make content take up page height. I could add

[^2]: Adding `<style>` tag makes sense sometimes, but not for a style that no one will see the effect of (because footer has no content).

[^3]: Core-Portal could support static files. But my old propose for that was declined, and a second proposal will be declined, because it's not worth the changeset for minimal use case(s).

## UI

Aborted.