### PR TITLE
Task/WP-360

### DIFF
--- a/client/src/components/_common/Searchbar/Searchbar.jsx
+++ b/client/src/components/_common/Searchbar/Searchbar.jsx
@@ -48,7 +48,7 @@ const Searchbar = ({
     const prevQuery = queryString.parse(location.search);
     const updatedQuery = queryString.stringify({
       ...prevQuery,
-      query_string: query || undefined,
+      query_string: query?.trim() || undefined,
       page: !infiniteScroll ? 1 : undefined,
     });
     history.push(`${location.pathname}?${updatedQuery}`);


### PR DESCRIPTION
## Overview
Updating job search functionality to allow users to search via the job statuses (e.g., "Finished", "Failure", "Processing", etc.)


## Related

* [WP-360](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-360)

## Changes

- Added status_text_map for mapping backend statuses to UI labels
- Added python-side filtering to match jobs by UI label and strings input by user. 
- Removed trailing whitespace from user's input


## Testing

1. Search for a job status as it appears in the UI (e.g., "Finished", "Failure", "Processing").
2. Verify that all jobs with backend statuses that map to that label are returned, including jobs whose status is mutated by backend logic. (Interactive app job statuses)

## UI
<img width="1028" height="487" alt="Screenshot 2025-07-25 at 11 31 25 AM" src="https://github.com/user-attachments/assets/bfd7cfe1-6986-4bf9-a730-da66456c639f" />
<img width="1026" height="455" alt="Screenshot 2025-07-25 at 11 31 43 AM" src="https://github.com/user-attachments/assets/9b2a7608-d6f4-4570-aa7f-dc515fefd646" />



## Notes

