### PR TITLE
feat: signal async CMS nav ready via flag and event

### DIFF
--- a/server/portal/templates/includes/nav_cms.html
+++ b/server/portal/templates/includes/nav_cms.html
@@ -13,6 +13,9 @@
   import flagLinkActive from '/static/site_cms/js/modules/flagLinkActive.js';
   import * as importHTML from '/static/site_cms/js/modules/importHTML.js';
 
+  const NAV_READY_ATTR  = 'navReady';
+  const NAV_READY_EVENT = 'cms-nav:ready';
+
   const container = document.getElementById('s-cms-nav');
 
   importHTML.insertFromURL('/cms/nav/pages/markup/', container).then(container => {
@@ -39,5 +42,8 @@
         )
       }
     });
+
+    container.dataset[NAV_READY_ATTR] = 'true';
+    container.dispatchEvent(new CustomEvent(NAV_READY_EVENT, { bubbles: true }));
   });
 </script>


### PR DESCRIPTION
## Overview

After the CMS nav HTML is injected and post-processed, set a `data-` attr flag and send a `CustomEvent`. This lets scripts in other repos safely defer link initialization until the async nav is populated.

_The custom script loaded via #1303 needs to modify a CMS nav link — but on Portal the nav is injected asynchronously, so the link doesn't exist at script load time. This PR adds the signal that lets that script wait safely._

[WP-1230]: https://tacc-main.atlassian.net/browse/WP-1230
[WP-1290]: https://tacc-main.atlassian.net/browse/WP-1290

## Related

- **supports client-side solution for [WP-1230]**
- **server-side alternative: https://github.com/TACC/Core-CMS/pull/1151**
- requires #1303
- required by https://github.com/TACC/Core-CMS-Custom/pull/538
- tested via https://github.com/TACC/Core-Portal-Deployments/pull/194
- _mentioned in [WP-1290]_

## Changes

- **added** `NAV_READY_ATTR` and `NAV_READY_EVENT` const's
- **added** `data-nav-ready` flag and `cms-nav:ready` event dispatch

## Testing

1. In DevTools console, run `document.getElementById('s-cms-nav').dataset.navReady` — should return `'true'` once the nav is populated.
2. Test https://github.com/TACC/Core-CMS-Custom/pull/538.
3. Load a Portal page and confirm the CMS nav renders normally.
4. Confirm no regressions i.e. these still work:
    1. On portal, active link is highlighted.
    2. On CMS page, Bootstrap 4→5 toggle shim still work.

## UI

> [!TIP]
> Tested on https://pprd.ptdatax.tacc.utexas.edu/.

| 1. Console Test |
| - |
| <img width="900" height="470" alt="Console Test" src="https://github.com/user-attachments/assets/c0343e5e-2813-4ad5-99dd-cfea4f5e3061" /> |

| 2. & 3. Render Normal & Link Set to Open in New Tab |
| - |
| <img width="900" height="470" alt="Link Set to Open in New Tab" src="https://github.com/user-attachments/assets/68a9e92c-f402-49d6-bae5-0614bc805f6a" /> |

| 4.a. flagLinkActive Still Works |
| - |
| <img width="900" height="470" alt="flagLinkActive Still Works" src="https://github.com/user-attachments/assets/46f1ec23-ea24-4003-9c1a-b16c25be7de3" /> |

| 4.b. Bootstrap Shim Still Works |
| - |
| <img width="900" height="470" alt="Bootstrap Tweak Still Works" src="https://github.com/user-attachments/assets/a5e99f2c-7885-428f-a588-ac47f92cee32" /> |

## Notes

> [!NOTE]
> Gray links in CMS Nav on Portal is known, recent, unrelated bug.

---

Made with [Cursor](https://cursor.com/)