### PR TITLE
bug/WP-1289: Fix errant `loginUser` field in `createUserCredential` call with TMS_KEYS

### DIFF
--- a/server/portal/apps/accounts/api/views/systems.py
+++ b/server/portal/apps/accounts/api/views/systems.py
@@ -13,7 +13,7 @@ from portal.apps.accounts.managers import accounts as AccountsManager
 from tapipy.errors import BaseTapyException
 from portal.apps.onboarding.steps.system_access_v3 import (
     create_system_credentials_with_keys,
-    create_system_credentials,
+    create_system_credentials_with_tms,
     create_system_credentials_with_password,
 )
 from portal.utils.encryption import createKeyPair
@@ -53,8 +53,8 @@ class SystemKeysView(BaseApiView):
 
         if default_authn_method == "TMS_KEYS":
             try:
-                create_system_credentials(
-                    client, login_username, system_id, createTmsKeys=True
+                create_system_credentials_with_tms(
+                    client, tapis_username, system_id
                 )
                 http_status = 200
                 result = "OK"

--- a/server/portal/apps/onboarding/steps/system_access_v3.py
+++ b/server/portal/apps/onboarding/steps/system_access_v3.py
@@ -62,13 +62,11 @@ def create_system_credentials_with_keys(
     )
 
 
-def create_system_credentials(
+def create_system_credentials_with_tms(
     client,
     username,
     system_id,
-    createTmsKeys,
     skipCredentialCheck=False,
-    loginUser=None,
 ) -> int:
     """
     Create user's auth credential on a Tapis system. This Tapis API uses TMS.
@@ -79,9 +77,8 @@ def create_system_credentials(
     client.systems.createUserCredential(
         systemId=system_id,
         userName=username,
-        createTmsKeys=createTmsKeys,
-        skipCredentialCheck=skipCredentialCheck,
-        loginUser=loginUser or username,
+        createTmsKeys=True,
+        skipCredentialCheck=skipCredentialCheck
     )
 
 
@@ -157,15 +154,14 @@ class SystemAccessStepV3(AbstractStep):
                         system,
                     )
                 else:
-                    create_system_credentials(
+                    create_system_credentials_with_tms(
                         self.user.tapis_oauth.client,
                         self.user.username,
                         system,
-                        createTmsKeys=True,
                     )
                 self.log(f"Successfully created credentials for system: {system}")
             except BaseTapyException as e:
-                logger.error(e)
+                logger.exception(f"Failed to create credentials for system: {system}")
                 self.fail(f"Failed to create credentials for system: {system}")
 
         if self.state != SetupState.FAILED:

--- a/server/portal/apps/onboarding/steps/system_access_v3.py
+++ b/server/portal/apps/onboarding/steps/system_access_v3.py
@@ -160,7 +160,7 @@ class SystemAccessStepV3(AbstractStep):
                         system,
                     )
                 self.log(f"Successfully created credentials for system: {system}")
-            except BaseTapyException as e:
+            except BaseTapyException:
                 logger.exception(f"Failed to create credentials for system: {system}")
                 self.fail(f"Failed to create credentials for system: {system}")
 

--- a/server/portal/apps/workspace/api/utils.py
+++ b/server/portal/apps/workspace/api/utils.py
@@ -4,7 +4,7 @@ import json
 import logging
 from django.conf import settings
 from tapipy.errors import BaseTapyException, UnauthorizedError, ForbiddenError
-from portal.apps.onboarding.steps.system_access_v3 import create_system_credentials
+from portal.apps.onboarding.steps.system_access_v3 import create_system_credentials_with_tms
 from portal.exceptions.api import ApiException
 
 logger = logging.getLogger(__name__)
@@ -116,8 +116,8 @@ def push_keys_required_if_not_credentials_ensured(
         if is_tms_system(system_def):
             if settings.IS_TACC_PORTAL is False:
                 return True
-            create_system_credentials(
-                tapis, user.username, system_id, createTmsKeys=True
+            create_system_credentials_with_tms(
+                tapis, user.username, system_id
             )
 
         elif should_push_keys(system_def, user.username):

--- a/server/portal/apps/workspace/api/utils_unit_test.py
+++ b/server/portal/apps/workspace/api/utils_unit_test.py
@@ -43,7 +43,6 @@ def test_push_keys_required_if_not_credentials_ensured_successful_credential_cre
         systemId="test_system",
         userName=authenticated_user.username,
         createTmsKeys=True,
-        loginUser=authenticated_user.username,
         skipCredentialCheck=False,
     )
 

--- a/server/portal/apps/workspace/api/utils_unit_test.py
+++ b/server/portal/apps/workspace/api/utils_unit_test.py
@@ -49,9 +49,9 @@ def test_push_keys_required_if_not_credentials_ensured_successful_credential_cre
 
 
 @patch("portal.apps.workspace.api.utils.should_push_keys")
-@patch("portal.apps.workspace.api.utils.create_system_credentials")
+@patch("portal.apps.workspace.api.utils.create_system_credentials_with_tms")
 def test_push_keys_required_if_not_credentials_ensured_credentials_ok(
-    mock_create_system_credentials,
+    mock_create_system_credentials_with_tms,
     mock_should_push_keys,
     authenticated_user,
     mock_tapis_client,
@@ -75,7 +75,7 @@ def test_push_keys_required_if_not_credentials_ensured_credentials_ok(
 
     assert result is False
     mock_should_push_keys.assert_not_called()
-    mock_create_system_credentials.assert_not_called()
+    mock_create_system_credentials_with_tms.assert_not_called()
 
 
 def test_push_keys_required_if_not_credentials_ensured_push_keys_required(


### PR DESCRIPTION
## Overview

The `loginUser` field being present throws an error on `createUserCredential` calls with `createTmsKeys` being true. Also renames the `create_system_credentials` utility function to `create_system_credentials_with_tms` for clarity.

## Related

* [WP-1289](https://tacc-main.atlassian.net/browse/WP-1289)


## Testing

1. Delete your `cloud.data` system credentials via tapipy, or ask me to.
2. Reset your System Access onboarding step and confirm it succeeds
