### PR TITLE
task/WP-1221 - Fix scroll for longer descriptions

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.module.scss
@@ -23,7 +23,6 @@
   margin-bottom: 1em; /* padding would only be effectual within scrollarea */
   color: var(--global-color-primary--x-dark);
   white-space: pre-wrap;
-  overflow-y: auto;
   overflow-x: hidden;
   word-break: break-word;
   /* FAQ: `14px` is part of normalization of "table" font sizes */

--- a/client/src/components/_common/ShowMore/ShowMore.module.scss
+++ b/client/src/components/_common/ShowMore/ShowMore.module.scss
@@ -9,5 +9,5 @@
   max-height: 200px;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: #ccc transparent;
+  scrollbar-color: #cccccc transparent;
 }

--- a/client/src/components/_common/ShowMore/ShowMore.module.scss
+++ b/client/src/components/_common/ShowMore/ShowMore.module.scss
@@ -8,6 +8,4 @@
   composes: x-untruncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
   max-height: 200px;
   overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: #cccccc transparent;
 }

--- a/client/src/components/_common/ShowMore/ShowMore.module.scss
+++ b/client/src/components/_common/ShowMore/ShowMore.module.scss
@@ -6,4 +6,8 @@
 
 .expanded {
   composes: x-untruncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #ccc transparent;
 }


### PR DESCRIPTION
## Overview

If very very long description, can’t scroll out of description window unless the user collapses it again. 

## Related

* [WP-1221](https://tacc-main.atlassian.net/browse/WP-1221)

## Changes
Added max display height and scroll bar for Show More component


## Testing

1. Either create a shared workspace with a very long decsription (around 500 chars), or go here: https://cep.test/workbench/data/tapis/projects/cep.project.CEP-1892
2. Click the Show More button on the description.
3. Verify that you are able scroll through the entire description and that there is a maximum height
4. Verify that you are able to scroll past the metadata header of the Shared Workspace and view the file listing.

## UI

<img width="1294" height="580" alt="Screenshot 2026-04-17 at 1 47 49 PM" src="https://github.com/user-attachments/assets/cf48ea85-b389-45c8-ae43-e13dd534b666" />


## Notes

