### PR TITLE
RT_System to RT System

### DIFF
--- a/server/portal/apps/tickets/api/views.py
+++ b/server/portal/apps/tickets/api/views.py
@@ -19,6 +19,14 @@ SERVICE_ACCOUNTS = ["portal", "rtprod", "rtdev"]
 ALLOWED_HISTORY_TYPES = ["Correspond", "Create", "Status"]
 METADATA_HEADER = "*** Ticket Metadata ***"
 
+#"RT_System" -> "RT System"
+CREATOR_DISPLAY_OVERRIDE = getattr(
+    settings,
+    "TICKETS_CREATOR_DISPLAY_OVERRIDE",
+    {
+        "RT_System": "RT System",
+    },
+)
 
 class TicketsView(BaseApiView):
     def get(self, request, ticket_id=None):
@@ -131,6 +139,8 @@ class TicketsHistoryView(BaseApiView):
 
             if entry['Type'] == "Create":
                 entry["Content"] = entry['Content'][:entry['Content'].rfind(METADATA_HEADER)]
+
+            entry['Creator'] = CREATOR_DISPLAY_OVERRIDE.get(entry['Creator'], entry['Creator'])
 
             entry["IsCreator"] = True if requesting_username == entry['Creator'] else False
 


### PR DESCRIPTION
## Overview
Overwriting "RT_System" to "RT System" keeping it consistent with other ticket spaces.


## Related

* [WP-978](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-978)

## Changes



## Testing
1. Go to CEP dashboard and navigate to tickets
1. Any "RT_System" that was on ticket info page should be changed to "RT System"

## UI
<img width="435" height="513" alt="Screenshot 2025-09-29 at 3 02 01 PM" src="https://github.com/user-attachments/assets/6429b1c6-2874-413f-8e6c-e2bb3107f593" />



## Notes

