### PR TITLE
fix: lccf logo size

### DIFF
--- a/server/portal/templates/base.html
+++ b/server/portal/templates/base.html
@@ -16,18 +16,18 @@
     <link rel="canonical" href="{{request.get_full_path}}">
     <base href="/">
     {% block head_extra %}{% endblock %}
-    {% if settings.PORTAL_CSS_FILENAMES|length %}
-    <!-- Project CSS -->
-      {% for stylesheet in settings.PORTAL_CSS_FILENAMES %}
-      <link rel="stylesheet" href="{{ stylesheet }}">
-      {% endfor %}
-    {% endif %}
     <!-- Vendor CSS -->
     <link id="css-bootstrap" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <!-- Header CSS -->
     <link rel="stylesheet" href="/static/site_cms/css/build/core-styles.theme.default.css">
     <link rel="stylesheet" href="/static/site_cms/css/build/core-styles.header.css">
-
+    <!-- Project CSS -->
+    {% if settings.PORTAL_CSS_FILENAMES|length %}
+      {% for stylesheet in settings.PORTAL_CSS_FILENAMES %}
+      <link rel="stylesheet" href="{{ stylesheet }}">
+      {% endfor %}
+    {% endif %}
+  
     {% block styles %}{% endblock %}
   </head>
   <body>


### PR DESCRIPTION
## Overview

Load project CSS after all other CSS.

> [!TIP]
> This fixes "LCCF workbench has tiny logo/header" bug.

> [!NOTE]
> Only LCCF (and ECEP) currently use `PORTAL_CSS_FILENAMES`.

## Related

* [2025-08-13 CEPv3 Testing Session: Release v3.15.1](https://tacc-main.atlassian.net/wiki/spaces/UP/pages/755957762)

## Changes

* **moves** `<link>`s to later in `<head>`

## Testing

1. In window/tab B, open LCCF [Pre-Prod](https://pprd.lccf.tacc.utexas.edu).
2. In window/tab A, [log in to LCCF (Pre-Prod)](https://pprd.lccf.tacc.utexas.edu/login).
3. Compare header.
4. Verify header visually matches.

## UI

| CMS | Dashboard |
| - | - |
| … | … |

## Notes

Any "project" CSS must load after "foundation" CSS (Bootstrap) and "base" CSS (Core-Styles), otherwise it can not override them (with current CSS setup).[^1]

[^1]: There is a new CSS setup, where styles could be loaded in a different order. The `task/WC-219` and `task/ditial-rocks` branches are using it.