### PR TITLE
task/WP-1279: updating first column of allocations listing

### DIFF
--- a/client/src/components/Allocations/AllocationsCells.jsx
+++ b/client/src/components/Allocations/AllocationsCells.jsx
@@ -11,6 +11,23 @@ const CELL_PROPTYPES = {
   }).isRequired,
 };
 
+export const Title = ({ cell: { value } }) => {
+  const { title, projectName } = value;
+  return (
+    <>
+      <span style={{ whiteSpace: 'wrap' }}>{title} ({projectName})</span>
+    </>
+  )
+};
+Title.propTypes = {
+  cell: shape({
+    value: shape({
+      title: string.isRequired,
+      projectName: string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
 export const Team = ({ cell: { value } }) => {
   const { projectId, page } = value;
   const history = useHistory();

--- a/client/src/components/Allocations/AllocationsCells.jsx
+++ b/client/src/components/Allocations/AllocationsCells.jsx
@@ -15,9 +15,11 @@ export const Title = ({ cell: { value } }) => {
   const { title, projectName } = value;
   return (
     <>
-      <span style={{ whiteSpace: 'wrap' }}>{title} ({projectName})</span>
+      <span style={{ whiteSpace: 'wrap' }}>
+        {title} ({projectName})
+      </span>
     </>
-  )
+  );
 };
 Title.propTypes = {
   cell: shape({

--- a/client/src/components/Allocations/AllocationsTables.jsx
+++ b/client/src/components/Allocations/AllocationsTables.jsx
@@ -3,7 +3,14 @@ import { useTable, useSortBy } from 'react-table';
 import { useSelector, useDispatch } from 'react-redux';
 import { string } from 'prop-types';
 import { Message } from '_common';
-import { Title, Team, Systems, Awarded, Remaining, Expires } from './AllocationsCells';
+import {
+  Title,
+  Team,
+  Systems,
+  Awarded,
+  Remaining,
+  Expires,
+} from './AllocationsCells';
 import systemAccessor from './AllocationsUtils';
 
 import styles from './AllocationsTables.module.scss';
@@ -18,8 +25,8 @@ export const useAllocations = (page) => {
       {
         Header: 'Title',
         accessor: ({ title, projectName }) => ({
-          title, 
-          projectName
+          title,
+          projectName,
         }),
         Cell: Title,
         sortType: 'alphanumeric',

--- a/client/src/components/Allocations/AllocationsTables.jsx
+++ b/client/src/components/Allocations/AllocationsTables.jsx
@@ -3,7 +3,7 @@ import { useTable, useSortBy } from 'react-table';
 import { useSelector, useDispatch } from 'react-redux';
 import { string } from 'prop-types';
 import { Message } from '_common';
-import { Team, Systems, Awarded, Remaining, Expires } from './AllocationsCells';
+import { Title, Team, Systems, Awarded, Remaining, Expires } from './AllocationsCells';
 import systemAccessor from './AllocationsUtils';
 
 import styles from './AllocationsTables.module.scss';
@@ -17,7 +17,11 @@ export const useAllocations = (page) => {
     () => [
       {
         Header: 'Title',
-        accessor: 'projectName',
+        accessor: ({ title, projectName }) => ({
+          title, 
+          projectName
+        }),
+        Cell: Title,
         sortType: 'alphanumeric',
       },
       {

--- a/client/src/components/Allocations/tests/AllocationsCells.test.jsx
+++ b/client/src/components/Allocations/tests/AllocationsCells.test.jsx
@@ -81,9 +81,9 @@ describe('Allocations Table Cells', () => {
     const title = fixture.title;
     const projectName = fixture.projectName;
     const { getByText } = render(
-      <Title 
+      <Title
         cell={{
-          value: { title: title, projectName: projectName}
+          value: { title: title, projectName: projectName },
         }}
       />
     );

--- a/client/src/components/Allocations/tests/AllocationsCells.test.jsx
+++ b/client/src/components/Allocations/tests/AllocationsCells.test.jsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { toBeInTheDocument } from '@testing-library/jest-dom/dist/matchers';
 import {
+  Title,
   Team,
   Systems,
   Awarded,
@@ -14,6 +15,7 @@ import systemAccessor from '../AllocationsUtils';
 
 const fixture = {
   projectId: 'TEST-Project',
+  projectName: 'Test Project',
   systems: [
     {
       name: 'Test System',
@@ -75,6 +77,18 @@ const Wrapper = ({ store, children }) => (
 expect.extend({ toBeInTheDocument });
 describe('Allocations Table Cells', () => {
   const { systems } = fixture;
+  it('should have a title and projectName in a cell', () => {
+    const title = fixture.title;
+    const projectName = fixture.projectName;
+    const { getByText } = render(
+      <Title 
+        cell={{
+          value: { title: title, projectName: projectName}
+        }}
+      />
+    );
+    expect(getByText(/TEST-Team/)).toBeInTheDocument();
+  });
   it('should have a team view link in a cell', () => {
     const { getByText } = render(
       <Wrapper store={mockStore(mockInitialState)}>


### PR DESCRIPTION
## Overview
Adding the allocation title to the Title column on the allocations page


## Related

* [WP-1279](https://tacc-main.atlassian.net/browse/WP-1279)

## Changes
Adding the allocation title to the Title column


## Testing
1. Log in to the portal and go to the Allocations page
2. Make sure both the title and charge code (projectName) are showing in the Title column.

## UI
<img width="1482" height="425" alt="Screenshot 2026-06-05 at 11 05 01 AM" src="https://github.com/user-attachments/assets/5889d04c-6cde-4afd-aa43-f786b4ecc3a3" />


## Notes
The sorting doesn't work at the moment, Tracy is aware of it and is ok with it.  There will be another task to look into it.
