### PR TITLE
bug/WP-1226: Fix job webhook notifications

### DIFF
--- a/server/portal/apps/auth/middleware.py
+++ b/server/portal/apps/auth/middleware.py
@@ -47,7 +47,7 @@ class TapisTokenRefreshMiddleware:
                 extra={"user": request.user.username},
             )
             logout(request)
-            return HttpResponseRedirect(reverse("portal_accounts:login"))
+            return HttpResponseRedirect(reverse("login"))
 
         if not tapis_oauth.expired:
             return
@@ -72,7 +72,7 @@ class TapisTokenRefreshMiddleware:
                         extra={"user": request.user.username},
                     )
                     logout(request)
-                    return HttpResponseRedirect(reverse("portal_accounts:login"))
+                    return HttpResponseRedirect(reverse("login"))
 
             else:
                 logger.info(

--- a/server/portal/apps/signals/receivers.py
+++ b/server/portal/apps/signals/receivers.py
@@ -27,7 +27,7 @@ def portal_event_callback(sender, **kwargs):
     if users:
         for user in users:
             async_to_sync(channel_layer.group_send)(
-                user.username,
+                str(user.id),
                 {
                     'type': 'portal_notification',
                     'body': data
@@ -52,8 +52,9 @@ def send_notification_ws(sender, instance, created, **kwargs):
     try:
         instance_dict = instance.to_dict()
         logger.info(instance_dict)
+        user = get_user_model().objects.get(username=instance.user)
         async_to_sync(channel_layer.group_send)(
-            instance.user,
+            str(user.id),
             {
                 'type': 'portal_notification',
                 'body': instance_dict
@@ -90,7 +91,7 @@ def send_setup_event(sender, instance, **kwargs):
         }
         for user in set(receiving_users):
             async_to_sync(channel_layer.group_send)(
-                user.username,
+                str(user.id),
                 {
                     'type': 'portal_notification',
                     'body': data


### PR DESCRIPTION

## Overview

Fixes an issue where job webhooks would not come through, now that notification channels are based on user.id.

Also fixes an unrelated bad reverse url.

## Related

* [WP-1226](https://tacc-main.atlassian.net/browse/WP-1226)


## Testing

1. Submit a job, and confirm notifications come through
