### PR TITLE
hotfix: Bypass allocations check for toolbar apps running on VM

### DIFF
--- a/client/src/hooks/datafiles/mutations/toolbarAppUtils.ts
+++ b/client/src/hooks/datafiles/mutations/toolbarAppUtils.ts
@@ -72,6 +72,9 @@ export function getAllocationForToolbarAction(
     activeAllocations.length > 0 &&
     appObj
   ) {
+    if (!appObj.execSystems[0].canRunBatch) {
+      return 'VM'; // if app runs on VM, no allocation needed, so bypass allocation check
+    }
     return getAvailableHPCAlloc(
       activeAllocations,
       portalAllocName,

--- a/client/src/hooks/datafiles/mutations/toolbarAppUtils.ts
+++ b/client/src/hooks/datafiles/mutations/toolbarAppUtils.ts
@@ -4,6 +4,7 @@ import {
   TTasAllocatedSystem,
   TPortalApp,
   TUserAllocations,
+  TTapisSystem,
 } from 'utils/types';
 
 export const getAppUtil = async function fetchAppDefinitionUtil(
@@ -72,14 +73,20 @@ export function getAllocationForToolbarAction(
     activeAllocations.length > 0 &&
     appObj
   ) {
-    if (!appObj.execSystems[0].canRunBatch) {
-      return 'VM'; // if app runs on VM, no allocation needed, so bypass allocation check
-    }
-    return getAvailableHPCAlloc(
-      activeAllocations,
-      portalAllocName,
-      appObj.execSystems[0].host
+    const appExecSys = appObj.execSystems.find(
+      (execSys: TTapisSystem) =>
+        execSys.id === appObj.definition.jobAttributes.execSystemId
     );
+    if (appExecSys) {
+      if (!appExecSys.canRunBatch) {
+        return 'VM'; // if app runs on VM, no allocation needed, so bypass allocation check
+      }
+      return getAvailableHPCAlloc(
+        activeAllocations,
+        portalAllocName,
+        appExecSys.host
+      );
+    }
   }
   return null;
 }

--- a/client/src/utils/getCompressParams.ts
+++ b/client/src/utils/getCompressParams.ts
@@ -40,14 +40,19 @@ export const getCompressParams = (
           arg: compressionType,
         },
       ],
-      schedulerOptions: [
-        {
-          name: 'TACC Allocation',
-          description: 'The TACC allocation associated with this job execution',
-          include: true,
-          arg: `-A ${defaultAllocation}`,
-        },
-      ],
+      schedulerOptions:
+        defaultAllocation === 'VM'
+          ? []
+          : [
+              // if running on VM, no need to pass allocation param
+              {
+                name: 'TACC Allocation',
+                description:
+                  'The TACC allocation associated with this job execution',
+                include: true,
+                arg: `-A ${defaultAllocation}`,
+              },
+            ],
     },
   };
 };

--- a/client/src/utils/getExtractParams.ts
+++ b/client/src/utils/getExtractParams.ts
@@ -29,14 +29,19 @@ export const getExtractParams = (
     appVersion: extractApp.version,
     parameterSet: {
       appArgs: [],
-      schedulerOptions: [
-        {
-          name: 'TACC Allocation',
-          description: 'The TACC allocation associated with this job execution',
-          include: true,
-          arg: `-A ${defaultAllocation}`,
-        },
-      ],
+      schedulerOptions:
+        defaultAllocation === 'VM'
+          ? []
+          : [
+              // if running on VM, no need to pass allocation param
+              {
+                name: 'TACC Allocation',
+                description:
+                  'The TACC allocation associated with this job execution',
+                include: true,
+                arg: `-A ${defaultAllocation}`,
+              },
+            ],
     },
   };
 };


### PR DESCRIPTION
## Overview
VMs are not allocated resources in TAS projects, so need to not check these execution systems against TAS allocations to allow jobs to run.


## Related

* [WP-966](https://tacc-main.atlassian.net/browse/WP-966)

## Changes
- Check truthy of `canRunBatch` attribute on exec system object from compress/extract app, return 'VM' if false
- Use above return value to avoid passing `schedulerOptions` back to tapis (unneeded for VM apps)


## Testing

1. Update your `settings_default.py` `_WORKBENCH_SETTINGS` to point to `compress-express` and `extract-express` (both v0.0.1)
2. In Data Files + Shared Workspaces, confirm that you can submit compress and extract jobs from the toolbar and that they run and complete successfully

## UI



## Notes
thank you Sal for the fix idea!

Adding testing coverage for all of this new compress + extract code coming in Aug-Sept 2025 sprint