### PR TITLE
task/WP-1282 - Metadata cutoff fix

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.jsx
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.jsx
@@ -174,15 +174,14 @@ const DataFilesProjectFileListing = ({
           )}
         <>
           {DataFilesProjectFileListingMetadataAddon ? (
-            <ShowMore key={`${system}`}>
-              <DataFilesProjectFileListingMetadataAddon
-                folderMetadata={folderMetadata}
-                metadata={metadata}
-                system={system}
-                path={path}
-                showCitation={isPublicationSystem(rootSystem)}
-              />
-            </ShowMore>
+            <DataFilesProjectFileListingMetadataAddon
+              key={system}
+              folderMetadata={folderMetadata}
+              metadata={metadata}
+              system={system}
+              path={path}
+              showCitation={isPublicationSystem(rootSystem)}
+            />
           ) : (
             !!metadata.description && (
               <>

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataAddon/DataFilesProjectFileListingMetadataAddon.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataAddon/DataFilesProjectFileListingMetadataAddon.jsx
@@ -5,7 +5,7 @@ import { useFileListing } from 'hooks/datafiles';
 import DataDisplay from '../utils/DataDisplay/DataDisplay';
 import { formatDate } from 'utils/timeFormat';
 import { MLACitation } from '../DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ReviewAuthors';
-import { Button } from '_common';
+import { Button, ShowMore } from '_common';
 import { useDispatch, useSelector } from 'react-redux';
 import { EXCLUDED_METADATA_FIELDS } from '../constants/metadataFields';
 
@@ -85,7 +85,11 @@ const DataFilesProjectFileListingMetadataAddon = ({
       {!loading && tree &&
         (folderMetadata ? (
           <>
-            {folderMetadata.description}
+            {!!folderMetadata.description && (
+              <ShowMore className={styles['addon-description']}>
+                {folderMetadata.description}
+              </ShowMore>
+            )}
             <DataDisplay
               data={folderMetadata}
               tree={tree}
@@ -111,7 +115,11 @@ const DataFilesProjectFileListingMetadataAddon = ({
                 </div>
               </div>
             )}
-            {metadata.description}
+            {!!metadata.description && (
+              <ShowMore className={styles['addon-description']}>
+                {metadata.description}
+              </ShowMore>
+            )}
             <DataDisplay
               data={getProjectMetadata(metadata)}
               tree={tree}

--- a/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataAddon/DataFilesProjectFileListingMetadataAddon.module.scss
+++ b/client/src/components/_custom/drp/DataFilesProjectFileListingMetadataAddon/DataFilesProjectFileListingMetadataAddon.module.scss
@@ -21,3 +21,7 @@
 .citation-button {
   margin-top: 5px;
 }
+
+.addon-description {
+  overflow: hidden auto;
+}

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/DataFilesProjectPublishWizard.module.scss
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/DataFilesProjectPublishWizard.module.scss
@@ -120,3 +120,7 @@
   border: 1px solid #ffdcd6;
   background-color: #fff3f0;
 }
+
+.description-show-more {
+  overflow: hidden auto;
+}

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectDescription.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectDescription.jsx
@@ -42,7 +42,11 @@ const ProjectDescription = ({ project }) => {
     let projectData = {
       Title: project.title,
       Created: formatDate(new Date(project.created)),
-      Description: <ShowMore> {project.description} </ShowMore>,
+      Description: (
+        <ShowMore className={styles['description-show-more']}>
+          {project.description}
+        </ShowMore>
+      ),
       License: project.license ?? 'None',
     };
 

--- a/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectTreeView.jsx
+++ b/client/src/components/_custom/drp/DataFilesProjectPublish/DataFilesProjectPublishWizardSteps/ProjectTreeView.jsx
@@ -280,7 +280,9 @@ export const ProjectTreeView = ({ projectId, readOnly = false }) => {
                   )}
                 </div>
                 <div className={styles['description']}>
-                  <ShowMore>{node.metadata.description}</ShowMore>
+                  <ShowMore className={styles['description-show-more']}>
+                    {node.metadata.description}
+                  </ShowMore>
                   <DataDisplay
                     data={node.metadata}
                     tree={tree[0]}


### PR DESCRIPTION
## Overview

Fix for metadata description area being too small and getting cut off in DPM

## Related

* [WP-1282](https://tacc-main.atlassian.net/browse/WP-1282)

## Changes

- Updated layout and css to fix metadata cutoff


## Testing

1. Visual review should be enough

## UI

### **Before** 
<img width="1465" height="696" alt="Screenshot 2026-05-14 at 3 51 33 PM" src="https://github.com/user-attachments/assets/d893434c-fa5d-45d8-afa6-032f77e666b0" />


<img width="1465" height="696" alt="Screenshot 2026-05-14 at 3 51 40 PM" src="https://github.com/user-attachments/assets/f417ba44-b8fe-44c5-8f02-44f0c733d2f3" />


### **After** 
<img width="1465" height="696" alt="Screenshot 2026-05-14 at 3 51 55 PM" src="https://github.com/user-attachments/assets/31f72c92-e8ac-4f2a-b287-2484c361e5fc" />

<img width="1465" height="696" alt="Screenshot 2026-05-14 at 3 52 21 PM" src="https://github.com/user-attachments/assets/9188bac9-87c6-4711-8bc3-d23bb2e228f0" />



## Notes

