### PR TITLE
bug/WC-418: no compress in published area

### DIFF
--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.jsx
@@ -64,9 +64,11 @@ const DataFilesToolbar = ({ scheme, api }) => {
     }
   });
 
-  const { projectId, is_published_project: isPublishedProject } = useSelector(
-    (state) => state.projects.metadata
-  );
+  const {
+    projectId,
+    is_published_project: isPublishedProject,
+    is_review_project: isReviewProject,
+  } = useSelector((state) => state.projects.metadata);
 
   // defaults to return true if no custom permission check is provided
   const [customPermissionCheck, setCustomPermissionCheck] = useState(
@@ -222,7 +224,11 @@ const DataFilesToolbar = ({ scheme, api }) => {
     const { exceedsSizeLimit, containsFolder } =
       canCompressForDownload(selectedFiles);
     const isCommunityOrPublicData =
-      params.scheme === 'community' || params.scheme === 'public';
+      params.scheme === 'community' ||
+      params.scheme === 'public' ||
+      (params.scheme === 'projects' &&
+        (params.system.includes('review') ||
+          params.system.includes('published')));
     // no folders modal is not necessary to show in community + public data areas as downloading multiple files at once isn't possible
     // there anyways
     if (containsFolder && !isCommunityOrPublicData) {
@@ -286,21 +292,28 @@ const DataFilesToolbar = ({ scheme, api }) => {
   const canRename =
     getFilePermissions('rename', permissionParams) &&
     !isGuest &&
-    !isPublishedProject;
+    !isPublishedProject &&
+    !isReviewProject;
   const canMove =
     getFilePermissions('move', permissionParams) &&
     !isGuest &&
-    !isPublishedProject;
+    !isPublishedProject &&
+    !isReviewProject;
   const canCopy =
     getFilePermissions('copy', permissionParams) && !!authenticatedUser;
   const canTrash =
     getFilePermissions('trash', permissionParams) &&
     !isGuest &&
-    !isPublishedProject;
+    !isPublishedProject &&
+    !isReviewProject;
   const canCompress =
-    getFilePermissions('compress', permissionParams) && !isPublishedProject;
+    getFilePermissions('compress', permissionParams) &&
+    !isPublishedProject &&
+    !isReviewProject;
   const canExtract =
-    getFilePermissions('extract', permissionParams) && !isPublishedProject;
+    getFilePermissions('extract', permissionParams) &&
+    !isPublishedProject &&
+    !isReviewProject;
   const canMakePublic =
     showMakePublic && getFilePermissions('public', permissionParams);
   const canEmpty = trashedFiles.length > 0;


### PR DESCRIPTION
## Overview
Disabling Compress in the review areas
Disabling Downloads of multiple files in published and review areas


## Related

* [WC-418](https://tacc-main.atlassian.net/browse/WC-418)

## Changes
Updating variables to add published and review areas to the flags for the download modal
Updating variables to disable the compress button in the review area


## Testing

1. Locally, with a to-review publication, select multiple files and make sure that the Compress button in the toolbar is not active.
2. Also check that if Download is clicked, it produces the "compress not available in this area" message in the modal.

## UI



## Notes
This should also cover the same for the published area but I am unable to test that locally.