### PR TITLE
task/WC-269, 206, 209: updating all description mins and maxes

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesAddProjectModal.jsx
@@ -84,7 +84,7 @@ const DataFilesAddProjectModal = () => {
         onCreate,
       },
     });
-  };  
+  };
 
   const onAdd = (newUser) => {
     setMembers([...members, newUser]);
@@ -102,9 +102,9 @@ const DataFilesAddProjectModal = () => {
       .max(150, 'Title must be at most 150 characters')
       .required('Please enter a title.'),
     description: Yup.string()
-      .max(800, 'Description must be at most 800 characters')
+      .min(1000, 'Description must be at least 1000 characters')
+      .max(5000, 'Description must be at most 5000 characters'),
   });
-  
 
   return (
     <>
@@ -125,7 +125,7 @@ const DataFilesAddProjectModal = () => {
               Add {sharedWorkspacesDisplayName}
             </ModalHeader>
             <ModalBody>
-            <FormField
+              <FormField
                 name="title"
                 label={
                   <div>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesFormModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesFormModal.jsx
@@ -13,15 +13,15 @@ const DataFilesFormModal = () => {
   const history = useHistory();
   const location = useLocation();
 
-  const reloadPage = (updatedPath = '') => {  
+  const reloadPage = (updatedPath = '') => {
     const match = location.pathname.match(/^\/workbench\/data\/tapis\/[^\/]+\/[^\/]+\/[^\/]+/);
     if (!match) return;
 
     const projectUrl = match[0];
-  
+
     const cleanProjectUrl = projectUrl.replace(/\/$/, '');
     const cleanUpdatedPath = updatedPath.replace(/^\/+/, '');
-  
+
     history.replace(`${cleanProjectUrl}/${cleanUpdatedPath}`);
   };
 
@@ -71,7 +71,7 @@ const DataFilesFormModal = () => {
 
   const validationSchema = Yup.object().shape({
     ...(form?.form_fields ?? []).reduce((schema, field) => {
-      
+
       let validator;
 
       if (field.type === 'number') {
@@ -107,6 +107,19 @@ const DataFilesFormModal = () => {
             field.validation?.min ?? -Infinity,
             `${field.label} must be greater than or equal to ${field.validation?.min}`
           );
+      }
+
+      let descriptions = ['algorithm_description', 'description', 'porous_media_other_description'];
+      if ((field.type === 'textarea') && (descriptions.includes(field.name))) {
+        validator = validator
+          .min(
+            50,
+            `${field.label} must be greater than or equal to 50 characters`
+          )
+          .max(
+            5000,
+            `${field.label} must be less than or equal to 5000 characters`
+          )
       }
 
       schema[field.name] = validator;

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesFormModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesFormModal.jsx
@@ -109,8 +109,8 @@ const DataFilesFormModal = () => {
           );
       }
 
-      let descriptions = ['algorithm_description', 'description', 'porous_media_other_description'];
-      if ((field.type === 'textarea') && (descriptions.includes(field.name))) {
+      let other_descriptions = ['algorithm_description', 'description', 'porous_media_other_description'];
+      if ((field.type === 'textarea') && (other_descriptions.includes(field.name))) {
         validator = validator
           .min(
             50,

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescriptionModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescriptionModal.jsx
@@ -73,10 +73,9 @@ const DataFilesProjectEditDescriptionModal = () => {
         .min(3, 'Title must be at least 3 characters')
         .max(150, 'Title must be at most 150 characters')
         .required('Please enter a title.'),
-      description: Yup.string().max(
-        800,
-        'Description must be at most 800 characters'
-      ),
+      description: Yup.string()
+        .min(1000, 'Description must be minimum 1000 characters')
+        .max(5000, 'Description must be at most 5000 characters'),
     })
   );
 
@@ -112,7 +111,7 @@ const DataFilesProjectEditDescriptionModal = () => {
                   <div>
                     Dataset Description{' '}
                     <small>
-                      <em>(Maximum 800 characters)</em>
+                      <em>(Provide 200-300 words clearly describing the data as an independent output; do not copy related publication abstract.)</em>
                     </small>
                   </div>
                 }

--- a/client/src/components/_custom/drp/DataFilesProjectEditDescriptionModalAddon/DataFilesProjectEditDescriptionModalAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectEditDescriptionModalAddon/DataFilesProjectEditDescriptionModalAddon.jsx
@@ -81,6 +81,18 @@ const DataFilesProjectEditDescriptionModalAddon = ({ setValidationSchema }) => {
                   subAcc[subField.name] || Yup.string()
                 ).required(`${subField.label} is required`);
               }
+              let other_descriptions = ['software_description'];
+              if (other_descriptions.includes(subField.name)) {
+                subAcc[subField.name] = (subAcc[subField.name] || Yup.string())
+                  .min(
+                    50,
+                    `${subField.label} must be greater than or equal to 50 characters`
+                  )
+                  .max(
+                    5000,
+                    `${subField.label} must be less than or equal to 5000 characters`
+                  )
+              }
 
               return subAcc;
             }, {})


### PR DESCRIPTION
## Overview
Updated the main project description to require min 1000 characters and max 5000
Updated other types of descriptions to require min 50 characters and max 5000

## Related

* [WC-269](https://tacc-main.atlassian.net/browse/WC-269)
* [WC-206](https://tacc-main.atlassian.net/browse/WC-206)
* [WC-209](https://tacc-main.atlassian.net/browse/WC-209)

## Changes


## Testing
1. Check dataset description requires the correct character length.
2. Check dataset description on edit dataset modal has the same secondary text as the create dataset modal.
3. Check software description (found under related software on the edit project modal) requires correct character length.
4. Check other descriptions in [sample data, digital dataset, analysis dataset] requires correct character length.

## UI



## Notes
This is to match DesignSafe's description requirements.
The 50/5000 is Google Scholar requirements.
The main project description (1000/5000) matches Maria's requirements.
