### PR TITLE
task/WI-433: Route user to system `homeDir` after successful credential creation

### DIFF
--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -10,7 +10,12 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useTable, useBlockLayout } from 'react-table';
 import { FixedSizeList, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { Link } from 'react-router-dom';
+import {
+  Link,
+  useRouteMatch,
+  generatePath,
+  useHistory,
+} from 'react-router-dom';
 import { useFileListing } from 'hooks/datafiles';
 import { LoadingSpinner, SectionMessage } from '_common';
 import './DataFilesTable.scss';
@@ -34,6 +39,8 @@ export const isNearBottom = ({
 // What to render if there are no files to display
 const DataFilesTablePlaceholder = ({ section, data }) => {
   const { params, error: err, loading } = useFileListing(section);
+  const match = useRouteMatch();
+  const history = useHistory();
 
   const isPublicSystem = params?.scheme === 'public';
 
@@ -67,10 +74,19 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
           .map((downSys) => downSys.hostname)
       : []
   );
+  const reloadPage = (sys) => {
+    dispatch({
+      type: 'UPDATE_STORAGE_SYSTEM_CONFIGURATION',
+      payload: sys,
+    });
+    const newPath = `${generatePath(match.path, sys)}${sys.homeDir || ''}`;
+    window.location.href = newPath; // TODO: replace with history.push when system storage configuration is updated
+    history.push(newPath);
+  };
   const pushKeys = (e) => {
     e.preventDefault();
     const props = {
-      onSuccess: {}, // TODO refresh datafiles root route if non tacc system
+      reloadCallback: reloadPage,
       system,
     };
     if (modalRefs.FileSelector) {

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.jsx
@@ -343,7 +343,7 @@ describe('DataFilesTable', () => {
             operation: 'pushKeys',
             props: {
               callback: expect.any(Function),
-              onSuccess: expect.any(Object),
+              reloadCallback: expect.any(Function),
               system: expect.any(Object),
             },
           },

--- a/client/src/components/_common/SystemsPushKeysModal/SystemsPushKeysModal.jsx
+++ b/client/src/components/_common/SystemsPushKeysModal/SystemsPushKeysModal.jsx
@@ -18,6 +18,7 @@ const SystemsPushKeysModal = () => {
     system,
     submitting,
     onCancel,
+    reloadCallback,
     isTACCPortal,
     initialUsername,
   } = useSelector(
@@ -59,7 +60,7 @@ const SystemsPushKeysModal = () => {
         password,
         token,
         isTMSSystem,
-        reloadCallback: reloadPage,
+        reloadCallback: reloadCallback || reloadPage,
         onSuccess,
       },
     });

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -21,6 +21,18 @@ export const addSystemDefinition = (system, definitionList) => {
   ];
 };
 
+// Helper function to update a system configuration in the list after a push keys operation
+const updateStorageSystemConfiguration = (configuration, systemConf) => {
+  const systemIndex = configuration.findIndex(
+    (s) => s.system === systemConf.system
+  );
+  if (systemIndex !== -1) {
+    const updated = configuration.splice(systemIndex, 1, systemConf);
+    return updated;
+  }
+  return configuration;
+};
+
 export function systems(state = initialSystemState, action) {
   switch (action.type) {
     case 'FETCH_SYSTEMS_STARTED':
@@ -43,6 +55,17 @@ export function systems(state = initialSystemState, action) {
           defaultHost: action.payload.default_host,
           defaultSystemId: action.payload.default_system_id,
           loading: false,
+        },
+      };
+    case 'UPDATE_STORAGE_SYSTEM_CONFIGURATION':
+      return {
+        ...state,
+        storage: {
+          ...state.storage,
+          configuration: updateStorageSystemConfiguration(
+            state.storage.configuration,
+            action.payload.system
+          ),
         },
       };
     case 'FETCH_SYSTEMS_ERROR':

--- a/client/src/redux/sagas/systems.sagas.js
+++ b/client/src/redux/sagas/systems.sagas.js
@@ -16,7 +16,7 @@ function* pushSystemKeys(action) {
   });
   try {
     const modalRefs = yield select((state) => state.files.refs);
-    yield call(fetchUtil, {
+    const res = yield call(fetchUtil, {
       url: `/api/accounts/systems/${action.payload.systemId}/keys/`,
       body: JSON.stringify({ form, action: 'push' }),
       method: 'PUT',
@@ -35,6 +35,7 @@ function* pushSystemKeys(action) {
     if (action.payload.onSuccess) {
       yield put(action.payload.onSuccess);
     }
+    yield call(action.payload.reloadCallback(res.system));
   } catch (error) {
     yield put({
       type: 'SYSTEMS_MODAL_UPDATE',
@@ -47,7 +48,6 @@ function* pushSystemKeys(action) {
       },
     });
   }
-  yield call(action.payload.reloadCallback);
 }
 
 export default function* watchSystems() {

--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -2,6 +2,7 @@
 .. :module:: portal.apps.accounts.api.views.systems
    :synopsis: Account's systems views
 """
+
 import logging
 import json
 from django.http import JsonResponse
@@ -10,13 +11,17 @@ from django.utils.decorators import method_decorator
 from portal.views.base import BaseApiView
 from portal.apps.accounts.managers import accounts as AccountsManager
 from tapipy.errors import BaseTapyException
-from portal.apps.onboarding.steps.system_access_v3 import create_system_credentials_with_keys, create_system_credentials
+from portal.apps.onboarding.steps.system_access_v3 import (
+    create_system_credentials_with_keys,
+    create_system_credentials,
+)
 from portal.utils.encryption import createKeyPair
+from portal.apps.datafiles.utils import evaluate_datafiles_storage_system
 
 logger = logging.getLogger(__name__)
 
 
-@method_decorator(login_required, name='dispatch')
+@method_decorator(login_required, name="dispatch")
 class SystemKeysView(BaseApiView):
     """Systems View
 
@@ -30,7 +35,7 @@ class SystemKeysView(BaseApiView):
         :param str system_id: System id
         """
         body = json.loads(request.body)
-        action = body['action']
+        action = body["action"]
         op = getattr(self, action)
         return op(request, system_id, body)
 
@@ -40,47 +45,74 @@ class SystemKeysView(BaseApiView):
         :param request: Django's request object
         :param str system_id: System id
         """
-        isTMSSystem = body['form']['isTMSSystem']
-        if isTMSSystem:
+        is_tms_system = body["form"]["isTMSSystem"]
+        client = request.user.tapis_oauth.client
+        tapis_username = request.user.username
+        login_username = body["form"]["username"]
+
+        if is_tms_system:
             try:
                 create_system_credentials(
-                    request.user.client, body['form']['username'], system_id, createTmsKeys=True
+                    client, login_username, system_id, createTmsKeys=True
                 )
                 http_status = 200
-                result = 'OK'
+                result = "OK"
             except BaseTapyException as e:
                 logger.exception(
                     "System access check failed for user: %s on system: %s",
-                    request.user.username,
+                    tapis_username,
                     system_id,
                 )
                 http_status = e.response.status_code
                 result = e.message
         else:
-            logger.info(f"Resetting credentials for user {request.user.username} on system {system_id}")
+            logger.info(
+                f"Resetting credentials for user {tapis_username} on system {system_id}"
+            )
             (priv_key_str, publ_key_str) = createKeyPair()
 
-            _, result, http_status = AccountsManager.add_pub_key_to_resource(
+            success, result, http_status = AccountsManager.add_pub_key_to_resource(
                 request.user,
-                username=body['form']['username'],
-                password=body['form']['password'],
-                token=body['form']['token'],
+                username=login_username,
+                password=body["form"]["password"],
+                token=body["form"]["token"],
                 system_id=system_id,
                 pub_key=publ_key_str,
-                hostname=body['form']['hostname'],
+                hostname=body["form"]["hostname"],
             )
 
-            create_system_credentials_with_keys(request.user.tapis_oauth.client,
-                                                request.user.username,
-                                                publ_key_str,
-                                                priv_key_str,
-                                                system_id,
-                                                loginUser=body['form']['username'])
+            if not success:
+                logger.error(
+                    f"Failed to push keys for user {tapis_username} on system {system_id}: {result}"
+                )
+                return JsonResponse({"message": result}, status=http_status)
+
+            create_system_credentials_with_keys(
+                client,
+                tapis_username,
+                publ_key_str,
+                priv_key_str,
+                system_id,
+                loginUser=login_username,
+            )
+
+        tapis_system = client.systems.getSystem(systemId=system_id)
+
+        portal_system = {
+            "name": tapis_system.notes.get(
+                "label", tapis_system.notes.get("title", tapis_system.id)
+            ),
+            "system": tapis_system.id,
+            "scheme": "private",
+            "api": "tapis",
+            "icon": None,
+            "default": False,
+        }
+
+        evaluated_system = evaluate_datafiles_storage_system(
+            request.user.tapis_oauth, portal_system, default_host_eval="HOME"
+        )
 
         return JsonResponse(
-            {
-                'systemId': system_id,
-                'message': result
-            },
-            status=http_status
+            {"system": evaluated_system, "message": result}, status=http_status
         )


### PR DESCRIPTION
## Overview

After a user successfully creates credentials via the SystemsPushKeysModal in the datafiles view, we evaluate the correct `homeDir` for the user and redirect the user to this new path, correctly loading their data.

## Related

* [WI-433](https://tacc-main.atlassian.net/browse/WI-433)

## Changes

- systems push keys endpoint now returns an evaluated "system" for the client side to use

## Testing

Also in pprd: https://pprd.core-oidc.tacc.cloud/

1. Delete your credentials with tapipy, e.g. `client.systems.removeUserCredential(systemId='vista', userName='sal')` (ping me if want me to run this)
2. Go to https://cep.test/workbench/data/tapis/private/vista
3. Enter your credentials and submit
4. Confirm you are redirected to your $HOME dir after success
