### PR TITLE
bug/WP-1287: [CEP] Apps w/same id but different version show same header label 

### DIFF
--- a/client/src/components/Applications/AppLayout/AppLayout.jsx
+++ b/client/src/components/Applications/AppLayout/AppLayout.jsx
@@ -41,9 +41,14 @@ export const AppsLayout = () => {
 
 const AppsHeader = (categoryDict) => {
   const { params } = useRouteMatch();
+  const query = useQuery();
   const appMeta = Object.values(categoryDict.categoryDict)
     .flatMap((e) => e)
-    .find((app) => app.appId === params.appId);
+    .find(
+      (app) =>
+        app.appId === params.appId &&
+        (!query.get('appVersion') || app.version === query.get('appVersion'))
+    );
   const path = appMeta ? ` / ${appMeta.label || appMeta.appId}` : '';
   return `Applications ${path}`;
 };

--- a/client/src/components/Applications/AppLayout/AppLayout.jsx
+++ b/client/src/components/Applications/AppLayout/AppLayout.jsx
@@ -42,12 +42,13 @@ export const AppsLayout = () => {
 const AppsHeader = (categoryDict) => {
   const { params } = useRouteMatch();
   const query = useQuery();
+  const appVersion = query.get('appVersion');
   const appMeta = Object.values(categoryDict.categoryDict)
     .flatMap((e) => e)
     .find(
       (app) =>
         app.appId === params.appId &&
-        (!query.get('appVersion') || app.version === query.get('appVersion'))
+        (!appVersion || app.version === appVersion)
     );
   const path = appMeta ? ` / ${appMeta.label || appMeta.appId}` : '';
   return `Applications ${path}`;


### PR DESCRIPTION
## Overview
Apps of same id but different version show same header label, which is confusing to users. See screenshots


## Related

* [WP-1287](https://tacc-main.atlassian.net/browse/WP-1287)

## Changes

Added a version check to the AppsHeader component so that the correct app label is displayed.


## Testing

1. Using PORTALS tenant,  go to [/core/admin/](https://cep.test/core/admin/) page
2. Add two entries for `jupyter-hpc-native`, one with `version` as `vista` and the other with `frontera`
3. Validate that both apps appear in workbench and have correct headers in [app layout view](https://cep.test/workbench/applications/jupyter-hpc-native?appVersion=vista).

## UI

<img width="1118" height="155" alt="8f3dd38b-5eec-46bb-aa25-b59a632f0fd6#media-blob-url=true id=0a7fa1d8-70ac-48d8-84f6-0b798336d6dc contextId=1333133313 collection=contentId-1333133313 clientId=0ef646d4-ec3d-46ba-be8b-3a616316af1d" src="https://github.com/user-attachments/assets/954df8bd-1b4b-45e7-ace9-604debbc4df1" />

## Notes

