### PR TITLE
task/WA-526, task/WI-466: Handle more System Queue Scheduler Options types; Handle `PASSWORD` auth Tapis systems

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -251,7 +251,7 @@ export const AppSchemaForm = ({ app }) => {
     execSystem,
     defaultSystemId,
     defaultArchivePath,
-    keyService,
+    isTMSSystem,
     allocationToExecSysMap,
     hideManageAccount,
     isTACCPortal,
@@ -262,7 +262,7 @@ export const AppSchemaForm = ({ app }) => {
     );
     const { defaultHost, configuration, defaultSystemId } =
       state.systems.storage;
-    const keyService = pushKeysSystem?.defaultAuthnMethod === 'TMS_KEYS';
+    const isTMSSystem = pushKeysSystem?.defaultAuthnMethod === 'TMS_KEYS';
 
     const hasCorral =
       configuration.length &&
@@ -309,7 +309,7 @@ export const AppSchemaForm = ({ app }) => {
         ) ?? null,
       defaultSystemId,
       defaultArchivePath,
-      keyService,
+      isTMSSystem,
       allocationToExecSysMap,
       hideManageAccount: state.workbench.config.hideManageAccount,
       isTACCPortal,
@@ -406,7 +406,7 @@ export const AppSchemaForm = ({ app }) => {
       );
     }
   }
