### PR TITLE
WP-1284: Manage Account Password Changed Date Incorrect/Missing

### DIFF
--- a/client/src/redux/sagas/profile.sagas.js
+++ b/client/src/redux/sagas/profile.sagas.js
@@ -5,8 +5,10 @@ import { fetchUtil } from 'utils/fetchUtil';
 const ROOT_SLUG = '/accounts/api/profile';
 
 export const getPasswordStatus = (h) => {
-  const passwordChanged = h.filter((entry) =>
-	entry.comment.toLowerCase().includes('password') && entry.comment.toLowerCase().includes('change')
+  const passwordChanged = h.filter(
+    (entry) =>
+      entry.comment.toLowerCase().includes('password') &&
+      entry.comment.toLowerCase().includes('change')
   );
   if (isEmpty(passwordChanged)) return '';
   const lastChanged = passwordChanged.pop().timestamp;

--- a/client/src/redux/sagas/profile.sagas.js
+++ b/client/src/redux/sagas/profile.sagas.js
@@ -6,7 +6,7 @@ const ROOT_SLUG = '/accounts/api/profile';
 
 export const getPasswordStatus = (h) => {
   const passwordChanged = h.filter((entry) =>
-    entry.comment.includes('Change Password')
+	entry.comment.toLowerCase().includes('password') && entry.comment.toLowerCase().includes('change')
   );
   if (isEmpty(passwordChanged)) return '';
   const lastChanged = passwordChanged.pop().timestamp;

--- a/client/src/redux/sagas/profile.sagas.js
+++ b/client/src/redux/sagas/profile.sagas.js
@@ -6,7 +6,7 @@ const ROOT_SLUG = '/accounts/api/profile';
 
 export const getPasswordStatus = (h) => {
   const passwordChanged = h.filter((entry) =>
-    entry.comment.includes('Password changed')
+    entry.comment.includes('Change Password')
   );
   if (isEmpty(passwordChanged)) return '';
   const lastChanged = passwordChanged.pop().timestamp;


### PR DESCRIPTION
Updated string being searched for.

## Overview

Password changed dates on the manage accounts page was displaying incorrect dates or not at all due to searching history for a comment containing "Password changed". The password change comment at some point seems to have been updated to "Change Password", making this search pull very old data or none at all.


## Changes

Update string from Password changed to Change Password

## Testing

1. Navigate to workbench/account/ on CEP site and note that password change date seems accurate. 

## UI



## Notes

