### PR TITLE
chore: remove old styles

### DIFF
--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -4,20 +4,6 @@
 <!-- FAQ: This template loads independently at a unique url (see `urls.py`)
           so CMS and User Guide can render this markup into their markup. -->
 
-{# GH-101: Remove style tag i.e. rely only on `site.header.css` #}
-<style type="text/css">
-  .s-portal-nav .icon {
-    margin-right: 0.25em;
-
-    /* Copied from FontAwesome `.fa-lg` */
-    font-size: 1.3em;
-    vertical-align: text-bottom; /* tweaked to align better */
-  }
-  .s-portal-nav .nav-link .icon {
-      font-size: 1.5em;
-      vertical-align: middle; /* tweaked to align better */
-  }
-</style>
 {% if user.is_authenticated %}
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Overview

Delete redundant styles.

<details><summary>Details</summary>

Styles are in `core-styles.header.css` via [`s-portal-nav.css`](https://github.com/TACC/Core-Styles/blob/v2.39.4/src/lib/_imports/trumps/s-portal-nav.css#L33-L38)

</details> 

## Changes

- deleted `<style>` tag

## Testing & UI

- When logged **out**, login button looks _the same as_ before.

	https://github.com/user-attachments/assets/f87b777b-95df-4a0a-a978-09dbba43146a

- When logged **in**, login menu looks _similar to_ before.

	https://github.com/user-attachments/assets/bab65163-dcb9-46d7-8905-397d1b395bee


## Notes

