### PR TITLE
task/WA-193: Develop a dynamic profile system for dynamic exec system apps

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -404,11 +404,6 @@ export const AppSchemaForm = ({ app }) => {
           [opt.name]: opt.fieldType === 'number' ? Number(opt.arg) : opt.arg,
         }))
       );
-
-      console.log(
-        'queueSchedulerOptions:',
-        initialValues.queueSchedulerOptions
-      );
     }
   }
   const sectionMessage = isTMSSystem ? (

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -679,7 +679,7 @@ export const AppSchemaForm = ({ app }) => {
             if (!job.parameterSet.schedulerOptions) {
               job.parameterSet.schedulerOptions = [];
             }
-            //pick the right profile for the right exec system
+            // pick the right profile for the right exec system
             const selectedSystem = app.definition.notes.dynamicExecSystems.find(
               (s) => s.systemId === job.execSystemId
             );

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -40,7 +40,11 @@ import {
   getExecSystemIdValidation,
   getQueueSchedulerOptionsValidation,
 } from './AppFormUtils';
-import { getExecSystemFromId, getDefaultExecSystem } from 'utils/apps';
+import {
+  getExecSystemFromId,
+  getDefaultExecSystem,
+  isValidDynamicExecSystems,
+} from 'utils/apps';
 
 import DataFilesSelectModal from '../../DataFiles/DataFilesModals/DataFilesSelectModal';
 import * as ROUTES from '../../../constants/routes';
@@ -679,42 +683,31 @@ export const AppSchemaForm = ({ app }) => {
             if (!job.parameterSet.schedulerOptions) {
               job.parameterSet.schedulerOptions = [];
             }
-            // pick the right profile for the right exec system
 
-            const isValidDynamicExecSystems =
-              Array.isArray(app.definition.notes.dynamicExecSystems) &&
-              app.definition.notes.dynamicExecSystems.every(
-                (s) => typeof s === 'object' && s !== null && 'systemId' in s
+            if (!isValidDynamicExecSystems(app)) {
+              console.error(
+                'DynamicExecSystems for this application are invalid'
               );
-            if (!isValidDynamicExecSystems) {
-              return (
-                <div
-                  id="appDetail-wrapper"
-                  className="has-message  appDetail-error"
-                >
-                  <SectionMessage type="warning">
-                    {'DynamicExecSystems for this application are invalid'}
-                  </SectionMessage>
-                </div>
-              );
-            }
-
-            const selectedSystem = app.definition.notes.dynamicExecSystems.find(
-              (s) => s.systemId === job.execSystemId
-            );
-            const profileName = selectedSystem?.profileName;
-            if (!!profileName) {
-              job.parameterSet.schedulerOptions = [
-                ...job.parameterSet.schedulerOptions.filter(
-                  (opt) => !opt.arg.startsWith('--tapis-profile')
-                ),
-                {
-                  name: 'TACC Scheduler Profile',
-                  arg: `--tapis-profile ${profileName}`,
-                  description: 'Scheduler profile for HPC clusters at TACC',
-                  include: true,
-                },
-              ];
+            } else {
+              // pick the right profile for the right exec system
+              const selectedSystem =
+                app.definition.notes.dynamicExecSystems.find(
+                  (s) => s.systemId === job.execSystemId
+                );
+              const profileName = selectedSystem?.profileName;
+              if (!!profileName) {
+                job.parameterSet.schedulerOptions = [
+                  ...job.parameterSet.schedulerOptions.filter(
+                    (opt) => !opt.arg.startsWith('--tapis-profile')
+                  ),
+                  {
+                    name: 'TACC Scheduler Profile',
+                    arg: `--tapis-profile ${profileName}`,
+                    description: 'Scheduler profile for HPC clusters at TACC',
+                    include: true,
+                  },
+                ];
+              }
             }
           }
 

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -404,6 +404,11 @@ export const AppSchemaForm = ({ app }) => {
           [opt.name]: opt.fieldType === 'number' ? Number(opt.arg) : opt.arg,
         }))
       );
+
+      console.log(
+        'queueSchedulerOptions:',
+        initialValues.queueSchedulerOptions
+      );
     }
   }
   const sectionMessage = keyService ? (
@@ -674,6 +679,22 @@ export const AppSchemaForm = ({ app }) => {
             app.definition.jobAttributes.memoryMB > queue.maxMemoryMB
           ) {
             job.memoryMB = queue.maxMemoryMB;
+          }
+          debugger;
+          if (isAppUsingDynamicExecSystem(app)) {
+            if (!job.parameterSet.schedulerOptions) {
+              job.parameterSet.schedulerOptions = [];
+            }
+            job.parameterSet.schedulerOptions.push({
+              name: 'TACC Scheduler Profile',
+              description: 'Scheduler profile for HPC clusters at TACC',
+              inputMode: 'FIXED',
+              include: true,
+              arg: `--tapis-profile ${app.definition.notes.dynamicExecSystems.profileName}`,
+              notes: { isHidden: true },
+            });
+
+            console.log('SchedulerOptions:', job.parameterSet.schedulerOptions);
           }
 
           // Add allocation scheduler option

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -680,21 +680,21 @@ export const AppSchemaForm = ({ app }) => {
           ) {
             job.memoryMB = queue.maxMemoryMB;
           }
-          debugger;
           if (isAppUsingDynamicExecSystem(app)) {
             if (!job.parameterSet.schedulerOptions) {
               job.parameterSet.schedulerOptions = [];
             }
+            //pick the right profile for the right exec system
+            const selectedSystem = app.definition.notes.dynamicExecSystems.find(
+              (s) => s.systemId === job.execSystemId
+            );
+            const profileName = selectedSystem?.profileName;
             job.parameterSet.schedulerOptions.push({
               name: 'TACC Scheduler Profile',
               description: 'Scheduler profile for HPC clusters at TACC',
-              inputMode: 'FIXED',
               include: true,
-              arg: `--tapis-profile ${app.definition.notes.dynamicExecSystems.profileName}`,
-              notes: { isHidden: true },
+              arg: `--tapis-profile ${profileName}`,
             });
-
-            console.log('SchedulerOptions:', job.parameterSet.schedulerOptions);
           }
 
           // Add allocation scheduler option

--- a/client/src/components/Applications/AppForm/AppForm.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.jsx
@@ -680,16 +680,42 @@ export const AppSchemaForm = ({ app }) => {
               job.parameterSet.schedulerOptions = [];
             }
             // pick the right profile for the right exec system
+
+            const isValidDynamicExecSystems =
+              Array.isArray(app.definition.notes.dynamicExecSystems) &&
+              app.definition.notes.dynamicExecSystems.every(
+                (s) => typeof s === 'object' && s !== null && 'systemId' in s
+              );
+            if (!isValidDynamicExecSystems) {
+              return (
+                <div
+                  id="appDetail-wrapper"
+                  className="has-message  appDetail-error"
+                >
+                  <SectionMessage type="warning">
+                    {'DynamicExecSystems for this application are invalid'}
+                  </SectionMessage>
+                </div>
+              );
+            }
+
             const selectedSystem = app.definition.notes.dynamicExecSystems.find(
               (s) => s.systemId === job.execSystemId
             );
             const profileName = selectedSystem?.profileName;
-            job.parameterSet.schedulerOptions.push({
-              name: 'TACC Scheduler Profile',
-              description: 'Scheduler profile for HPC clusters at TACC',
-              include: true,
-              arg: `--tapis-profile ${profileName}`,
-            });
+            if (!!profileName) {
+              job.parameterSet.schedulerOptions = [
+                ...job.parameterSet.schedulerOptions.filter(
+                  (opt) => !opt.arg.startsWith('--tapis-profile')
+                ),
+                {
+                  name: 'TACC Scheduler Profile',
+                  arg: `--tapis-profile ${profileName}`,
+                  description: 'Scheduler profile for HPC clusters at TACC',
+                  include: true,
+                },
+              ];
+            }
           }
 
           // Add allocation scheduler option

