### PR TITLE
display non-hidden env vars

### DIFF
--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -83,7 +83,7 @@ function Workbench() {
       dispatch({ type: 'GET_JOBS', params: { offset: 0 } });
       dispatch({ type: 'PROJECTS_GET_LISTING' });
     }
-  }, [setupComplete]);
+  }, [setupComplete, isTACCPortal, dispatch]);
 
   return (
     <div className="workbench-wrapper">

--- a/client/src/redux/sagas/fixtures/jobdetaildisplay.fixture.js
+++ b/client/src/redux/sagas/fixtures/jobdetaildisplay.fixture.js
@@ -29,6 +29,11 @@ const jobDetailDisplayFixture = {
       id: '_mainProgram',
       value: 'OpenSeesSP',
     },
+    {
+      label: 'tacc Scheduler Profile',
+      id: 'tacc Scheduler Profile',
+      value: '--tapis-profile tacc',
+    },
   ],
   queue: 'development',
   systemName: 'Frontera',

--- a/client/src/redux/sagas/fixtures/jobdetaildisplaySlurm.fixture.js
+++ b/client/src/redux/sagas/fixtures/jobdetaildisplaySlurm.fixture.js
@@ -19,6 +19,11 @@ const jobDisplaySlurmFixture = {
       id: 'Target',
       value: 'world',
     },
+    {
+      label: 'tacc Scheduler Profile',
+      id: 'tacc Scheduler Profile',
+      value: '--tapis-profile tacc',
+    },
   ],
   nodeCount: 1,
   coresPerNode: 1,

