### PR TITLE
task/WI-398: Update Allocation Onboarding Check

### DIFF
--- a/server/portal/apps/onboarding/steps/allocation.py
+++ b/server/portal/apps/onboarding/steps/allocation.py
@@ -1,7 +1,7 @@
 from portal.apps.onboarding.steps.abstract import AbstractStep
 from portal.apps.onboarding.state import SetupState
 from portal.apps.users.utils import get_allocations
-
+from django.conf import settings
 
 class AllocationStep(AbstractStep):
     def __init__(self, user):
@@ -35,4 +35,23 @@ class AllocationStep(AbstractStep):
                 """User {0} does not have any allocations""".format(self.user.username),
             )
         else:
+            if self.settings.get("expected_hosts"):
+                # checking if expected hosts are included in allocation hosts
+                expected_hosts = self.settings["expected_hosts"]
+                hosts = [
+                    h
+                    for h in allocations["hosts"].keys()
+                    if h.lower() in expected_hosts
+                ]
+
+                if not hosts:
+                    self.state = SetupState.FAILED
+                    self.log(
+                        "User {0} does not have active allocations on any expected hosts: {1}".format(
+                            self.user.username, expected_hosts
+                        )
+                    )
+                    return
+                self.log("Expected host allocations found: {0}".format(hosts))
+
             self.complete("Allocations retrieved", data=allocations)

--- a/server/portal/apps/onboarding/steps/allocation.py
+++ b/server/portal/apps/onboarding/steps/allocation.py
@@ -1,7 +1,7 @@
 from portal.apps.onboarding.steps.abstract import AbstractStep
 from portal.apps.onboarding.state import SetupState
 from portal.apps.users.utils import get_allocations
-from django.conf import settings
+
 
 class AllocationStep(AbstractStep):
     def __init__(self, user):
@@ -35,23 +35,21 @@ class AllocationStep(AbstractStep):
                 """User {0} does not have any allocations""".format(self.user.username),
             )
         else:
-            if self.settings.get("expected_hosts"):
+            if "expected_hosts" in self.settings:
                 # checking if expected hosts are included in allocation hosts
                 expected_hosts = self.settings["expected_hosts"]
-                hosts = [
-                    h
-                    for h in allocations["hosts"].keys()
-                    if h.lower() in expected_hosts
-                ]
+                allocation_hosts = {h.lower() for h in allocations["hosts"].keys()}
+                matched_hosts = [h for h in expected_hosts if h in allocation_hosts]
+                missing_hosts = [h for h in expected_hosts if h not in allocation_hosts]
 
-                if not hosts:
+                if missing_hosts:
                     self.state = SetupState.FAILED
                     self.log(
-                        "User {0} does not have active allocations on any expected hosts: {1}".format(
-                            self.user.username, expected_hosts
+                        "User {0} is missing allocations on: {1}".format(
+                            self.user.username, missing_hosts
                         )
                     )
                     return
-                self.log("Expected host allocations found: {0}".format(hosts))
+                self.log("Expected host allocations found: {0}".format(matched_hosts))
 
             self.complete("Allocations retrieved", data=allocations)

--- a/server/portal/apps/onboarding/steps/allocation_unit_test.py
+++ b/server/portal/apps/onboarding/steps/allocation_unit_test.py
@@ -1,4 +1,5 @@
 from portal.apps.onboarding.steps.allocation import AllocationStep
+from django.conf import settings
 from mock import ANY
 import pytest
 
@@ -6,10 +7,15 @@ import pytest
 @pytest.fixture
 def get_allocations_mock(mocker):
     get_allocations = mocker.patch('portal.apps.onboarding.steps.allocation.get_allocations')
-    get_allocations.return_value = {'hosts': {},
-                                    'portal_alloc': None,
-                                    'active': [{'allocation'}],
-                                    'inactive': [{'allocation'}]}
+    get_allocations.return_value = {
+        "hosts": {
+            "vista.tacc.utexas.edu": {},
+            "frontera.tacc.utexas.edu": {},
+        },
+        "portal_alloc": [],
+        "active": [{"allocation"}],
+        "inactive": [{"allocation"}],
+    }
     yield get_allocations
 
 
@@ -24,6 +30,23 @@ def get_allocations_failure_mock(mocker):
 
 
 @pytest.fixture
+def get_allocations_with_expected_systems_check_failure_mock(mocker):
+    get_allocations = mocker.patch(
+        "portal.apps.onboarding.steps.allocation.get_allocations"
+    )
+    get_allocations.return_value = {
+        "hosts": {
+            "vista.tacc.utexas.edu": {},
+            "frontera.tacc.utexas.edu": {},
+        },
+        "portal_alloc": [],
+        "active": [{"allocation"}],
+        "inactive": [{"allocation"}],
+    }
+    yield get_allocations
+
+
+@pytest.fixture
 def allocation_step_complete_mock(mocker):
     yield mocker.patch.object(AllocationStep, 'complete')
 
@@ -33,17 +56,86 @@ def allocation_step_log_mock(mocker):
     yield mocker.patch.object(AllocationStep, 'log')
 
 
-def test_get_allocations(regular_user, get_allocations_mock, allocation_step_complete_mock):
+def test_get_allocations_with_expected_systems_check_success(
+    regular_user, get_allocations_mock, allocation_step_complete_mock
+):
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+        {
+            "step": "portal.apps.onboarding.steps.allocation.AllocationStep",
+            "settings": {
+                "expected_hosts": ["vista.tacc.utexas.edu", "frontera.tacc.utexas.edu"]
+            },
+        }
+    ]
     step = AllocationStep(regular_user)
     step.process()
     get_allocations_mock.assert_called_with("username", force=True)