--- a/client/src/components/Applications/AppForm/AppForm.test.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.test.jsx
@@ -441,7 +441,66 @@ describe('AppSchemaForm', () => {
           ...helloWorldAppSubmissionPayloadFixture.job.parameterSet,
           schedulerOptions: [
             {
-              arg: '--tapis-profile tacc-apptainer',
+              arg: '--tapis-profile tacc-apptainer-frontera',
+              description: 'Scheduler profile for HPC clusters at TACC',
+              include: true,
+              name: 'TACC Scheduler Profile',
+            },
+            ...helloWorldAppSubmissionPayloadFixture.job.parameterSet
+              .schedulerOptions,
+          ],
+        },
+      },
+    };
+
+    const submitButton = getByText(/Submit/);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(store.getActions()).toEqual([
+        { type: 'GET_SYSTEM_MONITOR' },
+        { type: 'SUBMIT_JOB', payload: payload },
+      ]);
+    });
+  });
+
+  it('uses correct dynamic scheduler profile after the assigned dynamic exec system has changed', async () => {
+    const store = mockStore({
+      ...initialMockState,
+    });
+    const appFixture = {
+      ...helloWorldAppFixture,
+      definition: {
+        ...helloWorldAppFixture.definition,
+        notes: {
+          ...helloWorldAppFixture.definition.notes,
+          ...executionSystemNotesFixture,
+        },
+      },
+      execSystems: execSystemsFixture,
+    };
+
+    const { getByText, container } = renderAppSchemaFormComponent(
+      store,
+      appFixture
+    );
+
+    const execSystemDropDown = container.querySelector(
+      'select[name="execSystemId"]'
+    );
+    fireEvent.change(execSystemDropDown, { target: { value: 'ls6' } });
+
+    const payload = {
+      ...helloWorldAppSubmissionPayloadFixture,
+      job: {
+        ...helloWorldAppSubmissionPayloadFixture.job,
+        execSystemId: 'ls6',
+        name: `hello-world-0.0.1_${frozenDate}T00:00:00`,
+        parameterSet: {
+          ...helloWorldAppSubmissionPayloadFixture.job.parameterSet,
+          schedulerOptions: [
+            {
+              arg: '--tapis-profile tacc-apptainer-ls6',
               description: 'Scheduler profile for HPC clusters at TACC',
               include: true,
               name: 'TACC Scheduler Profile',

--- a/client/src/components/Applications/AppForm/AppForm.test.jsx
+++ b/client/src/components/Applications/AppForm/AppForm.test.jsx
@@ -341,10 +341,10 @@ describe('AppSchemaForm', () => {
     expect(execSystemDropDown.value).toBe('frontera');
     const options = Array.from(execSystemDropDown.querySelectorAll('option'));
     const actualValues = Array.from(options).map((option) => option.value);
-    const expectedValuesWithEmpty = [
-      '',
-      ...executionSystemNotesFixture['dynamicExecSystems'],
-    ];
+    const systemIds = executionSystemNotesFixture['dynamicExecSystems'].map(
+      (s) => s.systemId
+    );
+    const expectedValuesWithEmpty = ['', ...systemIds];
     expect(actualValues).toEqual(
       expect.arrayContaining(expectedValuesWithEmpty)
     );
@@ -412,6 +412,56 @@ describe('AppSchemaForm', () => {
     );
     expect(execSystemDropDown).not.toBeNull();
     expect(execSystemDropDown.value).toBe('ls6');
+  });
+
+  it('uses correct dynamic scheduler profile for the assigned dynamic exec system', async () => {
+    const store = mockStore({
+      ...initialMockState,
+    });
+
+    const appFixture = {
+      ...helloWorldAppFixture,
+      definition: {
+        ...helloWorldAppFixture.definition,
+        notes: {
+          ...helloWorldAppFixture.definition.notes,
+          ...executionSystemNotesFixture,
+        },
+      },
+      execSystems: execSystemsFixture,
+    };
+    const { getByText } = renderAppSchemaFormComponent(store, appFixture);
+
+    const payload = {
+      ...helloWorldAppSubmissionPayloadFixture,
+      job: {
+        ...helloWorldAppSubmissionPayloadFixture.job,
+        name: `hello-world-0.0.1_${frozenDate}T00:00:00`,
+        parameterSet: {
+          ...helloWorldAppSubmissionPayloadFixture.job.parameterSet,
+          schedulerOptions: [
+            {
+              arg: '--tapis-profile tacc-apptainer',
+              description: 'Scheduler profile for HPC clusters at TACC',
+              include: true,
+              name: 'TACC Scheduler Profile',
+            },
+            ...helloWorldAppSubmissionPayloadFixture.job.parameterSet
+              .schedulerOptions,
+          ],
+        },
+      },
+    };
+
+    const submitButton = getByText(/Submit/);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(store.getActions()).toEqual([
+        { type: 'GET_SYSTEM_MONITOR' },
+        { type: 'SUBMIT_JOB', payload: payload },
+      ]);
+    });
   });
 
   it('does not display exec system when dynamic exec system is not enabled', async () => {

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.app.fixture.js
@@ -75,13 +75,6 @@ export const helloWorldAppFixture = {
         containerArgs: [],
         schedulerOptions: [
           {
-            arg: '--tapis-profile tacc',
-            name: 'TACC Scheduler Profile',
-            description: 'Scheduler profile for HPC clusters at TACC',
-            inputMode: 'FIXED',
-            notes: {},
-          },
-          {
             arg: '--job-name ${JobName}',
             name: 'Slurm job name',
             description:

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.executionsystems.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.executionsystems.fixture.js
@@ -607,9 +607,9 @@ export const execSystemsFixture = [
 
 export const executionSystemNotesFixture = {
   dynamicExecSystems: [
-    { systemId: 'maverick2', profileName: 'tacc-apptainer' },
-    { systemId: 'frontera', profileName: 'tacc-apptainer' },
-    { systemId: 'ls6', profileName: 'tacc-apptainer' },
-    { systemId: 'vista', profileName: 'tacc-apptainer' },
+    { systemId: 'maverick2', profileName: 'tacc-apptainer-mav2' },
+    { systemId: 'frontera', profileName: 'tacc-apptainer-frontera' },
+    { systemId: 'ls6', profileName: 'tacc-apptainer-ls6' },
+    { systemId: 'vista', profileName: 'tacc-apptainer-vista' },
   ],
 };

--- a/client/src/components/Applications/AppForm/fixtures/AppForm.executionsystems.fixture.js
+++ b/client/src/components/Applications/AppForm/fixtures/AppForm.executionsystems.fixture.js
@@ -606,5 +606,10 @@ export const execSystemsFixture = [
 ];
 
 export const executionSystemNotesFixture = {
-  dynamicExecSystems: ['maverick2', 'frontera', 'ls6', 'vista'],
+  dynamicExecSystems: [
+    { systemId: 'maverick2', profileName: 'tacc-apptainer' },
+    { systemId: 'frontera', profileName: 'tacc-apptainer' },
+    { systemId: 'ls6', profileName: 'tacc-apptainer' },
+    { systemId: 'vista', profileName: 'tacc-apptainer' },
+  ],
 };

--- a/client/src/utils/apps.ts
+++ b/client/src/utils/apps.ts
@@ -50,3 +50,18 @@ export const getDefaultExecSystem = (
 
   return undefined;
 };
+
+/**
+ * This validates if dynamicExecSystems is an array of objects
+ * that is not empty and has a systemId in each item
+ *
+ * @returns boolean
+ */
+export const isValidDynamicExecSystems = (
+  app: TPortalApp
+): boolean => (
+  Array.isArray(app.definition.notes.dynamicExecSystems) &&
+  app.definition.notes.dynamicExecSystems.every(
+    (s) => typeof s === 'object' && s !== null && 'systemId' in s
+  )
+);

--- a/client/src/utils/apps.ts
+++ b/client/src/utils/apps.ts
@@ -57,11 +57,8 @@ export const getDefaultExecSystem = (
  *
  * @returns boolean
  */
-export const isValidDynamicExecSystems = (
-  app: TPortalApp
-): boolean => (
+export const isValidDynamicExecSystems = (app: TPortalApp): boolean =>
   Array.isArray(app.definition.notes.dynamicExecSystems) &&
   app.definition.notes.dynamicExecSystems.every(
     (s) => typeof s === 'object' && s !== null && 'systemId' in s
-  )
-);
+  );

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -51,6 +51,11 @@ export type TAppFileInput = {
   targetPath?: string;
 };
 
+type TAppNotesDynamicExecSystems = {
+  systemId: string;
+  profileName: string;
+};
+
 type TAppNotes = {
   label?: string;
   shortLabel?: string;
@@ -59,7 +64,7 @@ type TAppNotes = {
   isInteractive?: boolean;
   hideNodeCountAndCoresPerNode?: boolean;
   icon?: string;
-  dynamicExecSystems?: string[];
+  dynamicExecSystems?: TAppNotesDynamicExecSystems[];
   queueFilter?: string[];
   hideQueue?: boolean;
   hideAllocation?: boolean;

--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -69,7 +69,8 @@ def _get_app(app_id, app_version, user):
 
     data = {'definition': app_def}
 
-    exec_systems = getattr(app_def.notes, 'dynamicExecSystems', [])
+    dynamic_exec_systems = getattr(app_def.notes, "dynamicExecSystems", [])
+    exec_systems = [system.systemId for system in dynamic_exec_systems]
     if len(exec_systems) > 0:
         data['execSystems'] = _get_exec_systems(user, exec_systems)
     else:

--- a/server/portal/apps/workspace/api/views_unit_test.py
+++ b/server/portal/apps/workspace/api/views_unit_test.py
@@ -293,7 +293,10 @@ def test_get_app_dynamic_exec_sys(
     ) as f:
         app = json.load(f)
         if dynamic_exec_system:
-            app["notes"]["dynamicExecSystems"] = ["frontera", "ls6"]
+            app["notes"]["dynamicExecSystems"] = [
+                {"systemId": "frontera", "profileName": "tacc-apptainer"},
+                {"systemId": "ls6", "profileName": "tacc-apptainer"},
+            ]
 
     # setup tapis mocks
     mock_tapis_client.apps.getApp.return_value = TapisResult(**app)


### PR DESCRIPTION
## Overview

On each HPC system, profile requirements may differ between apps, needing different specialized profiles between the same app across systems. Develop a dynamic system to load a profile depending on the system given an app, using the existing field in notes for dynamicSystems.

## Related

* [WA-193](https://tacc-main.atlassian.net/browse/WA-193)

## Changes

This checks if there is a `dynamicExecSystems` blob in the `notes` field in an app's definition. The blob snippet should look like below. Then, it uses that to find the system to find the assigned scheduler profile and insert it into the app's tapis job submission.

```
"dynamicExecSystems": [
            {
                "systemId": "frontera",
                "profileName": "tacc-apptainer"
            },
            {
                "systemId": "ls6",
                "profileName": "tacc-apptainer"
            }
        ]
```

## Testing

1. Go to https://cep.test/workbench/applications/hello-world?appVersion=0.0.2
2. Make sure the app renders.
3. Make sure that you can submit a job for both Frontera and LS6.
4. Check job details and make sure that the `tacc-apptainer` is used as the TACC Scheduler Profile.

## UI



## Notes