--- a/client/src/utils/jobsUtil.js
+++ b/client/src/utils/jobsUtil.js
@@ -202,6 +202,7 @@ export function getJobDisplayInformation(job, app) {
   );
   const configMappedSchedulerOptionNames = new Set([
     'Project Allocation Account',
+    'TACC Allocation',
     'TACC Reservation',
   ]);
   const visibleSchedulerOptions = filterHiddenObjects(schedulerOptions).filter(
@@ -257,7 +258,9 @@ export function getJobDisplayInformation(job, app) {
 
       if (app.definition.jobType === 'BATCH') {
         const allocationParam = schedulerOptions.find(
-          (opt) => opt.name === 'Project Allocation Account'
+          (opt) =>
+            opt.name === 'Project Allocation Account' ||
+            opt.name === 'TACC Allocation'
         );
         const allocation = getAllocatonFromDirective(allocationParam.arg);
         if (allocation) {

--- a/client/src/utils/jobsUtil.js
+++ b/client/src/utils/jobsUtil.js
@@ -150,9 +150,21 @@ export function getInputDisplayValues(fileInputs) {
  * Get display values from job, app and execution system info
  */
 export function getJobDisplayInformation(job, app) {
+  const parseNotes = (notes) => {
+    if (!notes) return null;
+    if (typeof notes === 'string') {
+      try {
+        return JSON.parse(notes);
+      } catch (ignore) {
+        return null;
+      }
+    }
+    return notes;
+  };
+
   const filterHiddenObjects = (objects) =>
     objects.filter((obj) => {
-      const notes = obj.notes ? JSON.parse(obj.notes) : null;
+      const notes = parseNotes(obj.notes);
       return !notes || !notes.isHidden;
     });
 
@@ -162,16 +174,44 @@ export function getJobDisplayInformation(job, app) {
 
   const envVariables = parameterSet.envVariables;
   const schedulerOptions = parameterSet.schedulerOptions;
+  const visibleAppEnvVariables =
+    app?.definition?.jobAttributes?.parameterSet?.envVariables
+      ?.filter((envVar) => {
+        const notes = parseNotes(envVar.notes);
+        return !notes || !notes.isHidden;
+      })
+      ?.map((envVar) => ({
+        key: envVar.key,
+        label: parseNotes(envVar.notes)?.label || envVar.key,
+      })) ?? [];
+  const visibleAppEnvKeys = new Set(
+    visibleAppEnvVariables.map((envVar) => envVar.key)
+  );
+  const visibleAppEnvLabels = Object.fromEntries(
+    visibleAppEnvVariables.map((envVar) => [envVar.key, envVar.label])
+  );
+  const visibleEnvVariables = envVariables.filter((envVar) => {
+    if (!envVar.key || envVar.key.startsWith('_')) return false;
+    if (app) return visibleAppEnvKeys.has(envVar.key);
+    return true;
+  });
 
   const display = {
     applicationName: job.appId,
     systemName: job.execSystemId,
     inputs: getInputDisplayValues(fileInputs),
-    parameters: parameters.map((parameter) => ({
-      label: parameter.name,
-      id: parameter.name,
-      value: parameter.arg,
-    })),
+    parameters: [
+      ...parameters.map((parameter) => ({
+        label: parameter.name,
+        id: parameter.name,
+        value: parameter.arg,
+      })),
+      ...visibleEnvVariables.map((envVar) => ({
+        label: visibleAppEnvLabels[envVar.key] || envVar.key,
+        id: envVar.key,
+        value: envVar.value,
+      })),
+    ],
   };
 
   if (app) {

--- a/client/src/utils/jobsUtil.js
+++ b/client/src/utils/jobsUtil.js
@@ -189,13 +189,17 @@ export function getJobDisplayInformation(job, app) {
   const visibleAppEnvLabels = Object.fromEntries(
     visibleAppEnvVariables.map((envVar) => [envVar.key, envVar.label])
   );
-  const visibleEnvVariables = filterHiddenObjects(envVariables).filter((envVar) => {
-    if (!envVar.key || envVar.key.startsWith('_')) return false;
-    if (app) return visibleAppEnvKeys.has(envVar.key);
-    return true;
-  });
+  const visibleEnvVariables = filterHiddenObjects(envVariables).filter(
+    (envVar) => {
+      if (!envVar.key || envVar.key.startsWith('_')) return false;
+      if (app) return visibleAppEnvKeys.has(envVar.key);
+      return true;
+    }
+  );
   const visibleAppArgs = filterHiddenObjects(parameterSet.appArgs || []);
-  const visibleContainerArgs = filterHiddenObjects(parameterSet.containerArgs || []);
+  const visibleContainerArgs = filterHiddenObjects(
+    parameterSet.containerArgs || []
+  );
   const configMappedSchedulerOptionNames = new Set([
     'Project Allocation Account',
     'TACC Reservation',

--- a/client/src/utils/jobsUtil.js
+++ b/client/src/utils/jobsUtil.js
@@ -170,16 +170,15 @@ export function getJobDisplayInformation(job, app) {
 
   const fileInputs = filterHiddenObjects(JSON.parse(job.fileInputs));
   const parameterSet = JSON.parse(job.parameterSet);
-  const parameters = filterHiddenObjects(parameterSet.appArgs);
-
-  const envVariables = parameterSet.envVariables;
-  const schedulerOptions = parameterSet.schedulerOptions;
+  const envVariables = parameterSet.envVariables || [];
+  const schedulerOptions = parameterSet.schedulerOptions || [];
   const visibleAppEnvVariables =
     app?.definition?.jobAttributes?.parameterSet?.envVariables
       ?.filter((envVar) => {
         const notes = parseNotes(envVar.notes);
         return !notes || !notes.isHidden;
       })
+      ?.filter((envVar) => envVar?.key && !envVar.key.startsWith('_'))
       ?.map((envVar) => ({
         key: envVar.key,
         label: parseNotes(envVar.notes)?.label || envVar.key,
@@ -190,18 +189,27 @@ export function getJobDisplayInformation(job, app) {
   const visibleAppEnvLabels = Object.fromEntries(
     visibleAppEnvVariables.map((envVar) => [envVar.key, envVar.label])
   );
-  const visibleEnvVariables = envVariables.filter((envVar) => {
+  const visibleEnvVariables = filterHiddenObjects(envVariables).filter((envVar) => {
     if (!envVar.key || envVar.key.startsWith('_')) return false;
     if (app) return visibleAppEnvKeys.has(envVar.key);
     return true;
   });
+  const visibleAppArgs = filterHiddenObjects(parameterSet.appArgs || []);
+  const visibleContainerArgs = filterHiddenObjects(parameterSet.containerArgs || []);
+  const configMappedSchedulerOptionNames = new Set([
+    'Project Allocation Account',
+    'TACC Reservation',
+  ]);
+  const visibleSchedulerOptions = filterHiddenObjects(schedulerOptions).filter(
+    (parameter) => !configMappedSchedulerOptionNames.has(parameter?.name)
+  );
 
   const display = {
     applicationName: job.appId,
     systemName: job.execSystemId,
     inputs: getInputDisplayValues(fileInputs),
     parameters: [
-      ...parameters.map((parameter) => ({
+      ...visibleAppArgs.map((parameter) => ({
         label: parameter.name,
         id: parameter.name,
         value: parameter.arg,
@@ -210,6 +218,16 @@ export function getJobDisplayInformation(job, app) {
         label: visibleAppEnvLabels[envVar.key] || envVar.key,
         id: envVar.key,
         value: envVar.value,
+      })),
+      ...visibleContainerArgs.map((parameter) => ({
+        label: parameter.name,
+        id: parameter.name,
+        value: parameter.arg,
+      })),
+      ...visibleSchedulerOptions.map((parameter) => ({
+        label: parameter.name,
+        id: parameter.name,
+        value: parameter.arg,
       })),
     ],
   };

--- a/client/src/utils/jobsUtil.test.js
+++ b/client/src/utils/jobsUtil.test.js
@@ -87,6 +87,38 @@ describe('jobsUtil', () => {
     ]);
   });
 
+  it('handles mixed parameterSet values without app definition', () => {
+    const job = {
+      ...jobDetailFixture,
+      fileInputs: '[]',
+      parameterSet: JSON.stringify({
+        appArgs: [{ name: 'A', arg: '1', notes: 'not-json' }],
+        envVariables: [{ key: 'CUSTOM_KERNELSPEC', value: '/work/custom' }],
+        containerArgs: [{ name: 'Bind Mounts', arg: '--bind /work' }],
+        schedulerOptions: [],
+      }),
+    };
+
+    const display = getJobDisplayInformation(job);
+    expect(display.parameters).toEqual([
+      {
+        label: 'A',
+        id: 'A',
+        value: '1',
+      },
+      {
+        label: 'CUSTOM_KERNELSPEC',
+        id: 'CUSTOM_KERNELSPEC',
+        value: '/work/custom',
+      },
+      {
+        label: 'Bind Mounts',
+        id: 'Bind Mounts',
+        value: '--bind /work',
+      },
+    ]);
+  });
+
   it('get input display values for single file', () => {
     expect(
       getInputDisplayValues([

--- a/client/src/utils/jobsUtil.test.js
+++ b/client/src/utils/jobsUtil.test.js
@@ -45,6 +45,48 @@ describe('jobsUtil', () => {
     ).toEqual(jobDetailDisplayFixture);
   });
 
+  it('includes non-hidden env vars from app definition', () => {
+    const app = {
+      definition: {
+        jobType: 'BATCH',
+        notes: {},
+        jobAttributes: {
+          parameterSet: {
+            envVariables: [
+              {
+                key: 'CUSTOM_KERNELSPEC',
+                notes: { label: 'Custom Python Kernelspec Directory' },
+              },
+              { key: 'HIDDEN_VAR', notes: { isHidden: true } },
+            ],
+          },
+        },
+      },
+    };
+    const job = {
+      ...jobDetailFixture,
+      parameterSet: JSON.stringify({
+        appArgs: [],
+        envVariables: [
+          { key: 'CUSTOM_KERNELSPEC', value: '/work/user/kernelspec' },
+          { key: 'HIDDEN_VAR', value: 'secret' },
+          { key: '_tapisJobUUID', value: 'abc' },
+        ],
+        schedulerOptions: [],
+      }),
+      fileInputs: '[]',
+    };
+
+    const display = getJobDisplayInformation(job, app);
+    expect(display.parameters).toEqual([
+      {
+        label: 'Custom Python Kernelspec Directory',
+        id: 'CUSTOM_KERNELSPEC',
+        value: '/work/user/kernelspec',
+      },
+    ]);
+  });
+
   it('get input display values for single file', () => {
     expect(
       getInputDisplayValues([


### PR DESCRIPTION
## Overview
Display non-hidden env vars in the parameter set when viewing a job detail modal. e.g. the CUSTOM_KERNELSPEC 


## Related

* [WP-1140](https://tacc-main.atlassian.net/browse/WP-1140)

## Changes
parseNotes normalizes notes into one shape (an object) 

visibleAppEnvVariables is used to read non-hidden env vars.


## Testing

1. Test using an app that has env vars: 
openfoam (solver, decomp, mesh)
Jupyter HPC Native with Custom Python Kernelspec Directory: /work2/05193/sabyadk/frontera/conda_install/custom_kernel/kernels/py311
2. Confirm env vars appears under "Inputs"

## UI

<img width="464" height="488" alt="Screen Shot 2026-04-10 at 4 24 31 PM" src="https://github.com/user-attachments/assets/aa55bb90-d455-4118-be5f-6924682df44c" />



## Notes

