### PR TITLE
feat: custom scripts via PORTAL_JS_FILENAMES

### DIFF
--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -68,6 +68,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 # Custom Portal Template Assets
 PORTAL_ICON_FILENAME = settings_custom._PORTAL_ICON_FILENAME
 PORTAL_CSS_FILENAMES = getattr(settings_custom, '_PORTAL_CSS_FILENAMES', [])
+PORTAL_JS_FILENAMES = getattr(settings_custom, '_PORTAL_JS_FILENAMES', [])
 
 ROOT_URLCONF = 'portal.urls'
 
@@ -683,6 +684,7 @@ SETTINGS: EXPORTS
 SETTINGS_EXPORT = [
     'PORTAL_ICON_FILENAME',
     'PORTAL_CSS_FILENAMES',
+    'PORTAL_JS_FILENAMES',
     'DEBUG',
     'GOOGLE_ANALYTICS_PROPERTY_ID',
     'PORTAL_NAMESPACE',

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -224,10 +224,23 @@ _PORTAL_PROJECTS_USE_SET_FACL_JOB = True
 ########################
 
 # No Art.
-# _PORTAL_ICON_FILENAME=''                 # Empty string yields NO icon.
-
+# _PORTAL_ICON_FILENAME='' # Empty string yields NO icon.
 # Default Art.
-_PORTAL_ICON_FILENAME = "/static/site_cms/img/favicons/favicon.ico"
+# _PORTAL_ICON_FILENAME = "https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@813aa7c/ptdatax_assets/favicon.ico"
+
+# No Extra Scripts.
+# _PORTAL_CSS_FILENAMES = [] # Empty array yields NO extra styles.
+# Custom CMS Scripts
+# _PORTAL_CSS_FILENAMES = [
+#     "https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@cc02b6d8/lccf_assets/header.css"
+# ]
+
+# No Extra Scripts.
+# _PORTAL_JS_FILENAMES = [] # Empty array yields NO extra scripts.
+# Custom CMS Scripts
+# _PORTAL_JS_FILENAMES = [
+#     "https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@main/ptdatax_assets/js/open-certain-links-in-new-tab.js"
+# ]
 
 ########################
 # GOOGLE ANALYTICS

--- a/server/portal/templates/base.html
+++ b/server/portal/templates/base.html
@@ -47,7 +47,7 @@
     <!-- Project JS -->
     {% if settings.PORTAL_JS_FILENAMES|length %}
       {% for script in settings.PORTAL_JS_FILENAMES %}
-      <script type="module" src="{{ script }}">
+      <script type="module" src="{{ script }}"></script>
       {% endfor %}
     {% endif %}
   </body>

--- a/server/portal/templates/base.html
+++ b/server/portal/templates/base.html
@@ -43,5 +43,12 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js" integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
+
+    <!-- Project JS -->
+    {% if settings.PORTAL_JS_FILENAMES|length %}
+      {% for script in settings.PORTAL_JS_FILENAMES %}
+      <script type="module" src="{{ script }}">
+      {% endfor %}
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Overview

Add `PORTAL_JS_FILENAMES` (like existing `PORTAL_CSS_FILENAMES`).

_Enables the client-side solution for [WP-1230]: a custom script on PTDataX needs to run on Portal pages, but Portal had no mechanism for per-project JS._

[WP-1230]: https://tacc-main.atlassian.net/browse/WP-1230
[WP-1290]: https://tacc-main.atlassian.net/browse/WP-1290

## Related

* **supports client-side solution for [WP-1230]**
* **server-side alternative: https://github.com/TACC/Core-CMS/pull/1151**
* required by #1304
* tested via https://github.com/TACC/Core-Portal-Deployments/pull/194
* _mentioned in [WP-1290]_

## Changes

* **added** `PORTAL_JS_FILENAMES`
* **documents** `PORTAL_…_FILENAMES`

## Testing

1. Deploy to PTDataX with https://github.com/TACC/Core-Portal-Deployments/f5c4ee1a.
2. Login to Portal.
3. In Portal (not CMS page), click "Docs" in CMS nav.
4. **Docs should open in new window.**

## UI

> [!TIP]
> Tested on https://pprd.ptdatax.tacc.utexas.edu/.

https://github.com/user-attachments/assets/7166dd5f-51f5-4ed1-93d9-09b5a1b8bcc2

<details><summary>Still Works on CMS Too</summary>

https://github.com/user-attachments/assets/5709c524-5c7b-4125-bf1c-a55e1c13a934

</details>

## Notes

> [!IMPORTANT]
> Assumes `type="module"`. Could instead allow object instead of array, like [CMS `PORTAL_LOGO` and `PORTAL_FAVICON`](https://github.com/TACC/Core-CMS/blob/v4.39.2/taccsite_cms/settings/settings.py#L249-L267), as could other `PORTAL_…_FILENAMES`.