### PR TITLE
task/WI-411: Add datafiles categories

### DIFF
--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
@@ -122,7 +122,7 @@ const DataFilesSidebar = ({ readOnly }) => {
       iconName: sys.icon || 'my-data',
       disabled: false,
       hidden: false,
-      category: sys.resource_provider,
+      category: sys.resourceProvider,
     });
   });
 

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.jsx
@@ -122,6 +122,7 @@ const DataFilesSidebar = ({ readOnly }) => {
       iconName: sys.icon || 'my-data',
       disabled: false,
       hidden: false,
+      category: sys.resource_provider,
     });
   });
 

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -99,7 +99,7 @@ const Sidebar = ({
             */}
             {category && Object.keys(groupedItems).length > 1 && (
               <NavItem className={styles['category-label']}>
-                <span>{category}</span>
+                <span className={styles['category-text']}>{category}</span>
               </NavItem>
             )}
             {items.map((item) => (

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -93,8 +93,11 @@ const Sidebar = ({
       {!loading &&
         Object.entries(groupedItems).map(([category, items]) => (
           <React.Fragment key={category}>
-            {/* Sidebar category label. Categories with empty strings will not have a label rendered. */}
-            {category && (
+            {/* Sidebar category label.
+            - Categories with empty strings will not have a label rendered.
+            - If there is only one category, regardless of value, it is not rendered.
+            */}
+            {category && Object.keys(groupedItems).length > 1 && (
               <NavItem className={styles['category-label']}>
                 <span>{category}</span>
               </NavItem>

--- a/client/src/components/_common/Sidebar/Sidebar.jsx
+++ b/client/src/components/_common/Sidebar/Sidebar.jsx
@@ -29,6 +29,7 @@ const SidebarItem = ({ to, iconName, label, children, disabled, hidden }) => {
     </NavItem>
   );
 };
+
 SidebarItem.propTypes = {
   to: PropTypes.string.isRequired,
   iconName: PropTypes.string.isRequired,
@@ -37,10 +38,29 @@ SidebarItem.propTypes = {
   disabled: PropTypes.bool,
   hidden: PropTypes.bool,
 };
+
 SidebarItem.defaultProps = {
   children: null,
   disabled: false,
   hidden: false,
+};
+
+/**
+ * Groups sidebar items by their category, returning an object where keys are categories and values are arrays of items.
+ * Items with no category are grouped under an empty string key. For empty string categories, the category label is not rendered in the sidebar.
+ *
+ * @param {*} items - An array of sidebar item objects, each potentially containing a 'category' property.
+ * @returns {Object} An object with category keys and arrays of sidebar items as values.
+ */
+const groupByCategory = (items) => {
+  return items
+    .filter((item) => !item.hidden)
+    .reduce((groups, item) => {
+      const category = item.category || '';
+      if (!groups[category]) groups[category] = [];
+      groups[category].push(item);
+      return groups;
+    }, {});
 };
 
 const Sidebar = ({
@@ -50,6 +70,8 @@ const Sidebar = ({
   loading,
   isMain,
 }) => {
+  const groupedItems = groupByCategory(sidebarItems);
+
   return (
     <Nav
       className={`nav-sidebar ${styles['root']} ${
@@ -69,9 +91,15 @@ const Sidebar = ({
         : null}
 
       {!loading &&
-        sidebarItems.map(
-          (item) =>
-            !item.hidden && (
+        Object.entries(groupedItems).map(([category, items]) => (
+          <React.Fragment key={category}>
+            {/* Sidebar category label. Categories with empty strings will not have a label rendered. */}
+            {category && (
+              <NavItem className={styles['category-label']}>
+                <span>{category}</span>
+              </NavItem>
+            )}
+            {items.map((item) => (
               <SidebarItem
                 to={item.to}
                 iconName={item.iconName}
@@ -81,8 +109,9 @@ const Sidebar = ({
               >
                 {item.children}
               </SidebarItem>
-            )
-        )}
+            ))}
+          </React.Fragment>
+        ))}
 
       {!loading && addItemsAfter
         ? addItemsAfter.map(
@@ -105,6 +134,7 @@ Sidebar.propTypes = {
   loading: PropTypes.bool,
   isMain: PropTypes.bool,
 };
+
 Sidebar.defaultProps = {
   addItemsBefore: [],
   addItemsAfter: [],

--- a/client/src/components/_common/Sidebar/Sidebar.module.css
+++ b/client/src/components/_common/Sidebar/Sidebar.module.css
@@ -51,5 +51,5 @@
 .category-label {
   padding: 20px 20px 10px;
   border-bottom: 1px solid var(--global-color-primary--dark);
-  font-weight: 500;
+  font-weight: var(--medium);
 }

--- a/client/src/components/_common/Sidebar/Sidebar.module.css
+++ b/client/src/components/_common/Sidebar/Sidebar.module.css
@@ -49,7 +49,11 @@
 }
 
 .category-label {
-  padding: 20px 20px 10px;
+  padding: 20px 1rem 10px;
   border-bottom: 1px solid var(--global-color-primary--dark);
   font-weight: var(--medium);
+}
+
+.category-text {
+  padding-left: 20px;
 }

--- a/client/src/components/_common/Sidebar/Sidebar.module.css
+++ b/client/src/components/_common/Sidebar/Sidebar.module.css
@@ -47,3 +47,9 @@
 .disabled {
   color: var(--global-color-primary--light);
 }
+
+.category-label {
+  padding: 20px 20px 10px;
+  border-bottom: 1px solid var(--global-color-primary--dark);
+  font-weight: 500;
+}

--- a/server/portal/apps/datafiles/utils.py
+++ b/server/portal/apps/datafiles/utils.py
@@ -21,7 +21,7 @@ class PortalDataFilesSystem(TypedDict):
     hostEval: NotRequired[str]
     icon: NotRequired[Optional[str]]
     siteSearchPriority: NotRequired[int]
-    resource_provider: NotRequired[str]
+    resourceProvider: NotRequired[str]
     readOnly: NotRequired[bool]
     hideSearchBar: NotRequired[bool]
     integration: NotRequired[bool]
@@ -81,20 +81,20 @@ def evaluate_datafiles_storage_system(
     else:
         evaluated_system = system
 
-    if "resource_provider" not in system:
+    if "resourceProvider" not in evaluated_system:
         if system["api"] != "tapis":
             # For non-tapis systems without a resource provider, default to "Other"
-            evaluated_system["resource_provider"] = "Other"
+            evaluated_system["resourceProvider"] = "Other"
 
         elif system["scheme"] == "projects":
             # For projects systems, determine resource provider based on projects host evaluation
             projects_host = settings.PORTAL_PROJECTS_ROOT_HOST
-            evaluated_system["resource_provider"] = _get_resource_provider_from_host(
+            evaluated_system["resourceProvider"] = _get_resource_provider_from_host(
                 projects_host
             )
         else:
             system_def = tapis.client.systems.getSystem(systemId=system["system"])
-            evaluated_system["resource_provider"] = _get_resource_provider_from_system(
+            evaluated_system["resourceProvider"] = _get_resource_provider_from_system(
                 system_def
             )
 
@@ -151,7 +151,7 @@ def get_user_storage_systems(tapis: TapisOAuthToken) -> list:
             "api": "tapis",
             "icon": None,
             "default": False,
-            "resource_provider": _get_resource_provider_from_system(system),
+            "resourceProvider": _get_resource_provider_from_system(system),
         }
         for system in systems
     ]
@@ -163,7 +163,7 @@ def get_user_storage_systems(tapis: TapisOAuthToken) -> list:
 
 def _get_resource_provider_from_system(system: TapisResult) -> str:
     """Get resource provider from a Tapis system's notes or via hostname evaluation"""
-    resource_provider = system.notes.get("resource_provider")
+    resource_provider = system.notes.get("resourceProvider")
 
     return resource_provider or _get_resource_provider_from_host(system.host)
 

--- a/server/portal/apps/datafiles/utils.py
+++ b/server/portal/apps/datafiles/utils.py
@@ -172,8 +172,8 @@ def _get_resource_provider_from_host(host: str) -> str:
     """Get resource provider from hostname evaluation of a Tapis system"""
     match host.split("."):
         case [*comps, "tacc", "utexas", "edu"]:
-            return "TACC Systems"
+            return "TACC"
         case [*comps, "edu"]:
-            return f"{comps[-1].upper()} Systems"
+            return comps[-1].upper()
         case _:
             return "Other"

--- a/server/portal/apps/datafiles/utils.py
+++ b/server/portal/apps/datafiles/utils.py
@@ -169,17 +169,11 @@ def _get_resource_provider_from_system(system: TapisResult) -> str:
 
 
 def _get_resource_provider_from_host(host: str) -> str:
-    match host.split('.'):
-        case [*comps, 'tacc', 'utexas', 'edu']:
-            return "TACC Systems"
-         case [*comps, 'edu']:
-             return comps[-1].upper()
-         case _:
-             return "Other"
     """Get resource provider from hostname evaluation of a Tapis system"""
-    if host.endswith(".tacc.utexas.edu"):
-        return "TACC Systems"
-    if host.endswith(".edu"):
-        return host.split(".")[-2].upper()
-
-    return "Other"
+    match host.split("."):
+        case [*comps, "tacc", "utexas", "edu"]:
+            return "TACC Systems"
+        case [*comps, "edu"]:
+            return comps[-1].upper()
+        case _:
+            return "Other"

--- a/server/portal/apps/datafiles/utils.py
+++ b/server/portal/apps/datafiles/utils.py
@@ -1,5 +1,8 @@
 import logging
-from tapipy.errors import InternalServerError
+from django.conf import settings
+from typing import TypedDict, NotRequired, Optional
+from tapipy.errors import InternalServerError, BaseTapyException
+from tapipy.tapis import TapisResult
 from portal.apps.notifications.models import Notification
 from portal.apps.users.utils import get_user_data
 from portal.apps.auth.models import TapisOAuthToken
@@ -7,6 +10,21 @@ from portal.apps.auth.models import TapisOAuthToken
 logger = logging.getLogger(__name__)
 
 NOTIFY_ACTIONS = ["move", "copy", "rename", "trash", "mkdir", "upload", "makepublic"]
+
+
+class PortalDataFilesSystem(TypedDict):
+    name: str
+    system: str
+    scheme: str
+    api: str
+    homeDir: str
+    hostEval: NotRequired[str]
+    icon: NotRequired[Optional[str]]
+    siteSearchPriority: NotRequired[int]
+    resource_provider: NotRequired[str]
+    readOnly: NotRequired[bool]
+    hideSearchBar: NotRequired[bool]
+    integration: NotRequired[bool]
 
 
 def notify(username, operation, status, extra):
@@ -22,17 +40,17 @@ def notify(username, operation, status, extra):
 
 
 def evaluate_datafiles_storage_system(
-    tapis: TapisOAuthToken, system: dict, default_host_eval: str = None
-) -> dict:
+    tapis: TapisOAuthToken, system: PortalDataFilesSystem, default_host_eval: str = None
+) -> PortalDataFilesSystem:
     """Evaluate storage system homeDir or hostEval for user
 
     Args:
         tapis (TapisOAuthToken): Tapis OAuth token object
-        system (dict): Storage system definition
+        system (PortalDataFilesSystem): Storage system definition
         default_host_eval (str, optional): Default environment variable name to evaluate for homeDir if hostEval is not provided.
 
     Returns:
-        dict: Evaluated storage system definition
+        PortalDataFilesSystem: Evaluated storage system definition
     """
 
     if "homeDir" in system:
@@ -63,6 +81,23 @@ def evaluate_datafiles_storage_system(
     else:
         evaluated_system = system
 
+    if "resource_provider" not in system:
+        if system["api"] != "tapis":
+            # For non-tapis systems without a resource provider, default to "Other"
+            evaluated_system["resource_provider"] = "Other"
+
+        elif system["scheme"] == "projects":
+            # For projects systems, determine resource provider based on projects host evaluation
+            projects_host = settings.PORTAL_PROJECTS_ROOT_HOST
+            evaluated_system["resource_provider"] = _get_resource_provider_from_host(
+                projects_host
+            )
+        else:
+            system_def = tapis.client.systems.getSystem(systemId=system["system"])
+            evaluated_system["resource_provider"] = _get_resource_provider_from_system(
+                system_def
+            )
+
     return evaluated_system
 
 
@@ -80,10 +115,19 @@ def evaluate_datafiles_storage_systems(
         list: List of evaluated storage system definitions
     """
 
-    return [
-        evaluate_datafiles_storage_system(tapis, system, default_host_eval)
-        for system in systems
-    ]
+    evaluated_systems = []
+    for system in systems:
+        try:
+            evaluated_systems.append(
+                evaluate_datafiles_storage_system(tapis, system, default_host_eval)
+            )
+        except (BaseTapyException, KeyError, AttributeError):
+            logger.exception(
+                "Error evaluating storage system %s for user %s",
+                system["system"],
+                tapis.user.username,
+            )
+    return evaluated_systems
 
 
 def get_user_storage_systems(tapis: TapisOAuthToken) -> list:
@@ -96,7 +140,7 @@ def get_user_storage_systems(tapis: TapisOAuthToken) -> list:
     """
     logger.info("Getting user storage systems for user: %s", tapis.user.username)
     systems = tapis.client.systems.getSystems(
-        listType="ALL", limit="-1", select="id,notes", orderBy="id"
+        listType="ALL", limit="-1", select="id,notes,host", orderBy="id"
     )
 
     available_systems = [
@@ -107,6 +151,7 @@ def get_user_storage_systems(tapis: TapisOAuthToken) -> list:
             "api": "tapis",
             "icon": None,
             "default": False,
+            "resource_provider": _get_resource_provider_from_system(system),
         }
         for system in systems
     ]
@@ -114,3 +159,20 @@ def get_user_storage_systems(tapis: TapisOAuthToken) -> list:
     return evaluate_datafiles_storage_systems(
         tapis, available_systems, default_host_eval="HOME"
     )
+
+
+def _get_resource_provider_from_system(system: TapisResult) -> str:
+    """Get resource provider from a Tapis system's notes or via hostname evaluation"""
+    resource_provider = system.notes.get("resource_provider")
+
+    return resource_provider or _get_resource_provider_from_host(system.host)
+
+
+def _get_resource_provider_from_host(host: str) -> str:
+    """Get resource provider from hostname evaluation of a Tapis system"""
+    if host.endswith(".tacc.utexas.edu"):
+        return "TACC Systems"
+    if host.endswith(".edu"):
+        return host.split(".")[-2].upper()
+
+    return "Other"

--- a/server/portal/apps/datafiles/utils.py
+++ b/server/portal/apps/datafiles/utils.py
@@ -174,6 +174,6 @@ def _get_resource_provider_from_host(host: str) -> str:
         case [*comps, "tacc", "utexas", "edu"]:
             return "TACC Systems"
         case [*comps, "edu"]:
-            return comps[-1].upper()
+            return f"{comps[-1].upper()} Systems"
         case _:
             return "Other"

--- a/server/portal/apps/datafiles/utils.py
+++ b/server/portal/apps/datafiles/utils.py
@@ -169,6 +169,13 @@ def _get_resource_provider_from_system(system: TapisResult) -> str:
 
 
 def _get_resource_provider_from_host(host: str) -> str:
+    match host.split('.'):
+        case [*comps, 'tacc', 'utexas', 'edu']:
+            return "TACC Systems"
+         case [*comps, 'edu']:
+             return comps[-1].upper()
+         case _:
+             return "Other"
     """Get resource provider from hostname evaluation of a Tapis system"""
     if host.endswith(".tacc.utexas.edu"):
         return "TACC Systems"

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -439,7 +439,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'homeDir': '/home/username',
                 'icon': None,
                 'default': True,
-                'resourceProvider': 'TACC Systems',
+                'resourceProvider': 'TACC',
 
             },
             {
@@ -449,7 +449,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'tapis',
                 'homeDir': '/home1/01234/username',
                 'icon': None,
-                'resourceProvider': 'TACC Systems',
+                'resourceProvider': 'TACC',
             },
             {
                 'name': 'Community Data',
@@ -459,7 +459,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'homeDir': '/path/to/community',
                 'icon': None,
                 'siteSearchPriority': 1,
-                'resourceProvider': 'TACC Systems',
+                'resourceProvider': 'TACC',
             },
             {
                 'name': 'Public Data',
@@ -469,14 +469,14 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'homeDir': '/path/to/public',
                 'icon': 'publications',
                 'siteSearchPriority': 0,
-                'resourceProvider': 'TACC Systems',
+                'resourceProvider': 'TACC',
             },
             {
                 'name': 'Shared Workspaces',
                 'scheme': 'projects',
                 'api': 'tapis',
                 'icon': 'publications',
-                'resourceProvider': 'TACC Systems',
+                'resourceProvider': 'TACC',
             },
             {
                 'name': 'Google Drive',

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -438,7 +438,9 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'tapis',
                 'homeDir': '/home/username',
                 'icon': None,
-                'default': True
+                'default': True,
+                'resource_provider': 'TACC Systems',
+
             },
             {
                 'name': 'My Data (Frontera)',
@@ -447,6 +449,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'tapis',
                 'homeDir': '/home1/01234/username',
                 'icon': None,
+                'resource_provider': 'TACC Systems',
             },
             {
                 'name': 'Community Data',
@@ -455,7 +458,8 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'tapis',
                 'homeDir': '/path/to/community',
                 'icon': None,
-                'siteSearchPriority': 1
+                'siteSearchPriority': 1,
+                'resource_provider': 'TACC Systems',
             },
             {
                 'name': 'Public Data',
@@ -464,13 +468,15 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'tapis',
                 'homeDir': '/path/to/public',
                 'icon': 'publications',
-                'siteSearchPriority': 0
+                'siteSearchPriority': 0,
+                'resource_provider': 'TACC Systems',
             },
             {
                 'name': 'Shared Workspaces',
                 'scheme': 'projects',
                 'api': 'tapis',
-                'icon': 'publications'
+                'icon': 'publications',
+                'resource_provider': 'TACC Systems',
             },
             {
                 'name': 'Google Drive',
@@ -478,7 +484,8 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'scheme': 'private',
                 'api': 'googledrive',
                 'icon': None,
-                'integration': 'portal.apps.googledrive_integration'
+                'integration': 'portal.apps.googledrive_integration',
+                'resource_provider': 'Other',
             }
         ]
     }

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -439,7 +439,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'homeDir': '/home/username',
                 'icon': None,
                 'default': True,
-                'resource_provider': 'TACC Systems',
+                'resourceProvider': 'TACC Systems',
 
             },
             {
@@ -449,7 +449,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'tapis',
                 'homeDir': '/home1/01234/username',
                 'icon': None,
-                'resource_provider': 'TACC Systems',
+                'resourceProvider': 'TACC Systems',
             },
             {
                 'name': 'Community Data',
@@ -459,7 +459,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'homeDir': '/path/to/community',
                 'icon': None,
                 'siteSearchPriority': 1,
-                'resource_provider': 'TACC Systems',
+                'resourceProvider': 'TACC Systems',
             },
             {
                 'name': 'Public Data',
@@ -469,14 +469,14 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'homeDir': '/path/to/public',
                 'icon': 'publications',
                 'siteSearchPriority': 0,
-                'resource_provider': 'TACC Systems',
+                'resourceProvider': 'TACC Systems',
             },
             {
                 'name': 'Shared Workspaces',
                 'scheme': 'projects',
                 'api': 'tapis',
                 'icon': 'publications',
-                'resource_provider': 'TACC Systems',
+                'resourceProvider': 'TACC Systems',
             },
             {
                 'name': 'Google Drive',
@@ -485,7 +485,7 @@ def test_systems_list(client, authenticated_user, mock_tapis_client, agave_stora
                 'api': 'googledrive',
                 'icon': None,
                 'integration': 'portal.apps.googledrive_integration',
-                'resource_provider': 'Other',
+                'resourceProvider': 'Other',
             }
         ]
     }

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -71,7 +71,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "homeDir": "/work/{tasdir}",
         "icon": None,
         "default": True,
-        "resource_provider": "TACC",
+        "resourceProvider": "TACC",
     },
     {
         "name": "My Data (Frontera Scratch)",
@@ -80,7 +80,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "api": "tapis",
         "hostEval": "SCRATCH",
         "icon": None,
-        "resource_provider": "TACC",
+        "resourceProvider": "TACC",
     },
     {
         "name": "My Data (Frontera Home)",
@@ -89,7 +89,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "api": "tapis",
         "homeDir": "/home1/{tasdir}",
         "icon": None,
-        "resource_provider": "TACC",
+        "resourceProvider": "TACC",
     },
     {
         "name": "Community Data",
@@ -99,7 +99,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "homeDir": "/corral/tacc/aci/CEP/community",
         "icon": None,
         "siteSearchPriority": 1,
-        "resource_provider": "TACC",
+        "resourceProvider": "TACC",
     },
     {
         "name": "Public Data",
@@ -109,7 +109,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "homeDir": "/corral/tacc/aci/CEP/public",
         "icon": "publications",
         "siteSearchPriority": 0,
-        "resource_provider": "TACC",
+        "resourceProvider": "TACC",
     },
     {
         "name": "Shared Workspaces",
@@ -118,7 +118,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "icon": "publications",
         "readOnly": False,
         "hideSearchBar": False,
-        "resource_provider": "TACC",
+        "resourceProvider": "TACC",
     },
     {
         "name": "Google Drive",
@@ -127,7 +127,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "api": "googledrive",
         "icon": None,
         "integration": "portal.apps.googledrive_integration",
-        "resource_provider": "External Resources",
+        "resourceProvider": "External Resources",
     },
 ]
 

--- a/server/portal/settings/settings_custom.example.py
+++ b/server/portal/settings/settings_custom.example.py
@@ -71,6 +71,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "homeDir": "/work/{tasdir}",
         "icon": None,
         "default": True,
+        "resource_provider": "TACC",
     },
     {
         "name": "My Data (Frontera Scratch)",
@@ -79,6 +80,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "api": "tapis",
         "hostEval": "SCRATCH",
         "icon": None,
+        "resource_provider": "TACC",
     },
     {
         "name": "My Data (Frontera Home)",
@@ -87,6 +89,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "api": "tapis",
         "homeDir": "/home1/{tasdir}",
         "icon": None,
+        "resource_provider": "TACC",
     },
     {
         "name": "Community Data",
@@ -96,6 +99,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "homeDir": "/corral/tacc/aci/CEP/community",
         "icon": None,
         "siteSearchPriority": 1,
+        "resource_provider": "TACC",
     },
     {
         "name": "Public Data",
@@ -105,6 +109,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "homeDir": "/corral/tacc/aci/CEP/public",
         "icon": "publications",
         "siteSearchPriority": 0,
+        "resource_provider": "TACC",
     },
     {
         "name": "Shared Workspaces",
@@ -113,6 +118,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "icon": "publications",
         "readOnly": False,
         "hideSearchBar": False,
+        "resource_provider": "TACC",
     },
     {
         "name": "Google Drive",
@@ -121,6 +127,7 @@ _PORTAL_DATAFILES_STORAGE_SYSTEMS = [
         "api": "googledrive",
         "icon": None,
         "integration": "portal.apps.googledrive_integration",
+        "resource_provider": "External Resources",
     },
 ]
 

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -212,7 +212,7 @@ PORTAL_PROJECTS_ROOT_DIR = '/path/to/root'
 
 PORTAL_PROJECTS_ROOT_SYSTEM_NAME = 'projects.system.name'
 
-PORTAL_PROJECTS_ROOT_HOST = 'host.for.projects'
+PORTAL_PROJECTS_ROOT_HOST = 'host.for.projects.tacc.utexas.edu'
 
 PORTAL_PROJECTS_SYSTEM_PORT = 22
 


### PR DESCRIPTION
## Overview

Splits datafiles items into sections, with category labels.

By default, `.tacc.utexas.edu` systems are given the category `"TACC Systems"`, other `.edu` institutions are given the TLD as category, like `"PSC Systems"` for `.psc.edu`, and non-.edu hosts as well as non-tapis resources defined in `_PORTAL_DATAFILES_STORAGE_SYSTEMS` are given `"Other"`.

Categories can be assigned to systems in the Tapis definition, via the `notes.resource_provider` field, e.g. `"resource_provider": "TACC"`, and these will override the defaults above.

On the client-side, if the number of categories 1 or fewer passed with the `sidebarItems` to the `<Sidebar />` component, no category label will be rendered.

## Related

* [WI-411](https://tacc-main.atlassian.net/browse/WI-411)


## Testing

1. In `settings_default.py`, add the following to the end of `_PORTAL_DATAFILES_STORAGE_SYSTEMS`:
```
    {
        "name": "Expanse",
        "system": "expanse",
        "scheme": "private",
        "api": "tapis",
        "icon": None,
        "siteSearchPriority": 1,
    },
    {
        "name": "Bridges2",
        "system": "bridges2",
        "scheme": "private",
        "api": "tapis",
        "icon": None,
        "siteSearchPriority": 1,
    },
```
2. Confirm these show up as different categories in https://cep.test/workbench/data
3. Add a specific`resource_provider` label to these, e.g. "resource_provider": "TEST", and confirm these are rendered after page refresh.

## UI

- Defaults
<img width="442" height="544" alt="Screenshot 2026-06-02 at 4 42 06 PM" src="https://github.com/user-attachments/assets/fea1068f-b791-4d36-8d0e-780282c0614d" />


- Only one category, hidden label
<img width="490" height="430" alt="Screenshot 2026-05-29 at 3 15 52 PM" src="https://github.com/user-attachments/assets/0acd236b-d468-48c9-8306-fa05284505fb" />



## Notes

Open questions:
- What should be the default category labels for TACC systems, other HPC centers, or other items?
- If there are only TACC systems, should there be no category rendered?
- Similarly, if there is only one category, should it be rendered?
