### PR TITLE
task/wc-379: referenced digital dataset should be link if valid url

### DIFF
--- a/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
+++ b/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
@@ -164,7 +164,7 @@ function PublishedDatasetEntityDetail({ params }) {
                                 if (key === 'digital_dataset') {
                                     return (
                                         <tr key={key}>
-                                            <th className="c-data-list__key">{formatLabel(key)}</th>
+                                            <th className="c-data-list__key">Reference Digital Dataset</th>
                                             <td className="c-data-list__value">{getDigitalDatasetLink(value)}</td>
                                         </tr>
                                     );

--- a/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
+++ b/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
@@ -119,8 +119,14 @@ function PublishedDatasetEntityDetail({ params }) {
         
         const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+        const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
+
         if (!uuidRegex.test(digitalDataset)) {
             return formatLabel(digitalDataset);
+        }
+        //if referenced digital dataset is a valid url, make it a link
+        else if (urlRegex.test(digitalDataset)) {
+            return <Link to={digitalDataset}>{digitalDataset}</Link>;
         }
     
         const digitalDatasetEntity = findNodeInTree(tree, digitalDataset);

--- a/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
+++ b/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
@@ -121,12 +121,12 @@ function PublishedDatasetEntityDetail({ params }) {
 
         const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
 
-        if (!uuidRegex.test(digitalDataset)) {
-            return formatLabel(digitalDataset);
-        }
         //if referenced digital dataset is a valid url, make it a link
-        else if (urlRegex.test(digitalDataset)) {
-            return <Link to={digitalDataset}>{digitalDataset}</Link>;
+        if (urlRegex.test(digitalDataset)) {
+            return <a href={`${digitalDataset}`} target="_blank">{digitalDataset}</a>;
+        }
+        else if (!uuidRegex.test(digitalDataset)) {
+            return formatLabel(digitalDataset);
         }
     
         const digitalDatasetEntity = findNodeInTree(tree, digitalDataset);

--- a/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
+++ b/client/src/components/_custom/drp/PublishedDatasets/PublishedDatasetEntityDetail.jsx
@@ -123,7 +123,7 @@ function PublishedDatasetEntityDetail({ params }) {
 
         //if referenced digital dataset is a valid url, make it a link
         if (urlRegex.test(digitalDataset)) {
-            return <a href={`${digitalDataset}`} target="_blank">{digitalDataset}</a>;
+            return <a href={`${digitalDataset}`} target="_blank" rel="noreferrer">{digitalDataset}</a>;
         }
         else if (!uuidRegex.test(digitalDataset)) {
             return formatLabel(digitalDataset);


### PR DESCRIPTION
## Overview
If a published digital dataset has a reference digital dataset, it should be clickable if it's a valid url.

## Related

* [WC-379](https://tacc-main.atlassian.net/browse/WC-379)

## Changes
Adding url regex to validate if a referenced digital dataset is a url
If valid, returns a link so the url is clickable

## Testing
I don't know if/how this can be tested locally.
1. If on pprd, in the top menu, go to publications, find a publication which has a digital dataset with a referenced digital dataset and if it's a valid url, it should be a link now.

## UI



## Notes

