### PR TITLE
bug/WP-1183: Portal nav underline out of place

### DIFF
--- a/server/portal/templates/includes/nav_portal.raw.html
+++ b/server/portal/templates/includes/nav_portal.raw.html
@@ -4,17 +4,17 @@
 <!-- FAQ: This template loads independently at a unique url (see `urls.py`)
           so CMS and User Guide can render this markup into their markup. -->
 
-<div style="display:flex; flex-direction: row; align-items: center;">
 {% if settings.DOCS_CHATBOT_URL %}
-<li>
-  <a href="{{settings.DOCS_CHATBOT_URL}}" target="_blank" rel="noopener noreferrer">
+<li class="nav-item">
+  <a class="ai-button-link" href="{{settings.DOCS_CHATBOT_URL}}" target="_blank" rel="noopener noreferrer">
   <button class="ai-button">
     <b><i class="icon icon-bulb" aria-label="Ask AI"></i>Ask AI (Beta)</b>
   </button>
+  </a>
 </li>
 {% endif %}
 {% if user.is_authenticated %}
-<li class="nav-item dropdown" style="{% if settings.DOCS_CHATBOT_URL %}border-left: 1px solid var(--header-minor-border-color);{% endif %}">
+<li class="nav-item dropdown" >
   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="icon icon-user" role="presentation"></i>
     <span>{{ user.get_username }}</span>
@@ -45,47 +45,9 @@
   </nav>
 </li>
 {% else %}
-<li class="nav-item" style="{% if settings.DOCS_CHATBOT_URL %}border-left: 1px solid var(--header-minor-border-color);{% endif %}">
+<li class="nav-item">
   <a class="nav-link" href="{% url 'portal_auth:tapis_oauth' %}">
     <i class="icon icon-user" role="presentation"></i> Log in
   </a>
 </li>
 {% endif %}
-</div>
-
-
-<style>
-  .ai-button {
-    margin: 0;
-    overflow: visible;
-    text-transform: none;
-    line-height: inherit;
-    vertical-align: baseline;
-    -webkit-appearance: button;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-    box-sizing: border-box;
-    outline: none;
-    position: relative;
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
-    justify-content: center;
-    font-weight: 400;
-    white-space: nowrap;
-    text-align: center;
-    cursor: pointer;
-    transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    user-select: none;
-    touch-action: manipulation;
-    font-size: 14px;
-    height: 32px;
-    padding: 0px 15px;
-    border-radius: 0;
-    background: linear-gradient(135deg, #47a59d, #337ab7) !important;
-    border: 2px solid transparent !important;
-    background-clip: padding-box !important;
-    color: #fff !important;
-    margin-left: 10px;
-    margin-right: 10px;
-  }
-</style>


### PR DESCRIPTION
## Overview
Fixes styling that led to misaligned portal nav element


## Related

* [WP-1183](https://tacc-main.atlassian.net/browse/WP-1183)
* requires https://github.com/TACC/Core-Styles/pull/644

## Changes
- Moves styles for the AI chat button from the portal nav template to [Core-Styles repo](https://github.com/TACC/Core-Styles/pull/644)
- Removes `<div>` surrounding chat button and portal nav to decouple their alignment
- Adds separate CSS class name for chat button to align itself in its own box


## Testing

1. (prior to merge of coinciding [Core-Styles PR](https://github.com/TACC/Core-Styles/pull/644)) locally, use this url (https://cdn.jsdelivr.net/gh/TACC/Core-Styles@276e28b/dist/core-styles.header.css) to change the stylesheet for the header like shown here: 

https://github.com/user-attachments/assets/257c68c6-8041-42c2-b278-d54f285faebd

2. Confirm that, on hovering over the portal nav with your username, the underline that shows is aligned with the bottom of the containing nav (see pic below)
3. Now add the AI Chat button to the nav by adding the following line to your settings_custom.py (on page reload, will also need to repeat step 1):
    `_DOCS_CHATBOT_URL = "/path/to/chatbot"`
4. Confirm the same as step 2

## UI
Before fix (dev.cep currently):
<img width="1725" height="788" alt="image" src="https://github.com/user-attachments/assets/a70e4f8e-88a8-4805-9bb7-ad62ddea6b17" />


Without AI Chat button: 
<img width="1725" height="788" alt="image" src="https://github.com/user-attachments/assets/bdb47f8f-a8f6-466a-a623-0ef881a144d6" />

With AI Chat button:
<img width="1725" height="788" alt="image" src="https://github.com/user-attachments/assets/e5c043d2-cecd-4468-8e0e-f95a535ed79a" />



## Notes
There is a change in the color of the portal nav font here when using the new stylesheet above - that bug is already logged here: https://tacc-main.atlassian.net/browse/WP-1280