-    allocation_step_complete_mock.assert_called_with("Allocations retrieved",
-                                                     data={'hosts': {}, 'portal_alloc': None,
-                                                           'active': [{'allocation'}],
-                                                           'inactive': [{'allocation'}]})
+    allocation_step_complete_mock.assert_called_with(
+        "Allocations retrieved",
+        data={
+            "hosts": {
+                "vista.tacc.utexas.edu": {},
+                "frontera.tacc.utexas.edu": {},
+            },
+            "portal_alloc": [],
+            "active": [{"allocation"}],
+            "inactive": [{"allocation"}],
+        },
+    )
 
 
-def test_get_allocations_failure(regular_user, get_allocations_failure_mock, allocation_step_log_mock):
+def test_get_allocations_with_expected_systems_check_failure(
+    regular_user,
+    allocation_step_log_mock,
+    get_allocations_with_expected_systems_check_failure_mock,
+):
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+        {
+            "step": "portal.apps.onboarding.steps.allocation.AllocationStep",
+            "settings": {
+                "expected_hosts": ["blah.tacc.utexas.edu", "frontera.tacc.utexas.edu"]
+            },
+        }
+    ]
+    step = AllocationStep(regular_user)
+    step.process()
+    get_allocations_with_expected_systems_check_failure_mock.assert_called_with(
+        "username", force=True
+    )
+    allocation_step_log_mock.assert_called_with(
+        "User username is missing allocations on: ['blah.tacc.utexas.edu']"
+    )
+
+
+def test_get_allocations_without_expected_systems_check_success(
+    regular_user, get_allocations_mock, allocation_step_complete_mock
+):
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+        {
+            "step": "portal.apps.onboarding.steps.allocation.AllocationStep",
+            "settings": {},
+        }
+    ]
+    step = AllocationStep(regular_user)
+    step.process()
+    get_allocations_mock.assert_called_with("username", force=True)
+    allocation_step_complete_mock.assert_called_with(
+        "Allocations retrieved",
+        data={
+            "hosts": {
+                "vista.tacc.utexas.edu": {},
+                "frontera.tacc.utexas.edu": {},
+            },
+            "portal_alloc": [],
+            "active": [{"allocation"}],
+            "inactive": [{"allocation"}],
+        },
+    )
+
+
+def test_get_allocations_without_expected_systems_check_failure(
+    regular_user, get_allocations_failure_mock, allocation_step_log_mock
+):
     step = AllocationStep(regular_user)
     step.process()
     get_allocations_failure_mock.assert_called_with("username", force=True)

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -122,7 +122,9 @@ Sample:
 _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
     {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
-        'settings': {}
+        'settings': {
+            'expected_hosts': 'vista.tacc.utexas.edu'
+        }
     },
     {
         'step': 'portal.apps.onboarding.steps.project_membership.ProjectMembershipStep',

--- a/server/portal/settings/settings_default.py
+++ b/server/portal/settings/settings_default.py
@@ -123,7 +123,7 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
     {
         'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
         'settings': {
-            'expected_hosts': 'vista.tacc.utexas.edu'
+            'expected_hosts': ['vista.tacc.utexas.edu']
         }
     },
     {


### PR DESCRIPTION
## Overview

Added part to allocation check that validates if a user has an allocation with access to a specific machine.

## Related

* [WI-398](https://tacc-main.atlassian.net/browse/WI-398)

## Changes
Adds an `expected_host` setting to the allocation check in onboarding, and will not let the user access the portal if they do not have an allocation with access to that host.


## Testing

1. Either in `settings_default.py` or `settings_custom.py`, add the snippet below to your `_PORTAL_USER_ACCOUNT_SETUP_STEPS`:
```
{
        'step': 'portal.apps.onboarding.steps.allocation.AllocationStep',
        'settings': {
            'expected_hosts': ['vista.tacc.utexas.edu']
        }
 },
```
2. Reset your user's onboarding steps, and the portal should check if you have an allocation with access to Vista. Then it will grant you access to the portal depending on whether or not that is true. The logs should show which steps failed or passed and for which hosts.
3. Now add a second host to the array, for example `frontera.tacc.utexas.edu`. Test two or more expected hosts where you don't have access to all of them. Reset your user's onboarding steps again and the logs should let you know which hosts failed.
4. If you remove `expected_host` from the `settings` in the snippet, the portal should only check if you have any active allocations at all.

## UI



## Notes

