### PR TITLE
bug/WP-1141 - Add comment in info modal to tell users that only 1 word is being used

### DIFF
--- a/client/src/components/Jobs/JobsSearchInfoModal/JobsSearchInfoModal.jsx
+++ b/client/src/components/Jobs/JobsSearchInfoModal/JobsSearchInfoModal.jsx
@@ -10,7 +10,6 @@ const JobsSearchInfoModal = ({ isOpen, toggle }) => {
       </ModalHeader>
       <ModalBody>
         <ul>
-          <li>Only the first word will be used in the search.</li>
           <li>
             Search is case-sensitive, meaning it looks for names that match
             exactly how they&apos;re written.

--- a/client/src/components/Jobs/JobsSearchInfoModal/JobsSearchInfoModal.jsx
+++ b/client/src/components/Jobs/JobsSearchInfoModal/JobsSearchInfoModal.jsx
@@ -10,6 +10,7 @@ const JobsSearchInfoModal = ({ isOpen, toggle }) => {
       </ModalHeader>
       <ModalBody>
         <ul>
+          <li>Only the first word will be used in the search.</li>
           <li>
             Search is case-sensitive, meaning it looks for names that match
             exactly how they&apos;re written.

--- a/client/src/components/_common/Searchbar/Searchbar.jsx
+++ b/client/src/components/_common/Searchbar/Searchbar.jsx
@@ -75,6 +75,19 @@ const Searchbar = ({
     history.push(location.pathname);
   };
 
+  const getValidationMessage = (value) => {
+    if (/\s/.test(value))
+      return 'Search term must be a single word with no spaces.';
+    if (value.length < 3)
+      return 'Include at least 3 characters in your search.';
+    return '';
+  };
+
+  const onInput = (e) =>
+    e.target.setCustomValidity(getValidationMessage(e.target.value));
+  const onInvalid = (e) =>
+    e.target.setCustomValidity(getValidationMessage(e.target.value));
+
   const onChange = (e) => setQuery(e.target.value);
 
   return (
@@ -98,12 +111,8 @@ const Searchbar = ({
         <input
           type="search"
           minLength="3"
-          onInput={(e) => e.target.setCustomValidity('')}
-          onInvalid={(e) =>
-            e.target.setCustomValidity(
-              'Include at least 3 characters in your search.'
-            )
-          }
+          onInput={onInput}
+          onInvalid={onInvalid}
           onChange={onChange}
           value={query || ''}
           name="query"


### PR DESCRIPTION
## Overview
Job history search only uses the first word in the field, but this isn't documented anywhere.


## Related

* [WP-1141](https://tacc-main.atlassian.net/browse/WP-1141)

## Changes
Updated the info modal to make it clear that job history search only uses the first word.


## Testing

1. Go to https://cep.tacc.utexas.edu/workbench/history/jobs
3. Attempt to enter more than one word in the search box and verify that a validation error comes up.

## UI


## Notes

