### PR TITLE
task/WP-1209: fixing error on refresh

### DIFF
--- a/client/src/components/_custom/drp/utils/utils.js
+++ b/client/src/components/_custom/drp/utils/utils.js
@@ -34,6 +34,11 @@ export const formatLabel = (key) => {
 // Find a node in a tree structure by UUID
 // Returns the node if found, null otherwise
 export const findNodeInTree = (node, uuid) => {
+    //upon refresh, node is null so returning null
+    if (node === null) {
+        return null;
+    }
+
     if (node?.uuid === uuid) {
         return node;
     }


### PR DESCRIPTION
## Overview



## Related
* [WP-1209](https://tacc-main.atlassian.net/browse/WP-1209)


## Changes
Added a catch for null node in util function that was erroring out upon page refresh


## Testing
1. Go into an analysis or digital dataset and when the page is refreshed, it will reload the page properly without going blank due to errors.

## UI



## Notes

