### PR TITLE
task/WC-459: Make whitespace validation configurable and only enable in Jobs search

### DIFF
--- a/client/src/components/Jobs/Jobs.jsx
+++ b/client/src/components/Jobs/Jobs.jsx
@@ -237,6 +237,7 @@ function JobsView({
             resultCount={jobs.length}
             dataType="Jobs"
             infiniteScroll
+            forbidWhitespace
             disabled={isJobLoading || isNotificationLoading}
           />
           <Button

--- a/client/src/components/_common/Searchbar/Searchbar.jsx
+++ b/client/src/components/_common/Searchbar/Searchbar.jsx
@@ -15,6 +15,7 @@ const Searchbar = ({
   dataType,
   filterTypes,
   infiniteScroll,
+  forbidWhitespace,
   className,
   siteSearch,
   sectionName,
@@ -76,7 +77,7 @@ const Searchbar = ({
   };
 
   const getValidationMessage = (value) => {
-    if (/\s/.test(value))
+    if (/\s/.test(value) && forbidWhitespace)
       return 'Search term must be a single word with no spaces.';
     if (value.length < 3)
       return 'Include at least 3 characters in your search.';
@@ -174,6 +175,7 @@ Searchbar.propTypes = {
   resultCount: PropTypes.number,
   filterTypes: PropTypes.arrayOf(PropTypes.string),
   infiniteScroll: PropTypes.bool,
+  forbidWhitespace: PropTypes.bool,
   dataType: PropTypes.string.isRequired,
   sectionName: PropTypes.string,
   /** Additional className(s) for the root element */


### PR DESCRIPTION
## Overview
Update searchbar form validation so that the whitespace ban is optional. We don't need this validation anywhere except for the Job History search.


## Related

* [WC-459](https://tacc-main.atlassian.net/browse/WC-459)


