### PR TITLE
task/WI-407: Redirect to the home page when the user's session expires

### DIFF
--- a/client/src/components/Workbench/Workbench.jsx
+++ b/client/src/components/Workbench/Workbench.jsx
@@ -21,6 +21,7 @@ import SystemStatus from '../SystemStatus';
 import './Workbench.scss';
 // Core Styles needs to be imported last for Rollup to compile the CSS correctly.
 import '../../index.css';
+import { useRedirectOnSessionExpired } from 'hooks/auth';
 
 function Workbench() {
   const { path } = useRouteMatch();
@@ -29,6 +30,9 @@ function Workbench() {
 
   // Prefetch the user's Tapis token so it's ready to go when the user tries to upload files
   useTapisToken();
+  // Get the time remaining in the user's session and redirect to the homepage if their
+  // browser is open when it expires.
+  useRedirectOnSessionExpired({ location: '/' });
 
   // showUIPatterns: Show some entries only in local development
   const {

--- a/client/src/hooks/auth/index.ts
+++ b/client/src/hooks/auth/index.ts
@@ -1,0 +1,2 @@
+export { useSessionLifetime} from './useSessionLifetime';
+export { useRedirectOnSessionExpired } from './useRedirectOnSessionExpired';

--- a/client/src/hooks/auth/index.ts
+++ b/client/src/hooks/auth/index.ts
@@ -1,2 +1,2 @@
-export { useSessionLifetime} from './useSessionLifetime';
+export { useSessionLifetime } from './useSessionLifetime';
 export { useRedirectOnSessionExpired } from './useRedirectOnSessionExpired';

--- a/client/src/hooks/auth/useRedirectOnSessionExpired.ts
+++ b/client/src/hooks/auth/useRedirectOnSessionExpired.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { useSessionLifetime } from './useSessionLifetime';
+
+/* Redirect to the home page if the browser is open when the session expires. */
+export function useRedirectOnSessionExpired({
+  location,
+}: {
+  location?: string;
+}) {
+  const [timeoutId, setTimeoutId] = useState<number>();
+  const { data: sessionRemaining } = useSessionLifetime();
+  useEffect(() => {
+    if (sessionRemaining) {
+      const newTimeoutId = setTimeout(
+        () => window.location.replace(location ?? '/'),
+        sessionRemaining
+      );
+      setTimeoutId(newTimeoutId);
+    }
+    return () => {
+      //Only maintain one active timeout
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [sessionRemaining]);
+}

--- a/client/src/hooks/auth/useRedirectOnSessionExpired.ts
+++ b/client/src/hooks/auth/useRedirectOnSessionExpired.ts
@@ -13,7 +13,8 @@ export function useRedirectOnSessionExpired({
     if (sessionRemaining) {
       const newTimeoutId = setTimeout(
         () => window.location.replace(location ?? '/'),
-        sessionRemaining
+        // Add 10 seconds to make sure username doesn't render in navbar after redirect
+        sessionRemaining + 10000
       );
       setTimeoutId(newTimeoutId);
     }

--- a/client/src/hooks/auth/useSessionLifetime.ts
+++ b/client/src/hooks/auth/useSessionLifetime.ts
@@ -1,0 +1,17 @@
+import { apiClient } from 'utils/apiClient';
+import { useQuery } from '@tanstack/react-query';
+
+async function fetchSessionLifetime() {
+  const res = await apiClient.get<{ sessionLifetime: number | null }>(
+    '/auth/session-lifetime'
+  );
+  if (res.data.sessionLifetime) return res.data.sessionLifetime * 1000; // convert to ms
+  return null;
+}
+
+export function useSessionLifetime() {
+  return useQuery({
+    queryKey: ['sessionLifetime'],
+    queryFn: fetchSessionLifetime,
+  });
+}

--- a/server/portal/apps/auth/urls.py
+++ b/server/portal/apps/auth/urls.py
@@ -8,6 +8,7 @@ from portal.apps.auth import views
 app_name = 'portal_auth'
 urlpatterns = [
     re_path(r'^logged-out/$', views.logged_out, name='logout'),
+    re_path(r'^session-lifetime/$', views.get_session_lifetime, name='session_lifetime'),
     re_path(r'^tapis/$', views.tapis_oauth, name='tapis_oauth'),
     re_path(r'^tapis/callback/$', views.tapis_oauth_callback, name='tapis_oauth_callback'),
 ]

--- a/server/portal/apps/auth/views.py
+++ b/server/portal/apps/auth/views.py
@@ -5,12 +5,15 @@ import logging
 import time
 import requests
 import secrets
+import math
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.urls import reverse
-from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseRedirect, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
+from django.contrib.sessions.models import Session
 from .models import TapisOAuthToken
 from portal.apps.onboarding.execute import (
     execute_setup_steps,
@@ -26,6 +29,44 @@ METRICS = logging.getLogger(f'metrics.{__name__}')
 
 def logged_out(request):
     return render(request, 'portal/apps/auth/logged_out.html')
+
+
+def get_session_seconds_left(request):
+    """
+    Return the number of seconds until the current session expires.
+
+    Returns:
+        int: seconds left
+    """
+
+    session_key = request.session.session_key
+
+    if not session_key:
+        return 0
+
+    expire_date = (
+        Session.objects
+        .filter(session_key=session_key)
+        .values_list("expire_date", flat=True)
+        .first()
+    )
+    if not expire_date:
+        return 0
+
+    seconds_left = (expire_date - timezone.now()).total_seconds()
+    return max(0, math.ceil(seconds_left))
+
+
+def get_session_lifetime(request):
+    """
+    View to return the number of seconds remaining the user's session. Useful for
+    handling session expiry on the client side.
+    """
+    if not request.user.is_authenticated:
+        return JsonResponse({"message": "unauthenticated user"}, status=401)
+    
+    seconds_left = get_session_seconds_left(request)
+    return JsonResponse({"sessionLifetime": seconds_left})
 
 
 def _get_auth_state():

--- a/server/portal/apps/auth/views.py
+++ b/server/portal/apps/auth/views.py
@@ -64,7 +64,7 @@ def get_session_lifetime(request):
     """
     if not request.user.is_authenticated:
         return JsonResponse({"message": "unauthenticated user"}, status=401)
-    
+
     seconds_left = get_session_seconds_left(request)
     return JsonResponse({"sessionLifetime": seconds_left})
 

--- a/server/portal/apps/auth/views_unit_test.py
+++ b/server/portal/apps/auth/views_unit_test.py
@@ -68,6 +68,18 @@ def test_tapis_callback_mismatched_state(client):
     assert response.status_code == 400
 
 
+def test_session_lifetime_endpoint(client, regular_user):
+    # add auth to session
+    client.force_login(regular_user)
+    session = client.session
+    session.save()
+    response = client.get("/auth/session-lifetime/")
+    # Exact remaining lifetime responds depends on speed of test execution
+    # It should be a positive number less than the max session age.
+    assert response.json()["sessionLifetime"] > 0
+    assert response.json()["sessionLifetime"] <= 604800
+
+
 def test_launch_setup_checks(regular_user, mocker):
     mock_execute_setup_steps = mocker.patch(
         "portal.apps.auth.views.execute_setup_steps"


### PR DESCRIPTION
## Overview
This PR addresses the issue where users see broken UI/CSRF errors if they keep the portal open after the session expires. When the workspace loads, we now grab the remaining session lifetime from the backend and set a timer. Once the timer is up the user is redirected to the home page, where they can log in again.


## Related

* [WI-407](https://tacc-main.atlassian.net/browse/WI-407)

## Changes
- Add an API endpoint to calculate the remaining session lifetime in seconds
- Add frontend hooks to fetch the session lifetime and redirect the user away from the workbench if their session is expired.


## Testing

1. In the Workbench, check the expiration time of your portal sessionid cookie. When the cookie expires, the Workbench should redirect you to the portal homepage.

## UI



## Notes

