### PR TITLE
bug/WP-1185 - Keywords & Description fields not wrapping correctly

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
@@ -23,7 +23,8 @@
   margin-bottom: 1em; /* padding would only be effectual within scrollarea */
   color: var(--global-color-primary--x-dark);
   white-space: pre-wrap;
-
+  overflow-x: hidden;
+  word-break: break-word;
   /* FAQ: `14px` is part of normalization of "table" font sizes */
   font-size: 0.875rem; /* 14px (assumed deviation from design) */
 


### PR DESCRIPTION
## Overview
Keywords & Description fields under a Shared Workspace are not wrapping correctly.


## Related

* [WP-1185](https://tacc-main.atlassian.net/browse/WP-1185)

## Changes
Added wordwrap to the description class in the CSS file for the Shared Workspace UI.


## Testing

1. Make a shared workspace with a very long description (around 500 characters) with no spaces. Or, use this one:
https://cep.test/workbench/data/tapis/projects/cep.project.CEP-1750
2. Make sure that you can still see the Edit Workspace and Manage Team buttons.

## UI
<img width="1540" height="771" alt="Screenshot 2026-04-08 at 4 06 14 PM" src="https://github.com/user-attachments/assets/87d47eb9-360f-4cd9-aa28-64d84f72394a" />



## Notes

