### PR TITLE
bug/WP-1232: Applications Category list height

### DIFF
--- a/client/src/components/Applications/AppBrowser/AppBrowser.scss
+++ b/client/src/components/Applications/AppBrowser/AppBrowser.scss
@@ -10,10 +10,10 @@
 
   --panel-vertical-buffer: 10px;
   --panel-max-item-count: 5;
-  --panel-item-height: 35px; /* (~30px design * 1.2 design-to-app ratio) */
+  --panel-item-height: 34px; /* (~30px design * 1.2 design-to-app ratio) */
   --panel-height: calc(
     (var(--panel-max-item-count) * var(--panel-item-height)) +
-      (var(--panel-vertical-buffer) * 2)
+      var(--panel-vertical-buffer)
   );
 
   border-bottom: 1px solid #707070;


### PR DESCRIPTION
## Overview
On the Workbench > Applications page, the Applications list renders too short by half a word height. 

## Related

* [WP-1232](https://tacc-main.atlassian.net/browse/WP-1232)

## Changes
Adjusted panel item height and panel height calculation to make the applications list shorter by about half a word height and render all five rows in the category list.


## Testing

1. Go to https://cep.test/core/admin
2. Add app categories until there are 5
3. Make sure each category has an app in it (doesn't matter which, or if it's the same app)
4. Go to https://cep.test/workbench/applications
5. Validate that UI looks correct and there isn't lingering space at the bottom of the navbar (see UI)

## UI
Prod:
<img width="262" height="238" alt="Screenshot 2026-06-23 at 3 25 47 PM" src="https://github.com/user-attachments/assets/c9cc92c8-ba43-4a39-b0fb-0b692fd2fd78" />


PR:
<img width="343" height="233" alt="Screenshot 2026-06-23 at 3 25 41 PM" src="https://github.com/user-attachments/assets/69ce4bc6-ecf9-457d-a5b1-2b3927020917" />


## Notes
See JIRA for short clips on how these changes were decided on
