### PR TITLE
WP-1208: Fix 'Show More' view display results for long descriptions

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
@@ -23,6 +23,7 @@
   margin-bottom: 1em; /* padding would only be effectual within scrollarea */
   color: var(--global-color-primary--x-dark);
   white-space: pre-wrap;
+  overflow-y: auto;
 
   /* FAQ: `14px` is part of normalization of "table" font sizes */
   font-size: 0.875rem; /* 14px (assumed deviation from design) */


### PR DESCRIPTION
## Overview
If the shared workspace description is too long and Show More is clicked, it takes up the entire screen and unable to scroll 


## Related

* [WP-1208](https://tacc-main.atlassian.net/browse/WP-1208)

## Changes
Addes overflow to the CSS for the description class.


## Testing
1. Either create a shared workspace with a very long decsription (around 500 chars), or go here: https://cep.test/workbench/data/tapis/projects/cep.project.CEP-1892
2. Click the Show More button on the description.
3. Verify that you are able to scroll down and read the whole description and get to the Show Less button.


## UI
<img width="1547" height="845" alt="Screenshot 2026-04-08 at 3 58 13 PM" src="https://github.com/user-attachments/assets/6aa4705c-4794-48f7-8d05-b7bf6d5646b5" />



## Notes

