### PR TITLE
bug/WP-1054: Reset reservation field to default

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -369,6 +369,7 @@ export const AppSchemaForm = ({ app }) => {
     appId: app.definition.id,
     appVersion: app.definition.version,
     execSystemId: app.definition.jobAttributes.execSystemId,
+    reservation: '',
   };
 
   let missingAllocation = false;


### PR DESCRIPTION
## Overview
"Reset to defaults" and "Submit" buttons will now clear the reservation field.


## Related

* [WP-1054](https://tacc-main.atlassian.net/browse/WP-1054)

## Changes

Reservation field didn't originally clear when the job was submitted, or the reset button was pushed

## Testing

1. Go to [an app with a reservation field](https://cep.test/workbench/applications/opensees-s3?appVersion=latest)
2. Press the "Reset to defaults" button and verify the field is cleared
3. Press the "Submit" button and verify that the field is cleared.

## UI



## Notes

