### PR TITLE
validate form on mount

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescriptionModal.jsx
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesProjectEditDescriptionModal.jsx
@@ -94,65 +94,74 @@ const DataFilesProjectEditDescriptionModal = () => {
       <ModalBody>
         <Formik
           initialValues={initialValues}
+          initialTouched={{
+            title: true,
+            description: true,
+            keywords: true,
+          }}
           onSubmit={setProjectTitleDescription}
           validationSchema={validationSchema}
+          validateOnMount
         >
-          <Form>
-            <FormField
-              name="title"
-              aria-label="title"
-              label={
-                <div>
-                  Title{' '}
-                  <small>
-                    <em>(Maximum {maxTitleLength} characters)</em>
-                  </small>
-                </div>
-              }
-            />
-            {!!minDescriptionLength && (
+          {({ isValid, dirty }) => (
+            <Form>
               <FormField
-                name="description"
-                aria-label="description"
+                name="title"
+                aria-label="title"
                 label={
                   <div>
-                    Description{' '}
+                    Title{' '}
                     <small>
-                      <em>(Minimum {minDescriptionLength} characters)</em>
+                      <em>(Maximum {maxTitleLength} characters)</em>
                     </small>
                   </div>
                 }
-                type="textarea"
-                className={styles['description-textarea']}
               />
-            )}
-            {!!enableWorkspaceKeywords && (
-              <FormField
-                name="keywords"
-                aria-label="keywords"
-                tags
-                label={<div>Keywords</div>}
-                type="textarea"
-                className={styles['description-textarea']}
-              />
-            )}
-            <div className={styles['button-container']}>
-              {updatingError && (
-                <Message type="error" dataTestid="updating-error">
-                  Something went wrong.
-                </Message>
+              {!!minDescriptionLength && (
+                <FormField
+                  name="description"
+                  aria-label="description"
+                  label={
+                    <div>
+                      Description{' '}
+                      <small>
+                        <em>(Minimum {minDescriptionLength} characters)</em>
+                      </small>
+                    </div>
+                  }
+                  type="textarea"
+                  className={styles['description-textarea']}
+                />
               )}
-              <Button
-                attr="submit"
-                type="primary"
-                size="long"
-                className={styles['update-button']}
-                isLoading={isUpdating}
-              >
-                Update Changes
-              </Button>
-            </div>
-          </Form>
+              {!!enableWorkspaceKeywords && (
+                <FormField
+                  name="keywords"
+                  aria-label="keywords"
+                  tags
+                  label={<div>Keywords</div>}
+                  type="textarea"
+                  className={styles['description-textarea']}
+                />
+              )}
+              <div className={styles['button-container']}>
+                {updatingError && (
+                  <Message type="error" dataTestid="updating-error">
+                    Something went wrong.
+                  </Message>
+                )}
+                <Button
+                  attr="submit"
+                  type="primary"
+                  size="long"
+                  disabled={!isValid}
+                  className={styles['update-button']}
+                  isLoading={isUpdating}
+                >
+                  Update Changes
+                </Button>
+              </div>
+            </Form>
+          )}
         </Formik>
       </ModalBody>
     </Modal>


### PR DESCRIPTION
## Overview

Validates edit project modal form on initial render.

## Related

* [WP-1207](https://tacc-main.atlassian.net/browse/WP-1207)


## Testing

1. Open a project with bad validation, and confirm form displays errors and submit is disabled on initial render

## UI

<img width="792" height="429" alt="Screenshot 2026-04-13 at 11 14 53 AM" src="https://github.com/user-attachments/assets/c1c80dbc-cc79-48d2-9b72-c78be7547d98" />