-  const sectionMessage = keyService ? (
+  const sectionMessage = isTMSSystem ? (
     <span>
       For help,{' '}
       <Link
@@ -425,7 +425,7 @@ export const AppSchemaForm = ({ app }) => {
         href="#"
         onClick={pushKeys}
       >
-        push your keys
+        create your system Tapis system credentials.
       </a>
       .
     </span>
@@ -921,6 +921,7 @@ export const AppSchemaForm = ({ app }) => {
                           name="allocation"
                           description="Enter the project allocation you would like to use with this job submission."
                           type="text"
+                          required
                         />
                       ))}
                     {isJobTypeBATCH(app) &&
@@ -973,16 +974,31 @@ export const AppSchemaForm = ({ app }) => {
                             (opt) =>
                               !opt.notes?.isHidden && (
                                 <FormField
-                                  key={opt.name}
-                                  label={opt.notes?.label || opt.name}
+                                  key={`queueSchedulerOptions.${opt.name}`}
                                   name={`queueSchedulerOptions.${opt.name}`}
+                                  label={opt.notes?.label || opt.name}
                                   description={opt.description}
-                                  type={
-                                    opt.notes?.fieldType === 'number'
-                                      ? 'number'
-                                      : 'text'
-                                  }
-                                />
+                                  type={opt.notes?.fieldType || 'text'}
+                                  required={opt.inputMode === 'REQUIRED'}
+                                >
+                                  {opt.notes?.enum_values
+                                    ? opt.notes?.enum_values.map((item) => {
+                                        let val = item;
+                                        if (val instanceof String) {
+                                          const tmp = {};
+                                          tmp[val] = val;
+                                          val = tmp;
+                                        }
+                                        return Object.entries(val).map(
+                                          ([key, value]) => (
+                                            <option key={key} value={key}>
+                                              {value}
+                                            </option>
+                                          )
+                                        );
+                                      })
+                                    : null}
+                                </FormField>
                               )
                           )}
                       </>

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -425,7 +425,7 @@ export const AppSchemaForm = ({ app }) => {
         href="#"
         onClick={pushKeys}
       >
-        create your system Tapis system credentials.
+        create your Tapis system credentials.
       </a>
       .
     </span>

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -169,7 +169,7 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
                 href="#"
                 onClick={pushKeys}
               >
-                push your keys
+                create your system Tapis system credentials.
               </a>
             </span>
           );

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.jsx
@@ -169,7 +169,7 @@ const DataFilesTablePlaceholder = ({ section, data }) => {
                 href="#"
                 onClick={pushKeys}
               >
-                create your system Tapis system credentials.
+                create your Tapis system credentials.
               </a>
             </span>
           );

--- a/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.jsx
+++ b/client/src/components/DataFiles/DataFilesTable/DataFilesTable.test.jsx
@@ -331,7 +331,7 @@ describe('DataFilesTable', () => {
       getByText(/There was a problem accessing this file system./)
     ).toBeDefined();
 
-    fireEvent.click(getByText(/push your keys/));
+    fireEvent.click(getByText(/create your Tapis system credentials/));
     await waitFor(() => {
       expect(storeWithError.getActions()).toEqual([
         {

--- a/client/src/components/_common/SystemsPushKeysModal/SystemsPushKeysModal.jsx
+++ b/client/src/components/_common/SystemsPushKeysModal/SystemsPushKeysModal.jsx
@@ -30,7 +30,7 @@ const SystemsPushKeysModal = () => {
     shallowEqual
   );
 
-  const isTMSSystem = system?.defaultAuthnMethod === 'TMS_KEYS';
+  const defaultAuthnMethod = system?.defaultAuthnMethod;
 
   const history = useHistory();
   const location = useLocation();
@@ -59,7 +59,7 @@ const SystemsPushKeysModal = () => {
         username,
         password,
         token,
-        isTMSSystem,
+        defaultAuthnMethod,
         reloadCallback: reloadCallback || reloadPage,
         onSuccess,
       },
@@ -129,7 +129,7 @@ const SystemsPushKeysModal = () => {
                     disabled={submitting}
                   />
                 )}
-                {!isTMSSystem && (
+                {!defaultAuthnMethod === 'TMS_KEYS' && (
                   <>
                     <FormField
                       name="password"
@@ -137,14 +137,17 @@ const SystemsPushKeysModal = () => {
                       type="password"
                       required
                       disabled={submitting}
-                    />
-                    <FormField
-                      name="token"
-                      label={isTACCPortal ? 'TACC Token' : 'MFA Token'}
-                      required
-                      disabled={submitting}
                       autoComplete="off"
                     />
+                    {defaultAuthnMethod === 'PKI_KEYS' && (
+                      <FormField
+                        name="token"
+                        label={isTACCPortal ? 'TACC Token' : 'MFA Token'}
+                        required
+                        disabled={submitting}
+                        autoComplete="off"
+                      />
+                    )}
                   </>
                 )}
               </ModalBody>

--- a/client/src/components/_common/SystemsPushKeysModal/SystemsPushKeysModal.jsx
+++ b/client/src/components/_common/SystemsPushKeysModal/SystemsPushKeysModal.jsx
@@ -70,8 +70,14 @@ const SystemsPushKeysModal = () => {
     username: Yup.string()
       .min(1)
       .required('Please enter your username for this system.'),
-    password: Yup.string().min(1).required('Please enter your password.'),
-    token: Yup.string().min(1).required('Please provide a valid MFA token.'),
+    password:
+      defaultAuthnMethod !== 'TMS_KEYS'
+        ? Yup.string().min(1).required('Please enter your password.')
+        : null,
+    token:
+      defaultAuthnMethod === 'PKI_KEYS'
+        ? Yup.string().min(1).required('Please provide a valid MFA token.')
+        : null,
   });
 
   const initialValues = {
@@ -129,26 +135,24 @@ const SystemsPushKeysModal = () => {
                     disabled={submitting}
                   />
                 )}
-                {!defaultAuthnMethod === 'TMS_KEYS' && (
-                  <>
-                    <FormField
-                      name="password"
-                      label="Password"
-                      type="password"
-                      required
-                      disabled={submitting}
-                      autoComplete="off"
-                    />
-                    {defaultAuthnMethod === 'PKI_KEYS' && (
-                      <FormField
-                        name="token"
-                        label={isTACCPortal ? 'TACC Token' : 'MFA Token'}
-                        required
-                        disabled={submitting}
-                        autoComplete="off"
-                      />
-                    )}
-                  </>
+                {defaultAuthnMethod !== 'TMS_KEYS' && (
+                  <FormField
+                    name="password"
+                    label="Password"
+                    type="password"
+                    required
+                    disabled={submitting}
+                    autoComplete="off"
+                  />
+                )}
+                {defaultAuthnMethod === 'PKI_KEYS' && (
+                  <FormField
+                    name="token"
+                    label={isTACCPortal ? 'TACC Token' : 'MFA Token'}
+                    required
+                    disabled={submitting}
+                    autoComplete="off"
+                  />
                 )}
               </ModalBody>
               <ModalFooter>

--- a/client/src/redux/sagas/systems.sagas.js
+++ b/client/src/redux/sagas/systems.sagas.js
@@ -8,7 +8,7 @@ function* pushSystemKeys(action) {
     password: action.payload.password,
     token: action.payload.token,
     hostname: action.payload.hostname,
-    isTMSSystem: action.payload.isTMSSystem,
+    defaultAuthnMethod: action.payload.defaultAuthnMethod,
   };
   yield put({
     type: 'SYSTEMS_MODAL_UPDATE',

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -289,6 +289,7 @@ export type TTapisSystemQueue = {
   maxMemoryMB: number;
   minMinutes: number;
   maxMinutes: number;
+  schedulerOptions: TAppArgSpec[];
 };
 
 type TTapisSystemQueueFilter = {

--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -14,6 +14,7 @@ from tapipy.errors import BaseTapyException
 from portal.apps.onboarding.steps.system_access_v3 import (
     create_system_credentials_with_keys,
     create_system_credentials,
+    create_system_credentials_with_password,
 )
 from portal.utils.encryption import createKeyPair
 from portal.apps.datafiles.utils import evaluate_datafiles_storage_system
@@ -45,12 +46,12 @@ class SystemKeysView(BaseApiView):
         :param request: Django's request object
         :param str system_id: System id
         """
-        is_tms_system = body["form"]["isTMSSystem"]
+        default_authn_method = body["form"]["defaultAuthnMethod"]
         client = request.user.tapis_oauth.client
         tapis_username = request.user.username
         login_username = body["form"]["username"]
 
-        if is_tms_system:
+        if default_authn_method == "TMS_KEYS":
             try:
                 create_system_credentials(
                     client, login_username, system_id, createTmsKeys=True
@@ -65,11 +66,11 @@ class SystemKeysView(BaseApiView):
                 )
                 http_status = e.response.status_code
                 result = e.message
-        else:
+        elif default_authn_method == "PKI_KEYS":
             logger.info(
                 f"Resetting credentials for user {tapis_username} on system {system_id}"
             )
-            (priv_key_str, publ_key_str) = createKeyPair()
+            priv_key_str, publ_key_str = createKeyPair()
 
             success, result, http_status = AccountsManager.add_pub_key_to_resource(
                 request.user,
@@ -95,6 +96,27 @@ class SystemKeysView(BaseApiView):
                 system_id,
                 loginUser=login_username,
             )
+
+        elif default_authn_method == "PASSWORD":
+            try:
+                create_system_credentials_with_password(
+                    client,
+                    tapis_username,
+                    publ_key_str,
+                    priv_key_str,
+                    system_id,
+                    loginUser=login_username,
+                )
+                http_status = 200
+                result = "OK"
+            except BaseTapyException as e:
+                logger.exception(
+                    "System credential creation failed for user: %s on system: %s",
+                    tapis_username,
+                    system_id,
+                )
+                http_status = e.response.status_code
+                result = e.message
 
         tapis_system = client.systems.getSystem(systemId=system_id)
 

--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -102,8 +102,7 @@ class SystemKeysView(BaseApiView):
                 create_system_credentials_with_password(
                     client,
                     tapis_username,
-                    publ_key_str,
-                    priv_key_str,
+                    body["form"]["password"],
                     system_id,
                     loginUser=login_username,
                 )

--- a/server/portal/apps/accounts/managers/ssh_keys.py
+++ b/server/portal/apps/accounts/managers/ssh_keys.py
@@ -47,15 +47,15 @@ class KeysManager(AbstractKeysManager):
         self.password = password
         self.token = token
 
-    def _tacc_prompt_handler(
+    def _ssh_prompt_handler(
             self,
             title,
             instructions,
             prompt_list
     ):
-        """TACC Prompt Handler
+        """SSH Prompt Handler
 
-        This method handles SSH prompts from TACC resources
+        This method handles SSH prompts from cloud resources
         """
         answers = {
             'password': self.password,
@@ -78,7 +78,7 @@ class KeysManager(AbstractKeysManager):
 
     def get_transport(self, hostname, port):
         """Gets authenticated transport"""
-        handler = self._tacc_prompt_handler
+        handler = self._ssh_prompt_handler
 
         trans = paramiko.Transport((hostname, port))
         # trans.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -135,7 +135,9 @@ class TapisFilesView(BaseApiView):
                 # In case of 500 determine cause
                 system_def = client.systems.getSystem(systemId=system)
 
-                if settings.IS_TACC_PORTAL:
+                if settings.IS_TACC_PORTAL and not system_def.notes.get(
+                    "noAllocationRequired"
+                ):
                     # If user is missing a non-corral allocation mangle error to a 403
                     allocations = get_allocations(request.user.username)
                     if not any(

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -47,7 +47,7 @@ def test_get_no_allocation(client, authenticated_user, mocker, monkeypatch, mock
         'hosts': {}
     }
 
-    mock_tapis_client.systems.getSystem.return_value = TapisResult(host='frontera.tacc.utexas.edu')
+    mock_tapis_client.systems.getSystem.return_value = TapisResult(host='frontera.tacc.utexas.edu', notes={})
 
     response = client.get('/api/datafiles/tapis/listing/private/frontera.home.username/')
     assert response.status_code == 403
@@ -97,6 +97,7 @@ def test_get_requires_push_keys(client, authenticated_user, mocker, monkeypatch,
         'host': 'frontera.tacc.utexas.edu',
         'defaultAuthnMethod': 'PKI_KEYS',
         "effectiveUserId": authenticated_user.username,
+        "notes": {}
     }
 
     mock_tapis_client.systems.getSystem.return_value = TapisResult(**system)

--- a/server/portal/apps/onboarding/steps/system_access_v3.py
+++ b/server/portal/apps/onboarding/steps/system_access_v3.py
@@ -8,6 +8,32 @@ from portal.utils.encryption import createKeyPair
 logger = logging.getLogger(__name__)
 
 
+def create_system_credentials_with_password(
+    client,
+    username,
+    password,
+    system_id,
+    skipCredentialCheck=False,
+    loginUser=None,
+) -> int:
+    """
+    Set a username/password as the user's auth credential on a Tapis system.
+    """
+    logger.info(
+        f"Creating user credential for {username} on Tapis system {system_id} using password"
+    )
+    data = {
+        "password": password,
+        "loginUser": loginUser or username,
+    }
+    client.systems.createUserCredential(
+        systemId=system_id,
+        userName=username,
+        skipCredentialCheck=skipCredentialCheck,
+        **data,
+    )
+
+
 def create_system_credentials_with_keys(
     client,
     username,
@@ -36,20 +62,26 @@ def create_system_credentials_with_keys(
     )
 
 
-def create_system_credentials(client,
-                              username,
-                              system_id,
-                              createTmsKeys,
-                              skipCredentialCheck=False) -> int:
+def create_system_credentials(
+    client,
+    username,
+    system_id,
+    createTmsKeys,
+    skipCredentialCheck=False,
+    loginUser=None,
+) -> int:
     """
     Create user's auth credential on a Tapis system. This Tapis API uses TMS.
     """
-    logger.info(f"Creating user credential for {username} on Tapis system {system_id} using TMS")
+    logger.info(
+        f"Creating user credential for {username} on Tapis system {system_id} using TMS"
+    )
     client.systems.createUserCredential(
         systemId=system_id,
         userName=username,
         createTmsKeys=createTmsKeys,
         skipCredentialCheck=skipCredentialCheck,
+        loginUser=loginUser or username,
     )
 
 
@@ -58,14 +90,10 @@ def set_user_permissions(user, system_id):
     logger.info(f"Adding {user.username} permissions to Tapis system {system_id}")
     client = service_account()
     client.systems.grantUserPerms(
-        systemId=system_id,
-        userName=user.username,
-        permissions=['READ'])
+        systemId=system_id, userName=user.username, permissions=["READ"]
+    )
     client.files.grantPermissions(
-        systemId=system_id,
-        path="/",
-        username=user.username,
-        permission='MODIFY'
+        systemId=system_id, path="/", username=user.username, permission="MODIFY"
     )
 
 
@@ -101,7 +129,7 @@ class SystemAccessStepV3(AbstractStep):
 
     def process(self):
         self.log(f"Processing system access for user {self.user.username}")
-        for system in self.settings.get('access_systems') or []:
+        for system in self.settings.get("access_systems") or []:
             try:
                 set_user_permissions(self.user, system)
                 self.log(f"Successfully granted permissions for system: {system}")
@@ -109,7 +137,7 @@ class SystemAccessStepV3(AbstractStep):
                 logger.error(e)
                 self.fail(f"Failed to grant permissions for system: {system}")
 
-        for system in self.settings.get('credentials_systems') or []:
+        for system in self.settings.get("credentials_systems") or []:
             try:
                 self.check_system(system)
                 self.log(f"Credentials already created for system: {system}")
@@ -119,14 +147,21 @@ class SystemAccessStepV3(AbstractStep):
 
             system_definition = self.get_system(system)
             try:
-                if system_definition.get("defaultAuthnMethod") != 'TMS_KEYS':
-                    (priv, pub) = createKeyPair()
+                if system_definition.get("defaultAuthnMethod") == "PKI_KEYS":
+                    priv, pub = createKeyPair()
                     create_system_credentials_with_keys(
-                        self.user.tapis_oauth.client, self.user.username, pub, priv, system
+                        self.user.tapis_oauth.client,
+                        self.user.username,
+                        pub,
+                        priv,
+                        system,
                     )
                 else:
                     create_system_credentials(
-                        self.user.tapis_oauth.client, self.user.username, system, createTmsKeys=True
+                        self.user.tapis_oauth.client,
+                        self.user.username,
+                        system,
+                        createTmsKeys=True,
                     )
                 self.log(f"Successfully created credentials for system: {system}")
             except BaseTapyException as e:

--- a/server/portal/apps/workspace/api/utils_unit_test.py
+++ b/server/portal/apps/workspace/api/utils_unit_test.py
@@ -43,6 +43,7 @@ def test_push_keys_required_if_not_credentials_ensured_successful_credential_cre
         systemId="test_system",
         userName=authenticated_user.username,
         createTmsKeys=True,
+        loginUser=authenticated_user.username
         skipCredentialCheck=False,
     )
 

--- a/server/portal/apps/workspace/api/utils_unit_test.py
+++ b/server/portal/apps/workspace/api/utils_unit_test.py
@@ -43,7 +43,7 @@ def test_push_keys_required_if_not_credentials_ensured_successful_credential_cre
         systemId="test_system",
         userName=authenticated_user.username,
         createTmsKeys=True,
-        loginUser=authenticated_user.username
+        loginUser=authenticated_user.username,
         skipCredentialCheck=False,
     )
 


### PR DESCRIPTION
## Overview

- Handles the `select` type for Tapis System Queue Scheduler Options
- Change "push keys" wording to "create Tapis system credentials"
- Handle Tapis systems with `PASSWORD` type of `defaultAuthnMethod`
- Do not raise allocation error if Tapis system has `noAllocationRequired` flag

## Related

* [WA-526](https://tacc-main.atlassian.net/browse/WA-526)
* [WI-466](https://tacc-main.atlassian.net/browse/WI-466)


## Testing

1. With OIDC/CPU `settings_local.py`, go to https://cep.test/workbench/data/tapis/private/bridges2
2. Confirm message is updated
3. Confirm the credential creation modal is displayed, with only username/password fields
4. Credentials should succeed to create, and file listings should work
5. Go to https://cep.test/workbench/applications/hello-world?appVersion=expanse
6. Submit job, and confirm it succeeds


