### PR TITLE
task/WP-1231: fix authenticated checks in client

### DIFF
--- a/client/src/components/Tickets/TicketCreateForm.jsx
+++ b/client/src/components/Tickets/TicketCreateForm.jsx
@@ -94,7 +94,7 @@ function TicketCreateForm({
 
   const dispatch = useDispatch();
 
-  const isAuthenticated = authenticatedUser != null;
+ const isAuthenticated = Boolean(authenticatedUser?.username);
 
   const formShape = {
     subject: Yup.string().required('Required'),

--- a/client/src/components/Tickets/TicketCreateForm.jsx
+++ b/client/src/components/Tickets/TicketCreateForm.jsx
@@ -94,7 +94,7 @@ function TicketCreateForm({
 
   const dispatch = useDispatch();
 
- const isAuthenticated = Boolean(authenticatedUser?.username);
+  const isAuthenticated = Boolean(authenticatedUser?.username);
 
   const formShape = {
     subject: Yup.string().required('Required'),

--- a/client/src/components/Tickets/TicketCreateForm.jsx
+++ b/client/src/components/Tickets/TicketCreateForm.jsx
@@ -94,7 +94,7 @@ function TicketCreateForm({
 
   const dispatch = useDispatch();
 
-  const isAuthenticated = Boolean(authenticatedUser?.username);
+  const isAuthenticated = !!authenticatedUser?.username;
 
   const formShape = {
     subject: Yup.string().required('Required'),

--- a/client/src/components/Workbench/AppRouter.jsx
+++ b/client/src/components/Workbench/AppRouter.jsx
@@ -24,7 +24,7 @@ function AppRouter() {
   }, []);
 
   useEffect(() => {
-    if (authenticatedUser) {
+    if (authenticatedUser?.username) {
       dispatch({ type: 'FETCH_INTRO' });
       dispatch({ type: 'FETCH_CUSTOM_MESSAGES' });
     }


### PR DESCRIPTION
## Overview

This bug disabled the unauthenticated "create ticket" path and broke post-login redirects.

While logged out, the portal fetched intro/custom messages that causing `GET /api/portal_messages/custom/` (and `/intro/`) to `302` to the Tapis login flow (the api requsts getting redirected to login and then tapis is described and covered in an separate issue, [WI-407](https://tacc-main.atlassian.net/browse/WI-407)). 

That `302` stores the API path in the session's `next`, so a user who then logged in was redirected to `/api/portal_messages/custom/` and shown a raw JSON response instead of the portal.

The same root cause also broke the anonymous ticket form: its inputs were disabled and reCAPTCHA was dropped.

The issue is that`authenticatedUser.user` initializes as an empty object in the reducer `{ first_name: '', username: '', ... }` — and any object is truthy, so `if (authenticatedUser)` always passed, even for unauthed users.  

Guest/anonymous ticket submission remains blocked until recaptcha key is fixed in in https://tacc-main.atlassian.net/browse/WP-1323

## Related
* [WP-1231](https://tacc-main.atlassian.net/browse/WP-1231)

## Changes
* AppRouter: Use `authenticatedUser?.username` instead of the always-truthy `authenticatedUser` object so anonymous sessions don't hit our messages endpoints.
* TicketCreateForm:  fix `isAuthenticated` variable (anonymous users on `/tickets/new/` had the name/last-name/email fields disabled and blank, and reCAPTCHA was neither rendered nor required)

## Testing

### Messages redirect
1. Log out of the portal.
2. Navigate to `https://cep.test/tickets/new/` 
3. Open DevTools → Network ("Preserve log" on) and confirm **no** requests to `/api/portal_messages/intro/` or `/custom/` 
4. Log in via Tapis.
5. Confirm you land on the portal normally and redirected to `https://cep.test/api/portal_messages/custom/` showing a JSON response.

### Tickets (anonymous)
1. Logged out, go to `https://cep.test/tickets/new/`.
2. Confirm name / last name / email fields are **editable** (not disabled) and empty.
3. ~Confirm the reCAPTCHA widget renders and is required to submit.~ to be done in https://tacc-main.atlassian.net/browse/WP-1323
4. ~Submit and confirm the ticket is created~ to be done in https://tacc-main.atlassian.net/browse/WP-1323

### Tickets (authenticated)
1. Log in, go to `https://cep.test/tickets/new/`.
2. Confirm fields are prefilled and disabled, and no reCAPTCHA is shown (unchanged behavior).

## Notes ##

TODO.  
- [x] Recapta key is wrong for cep.test.  ~Need to confirm if our prod/pprd deployed sites are correct. Could do Recaptcha in a 2nd PR if this needs time to sort out.~. To be fixed in https://tacc-main.atlassian.net/browse/WP-1323

