### PR TITLE
bug/WP-1142 - Change icon for button that loads information modal 

### DIFF
--- a/client/src/components/Jobs/Jobs.jsx
+++ b/client/src/components/Jobs/Jobs.jsx
@@ -245,7 +245,7 @@ function JobsView({
             size="small"
             onClick={() => setIsInfoModalOpen(true)}
           >
-            ?
+            ⓘ
           </Button>
         </div>
       )}


### PR DESCRIPTION
## Overview
Button had a question mark, which could imply searching rather than information.


## Related

* [WP-1142](https://tacc-main.atlassian.net/browse/WP-1142)

## Changes
Changed button icon for information modal to ⓘ


## Testing

1. Go to https://cep.test/workbench/history/jobs
2. Validate that UI changes button from ? to ⓘ and is acceptable

## UI

<img width="925" height="157" alt="Screenshot 2026-04-09 at 12 29 45 PM" src="https://github.com/user-attachments/assets/a880f16a-168f-46ce-8b76-3d377005c2be" />


## Notes

